### PR TITLE
Add merge utility to library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "figment-json5",
  "ortho_config_macros",
  "serde",
+ "serde_json",
  "serde_yaml",
  "thiserror 1.0.69",
  "toml",

--- a/docs/clap-dispatch-and-ortho-config-integration.md
+++ b/docs/clap-dispatch-and-ortho-config-integration.md
@@ -616,13 +616,8 @@ impl Run for ListArgs {
 }
 
 // --- Merging Logic ---
-// A simplified merge. Real merging would be more granular.
-fn merge_list_args(ortho_default: ListArgs, cli_parsed: ListArgs) -> ListArgs {
-    ListArgs {
-        hide_foo: cli_parsed.hide_foo.or(ortho_default.hide_foo),
-        default_format: cli_parsed.default_format.or(ortho_default.default_format),
-    }
-}
+// `ortho_config` provides a helper to merge CLI values over defaults.
+use ortho_config::merge_cli_over_defaults;
 
 
 fn main() -> Result<(), String> {
@@ -639,7 +634,7 @@ fn main() -> Result<(), String> {
             let ortho_default_list_args: ListArgs = ortho_config_store.get_subcommand_config_struct("list");
 
             // 5. Merge clap-parsed args over ortho-config defaults
-            let final_list_args = merge_list_args(ortho_default_list_args, clap_parsed_list_args);
+            let final_list_args = merge_cli_over_defaults(ortho_default_list_args, clap_parsed_list_args);
             Commands::List(final_list_args)
         }
         // Commands::Add(clap_parsed_add_args) => { /* similar logic for Add command */ }
@@ -654,7 +649,7 @@ fn main() -> Result<(), String> {
 }
 ```
 
-This conceptual code illustrates the key stages: loading `ortho-config` defaults, parsing CLI arguments with `clap`, merging these layers with defined precedence, and finally dispatching the command using the method provided by `clap-dispatch`. The critical merging step (here, `merge_list_args`) needs to inspect which CLI arguments were actually provided by the user (often by checking if `Option` fields in the `clap`-parsed struct are `Some(...)`) to ensure CLI values override `ortho-config` values. A more generic merging strategy might involve reflection or a trait implemented by all argument structs.
+This conceptual code illustrates the key stages: loading `ortho-config` defaults, parsing CLI arguments with `clap`, merging these layers with defined precedence, and finally dispatching the command using the method provided by `clap-dispatch`. The critical merging step now uses `merge_cli_over_defaults`, which inspects which CLI arguments were actually provided by the user (often by checking if `Option` fields in the `clap`-parsed struct are `Some(...)`) to ensure CLI values override `ortho-config` values. A more generic merging strategy might involve reflection or a trait implemented by all argument structs.
 
 ### E. Benefits and Rationale for the Proposed Design
 

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 ortho_config_macros = { path = "../ortho_config_macros" }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 clap-dispatch = "0.1"

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -8,7 +8,9 @@ pub use ortho_config_macros::OrthoConfig;
 
 mod error;
 mod file;
+mod merge;
 pub mod subcommand;
+pub use merge::merge_cli_over_defaults;
 pub use subcommand::load_subcommand_config;
 
 pub use error::OrthoError;

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -1,0 +1,24 @@
+use serde::{Serialize, de::DeserializeOwned};
+
+/// Merge CLI-provided values over application defaults.
+///
+/// Any field set to `None` in the `cli` argument will leave the corresponding
+/// value from `defaults` intact. This function is intended for simple "CLI over
+/// defaults" merging in example code and small projects.
+pub fn merge_cli_over_defaults<T>(defaults: T, cli: T) -> T
+where
+    T: Serialize + DeserializeOwned + Default,
+{
+    let mut val = serde_json::to_value(defaults).unwrap_or_default();
+    let cli_val = serde_json::to_value(cli).unwrap_or_default();
+    if let serde_json::Value::Object(cli_map) = cli_val {
+        if let serde_json::Value::Object(ref mut base) = val {
+            for (k, v) in cli_map {
+                if !v.is_null() {
+                    base.insert(k, v);
+                }
+            }
+        }
+    }
+    serde_json::from_value(val).unwrap_or_default()
+}

--- a/ortho_config/tests/merge_utils.rs
+++ b/ortho_config/tests/merge_utils.rs
@@ -1,0 +1,28 @@
+use ortho_config::merge_cli_over_defaults;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
+struct Sample {
+    a: Option<u32>,
+    b: Option<String>,
+}
+
+#[test]
+fn cli_overrides_defaults() {
+    let defaults = Sample {
+        a: Some(1),
+        b: Some("def".into()),
+    };
+    let cli = Sample {
+        a: None,
+        b: Some("cli".into()),
+    };
+    let merged = merge_cli_over_defaults(defaults, cli);
+    assert_eq!(
+        merged,
+        Sample {
+            a: Some(1),
+            b: Some("cli".into())
+        }
+    );
+}


### PR DESCRIPTION
## Summary
- add a generic `merge_cli_over_defaults` helper in the library
- expose it publicly through `ortho_config`
- use the helper in `registry_ctl` example
- document helper usage in clap dispatch docs
- add unit test for merge helper

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

------
https://chatgpt.com/codex/tasks/task_e_68473f4ac5888322805050f9c10d2142

## Summary by Sourcery

Introduce a generic merge utility to combine CLI arguments over configuration defaults, integrate it across examples and docs, add the necessary dependency, and include a unit test to ensure correct behavior.

New Features:
- Introduce `merge_cli_over_defaults` helper in ortho_config and expose it publicly

Enhancements:
- Replace ad-hoc merge implementations in examples and documentation with the new helper

Build:
- Add `serde_json` dependency to support serialization in the merge helper

Documentation:
- Document `merge_cli_over_defaults` usage in the clap-dispatch integration guide

Tests:
- Add unit test for `merge_cli_over_defaults` to verify CLI values override defaults