### PR TITLE
Implement flexible config location resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ The core principle is **orthographic option naming**: a single field in your Rus
 
       * With CLI arguments: `cargo run -- --log-level debug --port 3000 -v --features extra_cli_feature`
       * With environment variables: `APP_LOG_LEVEL=warn APP_PORT=4000 APP_DB_URL="postgres://localhost/mydb" APP_FEATURES="env_feat1,env_feat2" cargo run`
-      * With a `config.toml` file (OrthoConfig will look for `OrthoConfig.toml` or `config.toml` by default):
+     * With a `.app.toml` file (assuming `#[ortho_config(prefix = "APP_")]`; adjust for your prefix):
         ```toml
-        # config.toml
+        # .app.toml
         log_level = "file_level"
         port = 5000
         features = ["file_feat_a", "file_feat_b"]
@@ -107,7 +107,12 @@ The core principle is **orthographic option naming**: a single field in your Rus
 OrthoConfig loads configuration from the following sources, with later sources overriding earlier ones:
 
 1.  **Application-Defined Defaults:** Specified using `#[ortho_config(default =...)]` or `Option<T>` fields (which default to `None`).
-2.  **Configuration File:** Looks for `OrthoConfig.toml` or `config.toml` in the current directory or a path specified by the `CONFIG_PATH` environment variable. (Support for JSON and YAML can be enabled via features).
+2.  **Configuration File:** Resolved in this order:
+    1. `--config-path` CLI option
+    2. `[PREFIX]CONFIG_PATH` environment variable
+    3. `.<prefix>.toml` in the current directory
+    4. `.<prefix>.toml` in the user's home directory
+    (where `<prefix>` comes from `#[ortho_config(prefix = "...")]` and defaults to `config`). JSON and YAML support are feature gated.
 3.  **Environment Variables:** Variables prefixed with the string specified in `#[ortho_config(prefix = "...")]` (e.g., `APP_`). Nested struct fields are typically accessed using double underscores (e.g., `APP_DATABASE__URL` if `prefix = "APP"` on `AppConfig` and no prefix on `DatabaseConfig`, or `APP_DB_URL` with `#` on `DatabaseConfig`).
 4.  **Command-Line Arguments:** Parsed using `clap` conventions. Long flags are derived from field names (e.g., `my_field` becomes `--my-field`).
 

--- a/ortho_config/tests/clap_integration.rs
+++ b/ortho_config/tests/clap_integration.rs
@@ -33,7 +33,7 @@ fn cli_only_source() {
 #[test]
 fn cli_overrides_other_sources() {
     figment::Jail::expect_with(|j| {
-        j.create_file("config.toml", "sample_value = \"file\"\nother = \"f\"")?;
+        j.create_file(".config.toml", "sample_value = \"file\"\nother = \"f\"")?;
         j.set_env("SAMPLE_VALUE", "env");
         j.set_env("OTHER", "e");
         let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "cli", "--other", "cli2"])
@@ -47,7 +47,7 @@ fn cli_overrides_other_sources() {
 #[test]
 fn cli_combines_with_file() {
     figment::Jail::expect_with(|j| {
-        j.create_file("config.toml", "other = \"file\"")?;
+        j.create_file(".config.toml", "other = \"file\"")?;
         let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "cli", "--other", "cli2"])
             .expect("load");
         assert_eq!(cfg.sample_value, "cli");

--- a/ortho_config/tests/merge_strategy.rs
+++ b/ortho_config/tests/merge_strategy.rs
@@ -17,7 +17,7 @@ struct DefaultVec {
 #[test]
 fn append_merges_all_sources() {
     figment::Jail::expect_with(|j| {
-        j.create_file("config.toml", "values = [\"file\"]")?;
+        j.create_file(".config.toml", "values = [\"file\"]")?;
         j.set_env("VALUES", "[\"env\"]");
         let cfg = VecConfig::load_from_iter(["prog", "--values", "cli1", "--values", "cli2"])
             .expect("load");
@@ -29,7 +29,7 @@ fn append_merges_all_sources() {
 #[test]
 fn append_includes_defaults() {
     figment::Jail::expect_with(|j| {
-        j.create_file("config.toml", "values = [\"file\"]")?;
+        j.create_file(".config.toml", "values = [\"file\"]")?;
         j.set_env("VALUES", "[\"env\"]");
         let cfg = DefaultVec::load_from_iter(["prog", "--values", "cli"]).expect("load");
         assert_eq!(cfg.values, vec!["def", "file", "env", "cli"]);

--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -17,8 +17,9 @@ mod derive {
 
 use derive::build::{
     LoadImplArgs, LoadImplIdents, LoadImplTokens, build_append_logic, build_cli_fields,
-    build_default_struct_fields, build_default_struct_init, build_env_provider, build_load_impl,
-    build_override_struct, collect_append_fields,
+    build_config_env_var, build_default_struct_fields, build_default_struct_init,
+    build_dotfile_name, build_env_provider, build_load_impl, build_override_struct,
+    collect_append_fields,
 };
 use derive::parse::parse_input;
 
@@ -44,6 +45,8 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
     let default_struct_fields = build_default_struct_fields(&fields);
     let default_struct_init = build_default_struct_init(&fields, &field_attrs);
     let env_provider = build_env_provider(&struct_attrs);
+    let config_env_var = build_config_env_var(&struct_attrs);
+    let dotfile_name = build_dotfile_name(&struct_attrs);
     let append_fields = collect_append_fields(&fields, &field_attrs);
     let (override_struct_ts, override_init_ts) = build_override_struct(&ident, &append_fields);
     let append_logic = build_append_logic(&append_fields);
@@ -59,6 +62,8 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
             default_struct_init: &default_struct_init,
             override_init_ts: &override_init_ts,
             append_logic: &append_logic,
+            config_env_var: &config_env_var,
+            dotfile_name: &dotfile_name,
         },
     });
 


### PR DESCRIPTION
## Summary
- add `--config-path` CLI option and env var support
- derive dotfile names from prefix and search current and home directories
- update unit tests for new default `.config.toml`
- document new config path precedence

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6846b37ba07883228ba04434a3d66c90

## Summary by Sourcery

Implement flexible config file resolution by introducing a CLI option, environment variable support, prefix-derived dotfile naming, and a clear search precedence.

New Features:
- Add --config-path CLI option for specifying the configuration file.
- Support [PREFIX]CONFIG_PATH environment variable to override config file location.
- Derive default dotfile name from prefix (e.g., .config.toml or .<prefix>.toml).
- Search for config file in the following order: CLI option, env var, current directory, then home directory.

Enhancements:
- Extend derive macros to include the config_path field and generate env var and dotfile identifiers.

Documentation:
- Update README to document the new config path resolution precedence and prefix-based dotfile naming.

Tests:
- Update integration tests to use the new default dotfile names (e.g., .config.toml) instead of config.toml.