### PR TITLE
Implement core config layering

### DIFF
--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -14,5 +14,6 @@ pub use error::OrthoError;
 pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// Loads, merges, and deserializes configuration from all available
     /// sources according to predefined precedence rules.
+    #[allow(clippy::result_large_err)]
     fn load() -> Result<Self, OrthoError>;
 }


### PR DESCRIPTION
## Summary
- implement load method for `#[derive(OrthoConfig)]`
- allow large error enum in `OrthoConfig` trait

## Testing
- `cargo clippy --all-targets --all-features -q`
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68459f9bd4708322b08f3680a04b237d

## Summary by Sourcery

Implement layered configuration loading for types deriving `OrthoConfig` and adjust linting for large error enums

New Features:
- Derive `OrthoConfig::load` to merge configuration from a TOML file and environment variables via Figment

Enhancements:
- Suppress the `result_large_err` lint on the `OrthoConfig` trait to allow larger error enums