### PR TITLE
Add workspace package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,17 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.0"
+authors = ["Payton McIntosh <pmcintosh@df12.net>"]
+edition = "2024"
+license = "ISC"
+repository = "https://github.com/leynos/ortho-config"
+description = "A configuration management library for Rust, inspired by esbuild."
+readme = "README.md"
+keywords = ["config", "configuration", "cli", "env", "settings"]
+categories = ["config", "command-line-interface"]
+
 # `cargo clippy` lints configuration
 [workspace.lints.clippy]
 # make every pedantic lint emit a warning

--- a/ortho_config/src/file.rs
+++ b/ortho_config/src/file.rs
@@ -7,10 +7,7 @@ use figment::{
     Figment,
     providers::{Format, Toml},
 };
-#[cfg(feature = "json")]
-use serde_json;
-#[cfg(feature = "yaml")]
-use serde_yaml;
+
 use std::path::Path;
 
 /// Load configuration from a file, selecting the parser based on extension.


### PR DESCRIPTION
## Summary
- add `[workspace.package]` metadata for publishing the workspace
- clean unused imports from `ortho_config/src/file.rs`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6846b2500bd48322b03b55b0ec1d3867

## Summary by Sourcery

Add workspace-level package metadata and clean up unused imports

Enhancements:
- Add `[workspace.package]` metadata to Cargo.toml for workspace publishing
- Remove unused imports from `ortho_config/src/file.rs`