### PR TITLE
Make config path customizable

### DIFF
--- a/ortho_config/tests/clap_integration.rs
+++ b/ortho_config/tests/clap_integration.rs
@@ -93,3 +93,16 @@ fn option_field_cli_absent() {
     let cfg = OptionConfig::load_from_iter(["prog"]).expect("load");
     assert_eq!(cfg.maybe, None);
 }
+
+#[test]
+fn config_path_env_var() {
+    figment::Jail::expect_with(|j| {
+        j.create_file("alt.toml", "sample_value = \"from_env\"\nother = \"val\"")?;
+        j.set_env("CONFIG_PATH", "alt.toml");
+
+        let cfg = TestConfig::load_from_iter(["prog"]).expect("load");
+        assert_eq!(cfg.sample_value, "from_env");
+        assert_eq!(cfg.other, "val");
+        Ok(())
+    });
+}

--- a/ortho_config/tests/clap_integration.rs
+++ b/ortho_config/tests/clap_integration.rs
@@ -106,3 +106,16 @@ fn config_path_env_var() {
         Ok(())
     });
 }
+
+#[test]
+fn missing_config_file_is_ignored() {
+    figment::Jail::expect_with(|j| {
+        j.set_env("CONFIG_PATH", "nope.toml");
+
+        let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "cli", "--other", "val"])
+            .expect("load");
+        assert_eq!(cfg.sample_value, "cli");
+        assert_eq!(cfg.other, "val");
+        Ok(())
+    });
+}

--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -93,8 +93,11 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
                 let cli = #cli_mod::#cli_ident::try_parse_from(args)
                     .map_err(ortho_config::OrthoError::CliParsing)?;
 
+                let cfg_path = std::env::var("CONFIG_PATH")
+                    .unwrap_or_else(|_| "config.toml".to_string());
+
                 Figment::new()
-                    .merge(Toml::file("config.toml"))
+                    .merge(Toml::file(&cfg_path))
                     .merge(Env::raw()
                         .map(|k| Uncased::new(k.as_str().to_ascii_uppercase()))
                         .split("__"))


### PR DESCRIPTION
## Summary
- allow config file path via `CONFIG_PATH` environment variable
- test config loading respects the env var

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: expected one of `!` or `::`, found `:`)*
- `cargo test` *(fails: proc-macro derive produced unparsable tokens)*

------
https://chatgpt.com/codex/tasks/task_e_6845e55504d48322a1ed83a627e4eec2

## Summary by Sourcery

Enable customizing the configuration file path by reading the CONFIG_PATH environment variable in the derive macro (defaulting to "config.toml") and add an integration test to verify this behavior.

New Features:
- Allow specifying the config file path via the CONFIG_PATH environment variable

Tests:
- Add integration test that ensures config loading respects the CONFIG_PATH environment variable