### PR TITLE
Add JSON5 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +141,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,11 +201,31 @@ dependencies = [
  "parking_lot",
  "pear",
  "serde",
- "serde_json",
  "serde_yaml",
  "tempfile",
  "toml",
  "uncased",
+ "version_check",
+]
+
+[[package]]
+name = "figment-json5"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f6982da09e166efe7dc3c5cf1fe01ef85419733eb188c0df0b571eda9e8a81"
+dependencies = [
+ "figment",
+ "json5",
+ "serde",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
  "version_check",
 ]
 
@@ -230,6 +288,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,11 +344,11 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "figment",
+ "figment-json5",
  "ortho_config_macros",
  "serde",
- "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
  "toml",
  "trybuild",
  "uncased",
@@ -338,6 +407,51 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "pest"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
 ]
 
 [[package]]
@@ -466,6 +580,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,7 +647,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -530,6 +664,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -591,6 +736,18 @@ dependencies = [
  "termcolor",
  "toml",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uncased"

--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ ortho_config = { version = "0.1.0", features = ["json5", "yaml"] }
 ```
 
 The file loader selects the parser based on the extension (`.toml`, `.json`, `.json5`, `.yaml`, `.yml`).
+When the `json5` feature is active, both `.json` and `.json5` files are parsed
+using the JSON5 format. Standard JSON is valid JSON5, so existing `.json` files
+continue to work. Without this feature enabled, attempting to load a `.json` or
+`.json5` file will result in an error.
+
+JSON5 extends JSON with conveniences such as comments, trailing commas,
+single-quoted strings, and unquoted keys.
 
 ## Orthographic Naming
 

--- a/README.md
+++ b/README.md
@@ -112,20 +112,20 @@ OrthoConfig loads configuration from the following sources, with later sources o
     2. `[PREFIX]CONFIG_PATH` environment variable
     3. `.<prefix>.toml` in the current directory
     4. `.<prefix>.toml` in the user's home directory
-    (where `<prefix>` comes from `#[ortho_config(prefix = "...")]` and defaults to `config`). JSON and YAML support are feature gated.
+    (where `<prefix>` comes from `#[ortho_config(prefix = "...")]` and defaults to `config`). JSON5 and YAML support are feature gated.
 3.  **Environment Variables:** Variables prefixed with the string specified in `#[ortho_config(prefix = "...")]` (e.g., `APP_`). Nested struct fields are typically accessed using double underscores (e.g., `APP_DATABASE__URL` if `prefix = "APP"` on `AppConfig` and no prefix on `DatabaseConfig`, or `APP_DB_URL` with `#` on `DatabaseConfig`).
 4.  **Command-Line Arguments:** Parsed using `clap` conventions. Long flags are derived from field names (e.g., `my_field` becomes `--my-field`).
 
 ### File Format Support
 
-TOML parsing is enabled by default. Enable the `json` and `yaml` features to support additional formats:
+TOML parsing is enabled by default. Enable the `json5` and `yaml` features to support additional formats:
 
 ```toml
 [dependencies]
-ortho_config = { version = "0.1.0", features = ["json", "yaml"] }
+ortho_config = { version = "0.1.0", features = ["json5", "yaml"] }
 ```
 
-The file loader selects the parser based on the extension (`.toml`, `.json`, `.yaml`, `.yml`).
+The file loader selects the parser based on the extension (`.toml`, `.json`, `.json5`, `.yaml`, `.yml`).
 
 ## Orthographic Naming
 
@@ -134,7 +134,7 @@ A key goal of OrthoConfig is to make configuration natural from any source. A fi
   * CLI: `--max-connections <value>`
   * Environment (assuming `#[ortho_config(prefix = "MYAPP")]`): `MYAPP_MAX_CONNECTIONS=<value>`
   * TOML file: `max_connections = <value>`
-  * JSON file: `max_connections` or `maxConnections` (configurable)
+  * JSON5 file: `max_connections` or `maxConnections` (configurable)
 
 You can customize these mappings using `#[ortho_config(...)]` attributes.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -135,7 +135,7 @@ The implementation must be careful to wrap errors from `clap`, `figment`, and fi
     * `clap`: For CLI parsing. Choose a version with the `derive` feature.
     * `figment`: As the core layering engine.
     * `serde`: For serialization/deserialization.
-    * `toml`, `serde_json`, `serde_yaml`: As optional feature-gated dependencies for different file formats. `toml` should be a default feature.
+    * `toml`, `figment-json5`, `serde_yaml`: As optional feature-gated dependencies for different file formats. `toml` should be a default feature.
     * `thiserror`: For ergonomic error type definitions.
 
 ## 6. Implementation Roadmap
@@ -164,7 +164,7 @@ The implementation must be careful to wrap errors from `clap`, `figment`, and fi
     * Implement the `merge_strategy = "append"` logic for `Vec<T>`.
     * Refine error messages to be maximally helpful.
     * Add extensive documentation and examples.
-    * Feature-gate the file format support (`json`, `yaml`).
+    * Feature-gate the file format support (`json5`, `yaml`).
 
 ## 7. Future Work
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -135,7 +135,7 @@ The implementation must be careful to wrap errors from `clap`, `figment`, and fi
     * `clap`: For CLI parsing. Choose a version with the `derive` feature.
     * `figment`: As the core layering engine.
     * `serde`: For serialization/deserialization.
-    * `toml`, `figment-json5`, `serde_yaml`: As optional feature-gated dependencies for different file formats. `toml` should be a default feature.
+    * `toml`, `figment-json5`, `serde_yaml`: As optional feature-gated dependencies for different file formats. `toml` should be a default feature. The `json5` feature uses `figment-json5` to parse `.json` and `.json5` files; loading these formats without enabling `json5` should produce an error so users aren't surprised by silent TOML parsing.
     * `thiserror`: For ergonomic error type definitions.
 
 ## 6. Implementation Roadmap

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -14,13 +14,13 @@ clap = { version = "4", features = ["derive"] }
 figment = { version = "0.10", default-features = false, features = ["env", "test"] }
 uncased = "0.9"
 toml = { version = "0.8", optional = true }
-serde_json = { version = "1", optional = true }
+figment-json5 = { version = "0.1", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 
 [features]
 default = ["toml"]
 toml = ["figment/toml", "dep:toml"]
-json = ["figment/json", "dep:serde_json"]
+json5 = ["dep:figment-json5"]
 yaml = ["figment/yaml", "dep:serde_yaml"]
 
 [dev-dependencies]

--- a/ortho_config/src/file.rs
+++ b/ortho_config/src/file.rs
@@ -1,12 +1,12 @@
 use crate::OrthoError;
-#[cfg(feature = "json")]
-use figment::providers::Json;
 #[cfg(feature = "yaml")]
 use figment::providers::Yaml;
 use figment::{
     Figment,
     providers::{Format, Toml},
 };
+#[cfg(feature = "json5")]
+use figment_json5::Json5;
 
 use std::path::Path;
 
@@ -31,20 +31,16 @@ pub fn load_config_file(path: &Path) -> Result<Option<Figment>, OrthoError> {
         .and_then(|e| e.to_str())
         .map(str::to_ascii_lowercase);
     let figment = match ext.as_deref() {
-        Some("json") => {
-            #[cfg(feature = "json")]
+        Some("json") | Some("json5") => {
+            #[cfg(feature = "json5")]
             {
-                serde_json::from_str::<serde_json::Value>(&data).map_err(|e| OrthoError::File {
-                    path: path.to_path_buf(),
-                    source: Box::new(e),
-                })?;
-                Figment::from(Json::string(&data))
+                Figment::from(Json5::string(&data))
             }
-            #[cfg(not(feature = "json"))]
+            #[cfg(not(feature = "json5"))]
             {
                 return Err(OrthoError::File {
                     path: path.to_path_buf(),
-                    source: Box::new(std::io::Error::other("json feature disabled")),
+                    source: Box::new(std::io::Error::other("json5 feature disabled")),
                 });
             }
         }

--- a/ortho_config_macros/Cargo.toml
+++ b/ortho_config_macros/Cargo.toml
@@ -13,3 +13,9 @@ proc-macro = true
 syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
+
+[features]
+default = []
+json5 = []
+yaml = []
+toml = []

--- a/ortho_config_macros/src/derive/build.rs
+++ b/ortho_config_macros/src/derive/build.rs
@@ -217,10 +217,9 @@ pub(crate) fn build_load_impl(args: &LoadImplArgs<'_>) -> proc_macro2::TokenStre
             {
                 use clap::Parser as _;
                 use figment::{Figment, providers::{Toml, Env, Serialized, Format}, Profile};
-                #[cfg(feature = "json")] use figment::providers::Json;
+                #[cfg(feature = "json5")] use figment_json5::Json5;
                 #[cfg(feature = "yaml")] use figment::providers::Yaml;
                 use uncased::Uncased;
-                #[cfg(feature = "json")] use serde_json;
                 #[cfg(feature = "yaml")] use serde_yaml;
                 #[cfg(feature = "toml")] use toml;
 


### PR DESCRIPTION
## Summary
- switch from JSON to JSON5 for configuration file parsing
- introduce `json5` feature and use `figment-json5`
- document JSON5 support in README and design docs

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets` *(produced warnings)*
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6846ba4b4f148322b438fab63d4d2773

## Summary by Sourcery

Add support for JSON5-formatted configuration files by replacing the legacy JSON feature with a new `json5` feature, updating parsing logic, dependencies, feature flags, and documentation.

New Features:
- Enable parsing of `.json5` configuration files under the new `json5` feature

Enhancements:
- Treat both `.json` and `.json5` extensions as JSON5 inputs when the `json5` feature is enabled
- Refactor code to use `figment-json5` provider in place of `serde_json`

Build:
- Replace the `json` feature and `serde_json` dependency with `json5` and `figment-json5` in both crates’ Cargo.toml files
- Add `json5` feature gating in the macros crate and update build script imports

Documentation:
- Update README and design documentation to reference JSON5 support and show the `json5` feature flag instead of `json`