### PR TITLE
Implement v0.5 advanced features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,8 @@ dependencies = [
  "parking_lot",
  "pear",
  "serde",
+ "serde_json",
+ "serde_yaml",
  "tempfile",
  "toml",
  "uncased",
@@ -216,6 +218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,7 +271,10 @@ dependencies = [
  "figment",
  "ortho_config_macros",
  "serde",
+ "serde_json",
+ "serde_yaml",
  "thiserror",
+ "toml",
  "uncased",
 ]
 
@@ -382,6 +393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,12 +425,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -527,6 +569,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +281,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "toml",
+ "trybuild",
  "uncased",
 ]
 
@@ -482,6 +489,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +505,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -556,6 +578,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "trybuild"
+version = "1.0.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c9bf9513a2f4aeef5fdac8677d7d349c79fdbcc03b9c86da6e9d254f1e43be2"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +632,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ TOML parsing is enabled by default. Enable the `json` and `yaml` features to sup
 ortho_config = { version = "0.1.0", features = ["json", "yaml"] }
 ```
 
-The file loader selects the parser based on the extension (`.toml`, `.json`, `.yaml`).
+The file loader selects the parser based on the extension (`.toml`, `.json`, `.yaml`, `.yml`).
 
 ## Orthographic Naming
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ OrthoConfig loads configuration from the following sources, with later sources o
 3.  **Environment Variables:** Variables prefixed with the string specified in `#[ortho_config(prefix = "...")]` (e.g., `APP_`). Nested struct fields are typically accessed using double underscores (e.g., `APP_DATABASE__URL` if `prefix = "APP"` on `AppConfig` and no prefix on `DatabaseConfig`, or `APP_DB_URL` with `#` on `DatabaseConfig`).
 4.  **Command-Line Arguments:** Parsed using `clap` conventions. Long flags are derived from field names (e.g., `my_field` becomes `--my-field`).
 
+### File Format Support
+
+TOML parsing is enabled by default. Enable the `json` and `yaml` features to support additional formats:
+
+```toml
+[dependencies]
+ortho_config = { version = "0.1.0", features = ["json", "yaml"] }
+```
+
+The file loader selects the parser based on the extension (`.toml`, `.json`, `.yaml`).
+
 ## Orthographic Naming
 
 A key goal of OrthoConfig is to make configuration natural from any source. A field like `max_connections: u32` in your Rust struct will, by default, be configurable via:

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -8,8 +8,17 @@ ortho_config_macros = { path = "../ortho_config_macros" }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
-figment = { version = "0.10", features = ["toml", "env", "test"] }
+figment = { version = "0.10", default-features = false, features = ["env", "test"] }
 uncased = "0.9"
+toml = { version = "0.8", optional = true }
+serde_json = { version = "1", optional = true }
+serde_yaml = { version = "0.9", optional = true }
+
+[features]
+default = ["toml"]
+toml = ["figment/toml", "dep:toml"]
+json = ["figment/json", "dep:serde_json"]
+yaml = ["figment/yaml", "dep:serde_yaml"]
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env"] }

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -23,3 +23,4 @@ yaml = ["figment/yaml", "dep:serde_yaml"]
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env"] }
 serde = { version = "1", features = ["derive"] }
+trybuild = "1"

--- a/ortho_config/src/file.rs
+++ b/ortho_config/src/file.rs
@@ -1,0 +1,76 @@
+use crate::OrthoError;
+#[cfg(feature = "json")]
+use figment::providers::Json;
+#[cfg(feature = "yaml")]
+use figment::providers::Yaml;
+use figment::{
+    Figment,
+    providers::{Format, Toml},
+};
+#[cfg(feature = "json")]
+use serde_json;
+#[cfg(feature = "yaml")]
+use serde_yaml;
+use std::path::Path;
+
+/// Load configuration from a file, selecting the parser based on extension.
+///
+/// Returns `Ok(None)` if the file does not exist.
+#[allow(clippy::result_large_err)]
+pub fn load_config_file(path: &Path) -> Result<Option<Figment>, OrthoError> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let data = std::fs::read_to_string(path).map_err(|e| OrthoError::File {
+        path: path.to_path_buf(),
+        source: Box::new(e),
+    })?;
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+    let figment = match ext.as_deref() {
+        Some("json") => {
+            #[cfg(feature = "json")]
+            {
+                serde_json::from_str::<serde_json::Value>(&data).map_err(|e| OrthoError::File {
+                    path: path.to_path_buf(),
+                    source: Box::new(e),
+                })?;
+                Figment::from(Json::string(&data))
+            }
+            #[cfg(not(feature = "json"))]
+            {
+                return Err(OrthoError::File {
+                    path: path.to_path_buf(),
+                    source: Box::new(std::io::Error::other("json feature disabled")),
+                });
+            }
+        }
+        Some("yaml") | Some("yml") => {
+            #[cfg(feature = "yaml")]
+            {
+                serde_yaml::from_str::<serde_yaml::Value>(&data).map_err(|e| OrthoError::File {
+                    path: path.to_path_buf(),
+                    source: Box::new(e),
+                })?;
+                Figment::from(Yaml::string(&data))
+            }
+            #[cfg(not(feature = "yaml"))]
+            {
+                return Err(OrthoError::File {
+                    path: path.to_path_buf(),
+                    source: Box::new(std::io::Error::other("yaml feature disabled")),
+                });
+            }
+        }
+        _ => {
+            toml::from_str::<toml::Value>(&data).map_err(|e| OrthoError::File {
+                path: path.to_path_buf(),
+                source: Box::new(e),
+            })?;
+            Figment::from(Toml::string(&data))
+        }
+    };
+    Ok(Some(figment))
+}

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -7,8 +7,10 @@
 pub use ortho_config_macros::OrthoConfig;
 
 mod error;
+mod file;
 
 pub use error::OrthoError;
+pub use file::load_config_file;
 
 /// Trait implemented for structs that represent application configuration.
 pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {

--- a/ortho_config/tests/compile_fail.rs
+++ b/ortho_config/tests/compile_fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/ortho_config/tests/merge_strategy.rs
+++ b/ortho_config/tests/merge_strategy.rs
@@ -8,6 +8,12 @@ struct VecConfig {
     values: Vec<String>,
 }
 
+#[derive(Debug, Deserialize, OrthoConfig)]
+struct DefaultVec {
+    #[ortho_config(default = vec!["def".to_string()], merge_strategy = "append")]
+    values: Vec<String>,
+}
+
 #[test]
 fn append_merges_all_sources() {
     figment::Jail::expect_with(|j| {
@@ -16,6 +22,17 @@ fn append_merges_all_sources() {
         let cfg = VecConfig::load_from_iter(["prog", "--values", "cli1", "--values", "cli2"])
             .expect("load");
         assert_eq!(cfg.values, vec!["file", "env", "cli1", "cli2"]);
+        Ok(())
+    });
+}
+
+#[test]
+fn append_includes_defaults() {
+    figment::Jail::expect_with(|j| {
+        j.create_file("config.toml", "values = [\"file\"]")?;
+        j.set_env("VALUES", "[\"env\"]");
+        let cfg = DefaultVec::load_from_iter(["prog", "--values", "cli"]).expect("load");
+        assert_eq!(cfg.values, vec!["def", "file", "env", "cli"]);
         Ok(())
     });
 }

--- a/ortho_config/tests/merge_strategy.rs
+++ b/ortho_config/tests/merge_strategy.rs
@@ -1,0 +1,21 @@
+#![allow(non_snake_case)]
+use ortho_config::OrthoConfig;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, OrthoConfig)]
+struct VecConfig {
+    #[ortho_config(merge_strategy = "append")]
+    values: Vec<String>,
+}
+
+#[test]
+fn append_merges_all_sources() {
+    figment::Jail::expect_with(|j| {
+        j.create_file("config.toml", "values = [\"file\"]")?;
+        j.set_env("VALUES", "[\"env\"]");
+        let cfg = VecConfig::load_from_iter(["prog", "--values", "cli1", "--values", "cli2"])
+            .expect("load");
+        assert_eq!(cfg.values, vec!["file", "env", "cli1", "cli2"]);
+        Ok(())
+    });
+}

--- a/ortho_config/tests/ui/invalid_merge_strategy.rs
+++ b/ortho_config/tests/ui/invalid_merge_strategy.rs
@@ -1,0 +1,10 @@
+use ortho_config::OrthoConfig;
+use serde::Deserialize;
+
+#[derive(Deserialize, OrthoConfig)]
+struct Bad {
+    #[ortho_config(merge_strategy = "bogus")]
+    values: Vec<String>,
+}
+
+fn main() {}

--- a/ortho_config/tests/ui/invalid_merge_strategy.stderr
+++ b/ortho_config/tests/ui/invalid_merge_strategy.stderr
@@ -1,0 +1,5 @@
+error: unknown merge_strategy
+ --> tests/ui/invalid_merge_strategy.rs:6:37
+  |
+6 |     #[ortho_config(merge_strategy = "bogus")]
+  |                                     ^^^^^^^

--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -137,11 +137,7 @@ fn vec_inner(ty: &Type) -> Option<&Type> {
 fn build_override_struct(
     base: &syn::Ident,
     fields: &[(syn::Ident, &Type)],
-) -> (
-    syn::Ident,
-    proc_macro2::TokenStream,
-    proc_macro2::TokenStream,
-) {
+) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
     let ident = format_ident!("__{}VecOverride", base);
     let struct_fields = fields.iter().map(|(name, ty)| {
         quote! {
@@ -157,7 +153,7 @@ fn build_override_struct(
         }
     };
     let init_ts = quote! { #ident { #( #init, )* } };
-    (ident, ts, init_ts)
+    (ts, init_ts)
 }
 
 fn build_append_logic(fields: &[(syn::Ident, &Type)]) -> proc_macro2::TokenStream {
@@ -297,8 +293,7 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
         })
         .collect();
 
-    let (_override_ident, override_struct_ts, override_init_ts) =
-        build_override_struct(&ident, &append_fields);
+    let (override_struct_ts, override_init_ts) = build_override_struct(&ident, &append_fields);
     let append_logic = build_append_logic(&append_fields);
 
     let expanded = quote! {


### PR DESCRIPTION
## Summary
- support JSON and YAML config loading via new features
- add merge_strategy="append" handling for Vec fields
- improve error messages for file parsing
- document file format features
- test Vec append merging

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68460dfc17588322ae1326a58883b1a4

## Summary by Sourcery

Implement v0.5 advanced features including merge_strategy append for Vec fields, optional JSON/YAML file support, improved error messages, documentation updates, and related tests.

New Features:
- Add merge_strategy="append" support for Vec fields to cumulatively merge defaults, file, environment, and CLI values
- Enable JSON and YAML configuration file parsing behind optional features, selecting the parser by file extension

Enhancements:
- Improve error handling and messaging when loading and parsing configuration files
- Update Cargo.toml to make toml, json, and yaml providers feature-gated

Build:
- Configure default and optional dependencies and features for toml, json, and yaml in Cargo.toml

Documentation:
- Document File Format Support and feature flags for JSON and YAML in README

Tests:
- Add integration tests for Vec append merging across sources and compile-fail tests for invalid merge strategies