### PR TITLE
Enable workspace clippy pedantic warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ members = [
     "ortho_config_macros"
 ]
 resolver = "2"
+
+
+[workspace.lints.clippy]
+pedantic = "warn"

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -14,6 +14,10 @@ pub use error::OrthoError;
 pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// Loads, merges, and deserializes configuration from all available
     /// sources according to predefined precedence rules.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OrthoError`] if configuration loading fails at any step.
     #[allow(clippy::result_large_err)]
     fn load() -> Result<Self, OrthoError>;
 }

--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -93,7 +93,13 @@ fn option_inner(ty: &Type) -> Option<&Type> {
 }
 
 /// Derive macro for [`ortho_config::OrthoConfig`].
+///
+/// # Panics
+///
+/// Panics if the macro is used on a non-struct item or on a struct with
+/// unnamed fields.
 #[proc_macro_derive(OrthoConfig, attributes(ortho_config))]
+#[allow(clippy::too_many_lines)]
 pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let ident = input.ident;


### PR DESCRIPTION
## Summary
- configure clippy pedantic lints via `[workspace.lints.clippy]`

## Testing
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684617043cc083228f8a410a88487944

## Summary by Sourcery

Enable workspace-level clippy pedantic warnings and address new lints by annotating code and improving documentation

Enhancements:
- Configure workspace to warn on clippy pedantic lints
- Suppress the `too_many_lines` warning on the `derive_ortho_config` macro
- Add `# Panics` documentation to the derive macro and `# Errors` documentation to `OrthoConfig::load`