### PR TITLE
Implement attribute handling in macros

### DIFF
--- a/ortho_config/tests/attribute_handling.rs
+++ b/ortho_config/tests/attribute_handling.rs
@@ -1,0 +1,48 @@
+#![allow(non_snake_case)]
+
+use ortho_config::OrthoConfig;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, OrthoConfig)]
+#[allow(dead_code)]
+struct CustomCli {
+    #[ortho_config(cli_long = "my-val")]
+    value: String,
+}
+
+#[derive(Debug, Deserialize, OrthoConfig)]
+#[allow(dead_code)]
+#[ortho_config(prefix = "CFG_")]
+struct Prefixed {
+    value: String,
+}
+
+#[derive(Debug, Deserialize, OrthoConfig)]
+#[allow(dead_code)]
+struct Defaulted {
+    #[ortho_config(default = 5)]
+    num: u32,
+}
+
+#[test]
+fn uses_custom_cli_long() {
+    use clap::Parser;
+    let cli = CustomCliCli::parse_from(["prog", "--my-val", "42"]);
+    assert_eq!(cli.value.as_deref(), Some("42"));
+}
+
+#[test]
+fn env_prefix_is_used() {
+    figment::Jail::expect_with(|j| {
+        j.set_env("CFG_VALUE", "env");
+        let cfg = Prefixed::load_from_iter(["prog"]).expect("load");
+        assert_eq!(cfg.value, "env");
+        Ok(())
+    });
+}
+
+#[test]
+fn default_value_applied() {
+    let cfg = Defaulted::load_from_iter(["prog"]).expect("load");
+    assert_eq!(cfg.num, 5);
+}

--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -8,7 +8,74 @@
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{Data, DeriveInput, Fields, GenericArgument, PathArguments, Type, parse_macro_input};
+use syn::{
+    Attribute, Data, DeriveInput, Expr, Fields, GenericArgument, Lit, PathArguments, Type,
+    parse_macro_input,
+};
+
+#[derive(Default)]
+struct StructAttrs {
+    prefix: Option<String>,
+}
+
+#[derive(Default)]
+struct FieldAttrs {
+    cli_long: Option<String>,
+    cli_short: Option<char>,
+    default: Option<Expr>,
+}
+
+fn parse_struct_attrs(attrs: &[Attribute]) -> Result<StructAttrs, syn::Error> {
+    let mut out = StructAttrs::default();
+    for attr in attrs {
+        if !attr.path().is_ident("ortho_config") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("prefix") {
+                let val = meta.value()?.parse::<Lit>()?;
+                if let Lit::Str(s) = val {
+                    out.prefix = Some(s.value());
+                } else {
+                    return Err(syn::Error::new(val.span(), "prefix must be a string"));
+                }
+            }
+            Ok(())
+        })?;
+    }
+    Ok(out)
+}
+
+fn parse_field_attrs(attrs: &[Attribute]) -> Result<FieldAttrs, syn::Error> {
+    let mut out = FieldAttrs::default();
+    for attr in attrs {
+        if !attr.path().is_ident("ortho_config") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("cli_long") {
+                let val = meta.value()?.parse::<Lit>()?;
+                if let Lit::Str(s) = val {
+                    out.cli_long = Some(s.value());
+                } else {
+                    return Err(syn::Error::new(val.span(), "cli_long must be a string"));
+                }
+            } else if meta.path.is_ident("cli_short") {
+                let val = meta.value()?.parse::<Lit>()?;
+                if let Lit::Char(c) = val {
+                    out.cli_short = Some(c.value());
+                } else {
+                    return Err(syn::Error::new(val.span(), "cli_short must be a char"));
+                }
+            } else if meta.path.is_ident("default") {
+                let expr = meta.value()?.parse::<Expr>()?;
+                out.default = Some(expr);
+            }
+            Ok(())
+        })?;
+    }
+    Ok(out)
+}
 
 fn option_inner(ty: &Type) -> Option<&Type> {
     if let Type::Path(p) = ty {
@@ -26,10 +93,14 @@ fn option_inner(ty: &Type) -> Option<&Type> {
 }
 
 /// Derive macro for [`ortho_config::OrthoConfig`].
-#[proc_macro_derive(OrthoConfig)]
+#[proc_macro_derive(OrthoConfig, attributes(ortho_config))]
 pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let ident = input.ident;
+    let struct_attrs = match parse_struct_attrs(&input.attrs) {
+        Ok(a) => a,
+        Err(e) => return e.to_compile_error().into(),
+    };
 
     let fields = match input.data {
         Data::Struct(data) => match data.fields {
@@ -54,7 +125,15 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
     let cli_mod = format_ident!("__{}CliMod", ident);
     let cli_pub_ident = format_ident!("{}Cli", ident);
 
-    let cli_fields = fields.iter().map(|f| {
+    let mut field_attrs = Vec::new();
+    for f in &fields {
+        match parse_field_attrs(&f.attrs) {
+            Ok(a) => field_attrs.push(a),
+            Err(e) => return e.to_compile_error().into(),
+        }
+    }
+
+    let cli_fields = fields.iter().zip(field_attrs.iter()).map(|(f, attr)| {
         let name = f.ident.as_ref().expect("named field");
         let ty = &f.ty;
         let inner = option_inner(ty);
@@ -63,12 +142,53 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
         } else {
             quote! { Option<#ty> }
         };
+
+        let mut arg_tokens = quote! { long };
+        if let Some(ref long) = attr.cli_long {
+            arg_tokens = quote! { long = #long };
+        }
+        if let Some(ch) = attr.cli_short {
+            let short_token = quote! { short = #ch };
+            arg_tokens = quote! { #arg_tokens, #short_token };
+        }
+
         quote! {
-            #[arg(long, required = false)]
+            #[arg(#arg_tokens, required = false)]
             #[serde(skip_serializing_if = "Option::is_none")]
-            pub(super) #name: #cli_ty
+            pub #name: #cli_ty
         }
     });
+
+    let defaults_ident = format_ident!("__{}Defaults", ident);
+    let default_struct_fields = fields.iter().map(|f| {
+        let name = f.ident.as_ref().expect("named field");
+        let ty = &f.ty;
+        let inner = option_inner(ty);
+        let default_ty = if let Some(inner) = inner {
+            quote! { Option<#inner> }
+        } else {
+            quote! { Option<#ty> }
+        };
+        quote! {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub #name: #default_ty
+        }
+    });
+
+    let default_struct_init = fields.iter().zip(field_attrs.iter()).map(|(f, attr)| {
+        let name = f.ident.as_ref().expect("named field");
+        if let Some(expr) = &attr.default {
+            quote! { #name: Some(#expr) }
+        } else {
+            quote! { #name: None }
+        }
+    });
+
+    let env_provider = if let Some(prefix) = &struct_attrs.prefix {
+        quote! { Env::prefixed(#prefix) }
+    } else {
+        quote! { Env::raw() }
+    };
 
     let expanded = quote! {
         mod #cli_mod {
@@ -78,6 +198,11 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
             pub struct #cli_ident {
                 #( #cli_fields, )*
             }
+        }
+
+        #[derive(serde::Serialize)]
+        struct #defaults_ident {
+            #( #default_struct_fields, )*
         }
 
         pub use #cli_mod::#cli_ident as #cli_pub_ident;
@@ -102,14 +227,24 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
                     .unwrap_or_else(|_| "config.toml".to_string());
 
                 let mut fig = Figment::new();
+                let defaults = #defaults_ident {
+                    #( #default_struct_init, )*
+                };
+
+                fig = fig.merge(Serialized::defaults(defaults));
+
                 if std::path::Path::new(&cfg_path).is_file() {
                     fig = fig.merge(Toml::file(&cfg_path));
                 }
 
-                fig
-                    .merge(Env::raw()
+                let env_provider = {
+                    #env_provider
                         .map(|k| Uncased::new(k.as_str().to_ascii_uppercase()))
-                        .split("__"))
+                        .split("__")
+                };
+
+                fig
+                    .merge(env_provider)
                     .merge(Serialized::from(cli, Profile::Default))
                     .extract()
                     .map_err(ortho_config::OrthoError::Gathering)


### PR DESCRIPTION
## Summary
- implement attribute parser for `#[ortho_config(...)]`
- support `prefix`, `cli_long`, `cli_short`, and `default` attributes
- generate defaults provider and env prefix handling in derived code
- add tests covering custom CLI long name, env prefix, and default value

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6845fe1a12e0832283951e1e5340b24c

## Summary by Sourcery

Parse struct- and field-level ortho_config attributes in the OrthoConfig derive macro to support custom CLI arguments, default values, and optional environment variable prefixing, and add tests to validate these behaviors

New Features:
- Support #[ortho_config(prefix = "...")] on structs to set an env variable prefix
- Support #[ortho_config(cli_long = "...", cli_short = 'x', default = ...)] on fields for CLI flag customization and default values

Enhancements:
- Generate a defaults provider struct and merge default values into the Figment builder
- Merge an Env provider with optional prefix in the generated code for environment variable handling

Tests:
- Add integration tests for custom CLI long name, environment variable prefix usage, and default value application