### PR TITLE
Expose generated CLI structs

### DIFF
--- a/ortho_config/tests/clap_integration.rs
+++ b/ortho_config/tests/clap_integration.rs
@@ -9,9 +9,6 @@ struct TestConfig {
     other: String,
 }
 
-#[allow(non_camel_case_types, non_snake_case)]
-type TestConfigCli = __TestConfigCliMod::__TestConfigCli;
-
 #[derive(Debug, Deserialize, OrthoConfig)]
 struct OptionConfig {
     maybe: Option<u32>,

--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -52,6 +52,7 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
 
     let cli_ident = format_ident!("__{}Cli", ident);
     let cli_mod = format_ident!("__{}CliMod", ident);
+    let cli_pub_ident = format_ident!("{}Cli", ident);
 
     let cli_fields = fields.iter().map(|f| {
         let name = f.ident.as_ref().expect("named field");
@@ -78,6 +79,8 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
                 #( #cli_fields, )*
             }
         }
+
+        pub type #cli_pub_ident = #cli_mod::#cli_ident;
 
         impl #ident {
             #[allow(dead_code)]

--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -75,19 +75,19 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
             use std::option::Option as Option;
             #[derive(clap::Parser, serde::Serialize)]
             #[command(rename_all = "kebab-case")]
-            pub(super) struct #cli_ident {
+            pub struct #cli_ident {
                 #( #cli_fields, )*
             }
         }
 
-        pub type #cli_pub_ident = #cli_mod::#cli_ident;
+        pub use #cli_mod::#cli_ident as #cli_pub_ident;
 
         impl #ident {
             #[allow(dead_code)]
-                S: Into<std::ffi::OsString> + Clone,
-                Self::load_from_iter(std::env::args_os())
+            pub fn load_from_iter<I>(args: I) -> Result<Self, ortho_config::OrthoError>
+            where
                 I: IntoIterator,
-                I::Item: AsRef<::std::ffi::OsStr>,
+                I::Item: Into<std::ffi::OsString> + Clone,
             {
                 use clap::Parser as _;
                 use figment::{Figment, providers::{Toml, Env, Serialized, Format}, Profile};


### PR DESCRIPTION
## Summary
- expose the generated CLI struct with a public alias
- update tests to use the alias directly

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: expected one of `!` or `::`, found `:`)*
- `cargo test --manifest-path ortho_config/Cargo.toml` *(fails: expected one of `!` or `::`, found `:`)*

------
https://chatgpt.com/codex/tasks/task_e_6845e56474e08322a0b30eadd233073d

## Summary by Sourcery

Expose the internally generated CLI struct from the derive macro, adjust its load_from_iter signature, and update tests to use the new public alias

Enhancements:
- Derive macro now re-exports the generated CLI struct under a public alias
- Make load_from_iter method public and refine its generic trait bounds

Tests:
- Remove manual CLI alias type in tests and reference the new public alias directly