### PR TITLE
Simplify load_from_iter implementation

### DIFF
--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -84,22 +84,19 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
 
         impl #ident {
             #[allow(dead_code)]
-            pub fn load_from_iter<I, S>(args: I) -> Result<Self, ortho_config::OrthoError>
+            pub fn load_from_iter<I>(args: I) -> Result<Self, ortho_config::OrthoError>
             where
-                I: IntoIterator<Item = S>,
-                S: AsRef<std::ffi::OsStr>,
+                I: IntoIterator,
+                I::Item: AsRef<std::ffi::OsStr>,
             {
                 use clap::Parser as _;
                 use figment::{Figment, providers::{Toml, Env, Serialized, Format}, Profile};
                 use uncased::Uncased;
 
-                let cli_args: Vec<std::ffi::OsString> = args
-                    .into_iter()
-                    .map(|a| a.as_ref().to_os_string())
-                    .collect();
-
-                let cli = #cli_mod::#cli_ident::try_parse_from(cli_args)
-                    .map_err(ortho_config::OrthoError::CliParsing)?;
+                let cli = #cli_mod::#cli_ident::try_parse_from(
+                    args.into_iter().map(|a| a.as_ref().to_os_string())
+                )
+                .map_err(ortho_config::OrthoError::CliParsing)?;
 
                 Figment::new()
                     .merge(Toml::file("config.toml"))


### PR DESCRIPTION
## Summary
- improve clarity of `load_from_iter` in derive macro
- avoid an intermediate `Vec` and map args lazily

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_6845f96cef1883228b50dae150e0aade

## Summary by Sourcery

Simplify the derive macro’s load_from_iter by generalizing its iterator signature and eliminating an intermediate collection for improved clarity and efficiency

Enhancements:
- Generalize load_from_iter to accept any IntoIterator with items implementing AsRef<OsStr>
- Remove the temporary Vec by mapping arguments lazily when invoking CLI parser