### PR TITLE
Use Figment for CLI merging

### DIFF
--- a/examples/registry_ctl.rs
+++ b/examples/registry_ctl.rs
@@ -58,14 +58,16 @@ fn main() -> Result<(), String> {
         Commands::AddUser(args) => {
             let defaults: AddUserArgs =
                 load_subcommand_config("REGCTL_", "add-user").unwrap_or_default();
-            let merged = merge_cli_over_defaults(&defaults, &args);
+            let merged = merge_cli_over_defaults(&defaults, &args)
+                .map_err(|e| e.to_string())?;
             Commands::AddUser(merged)
         }
         Commands::ListItems(args) => {
             // `ListItems` becomes `list-items` when parsed by clap
             let defaults: ListItemsArgs =
                 load_subcommand_config("REGCTL_", "list-items").unwrap_or_default();
-            let merged = merge_cli_over_defaults(&defaults, &args);
+            let merged = merge_cli_over_defaults(&defaults, &args)
+                .map_err(|e| e.to_string())?;
             Commands::ListItems(merged)
         }
     };

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -1,17 +1,22 @@
 use figment::{Figment, providers::Serialized};
 use serde::{Serialize, de::DeserializeOwned};
 
-/// Merge CLI-provided values over application defaults.
+/// Merge CLI-provided values over application defaults using Figment.
 ///
 /// Any field set to `None` in the `cli` argument will leave the corresponding
-/// value from `defaults` intact. This function is intended for simple "CLI over
-/// defaults" merging in example code and small projects.
-pub fn merge_cli_over_defaults<T>(defaults: &T, cli: &T) -> T
+/// value from `defaults` intact. This function is intended for simple
+/// "CLI over defaults" merging in example code and small projects.
+///
+/// # Errors
+///
+/// Returns any [`figment::Error`] produced while extracting the merged
+/// configuration.
+#[allow(clippy::result_large_err)]
+pub fn merge_cli_over_defaults<T>(defaults: &T, cli: &T) -> Result<T, figment::Error>
 where
     T: Serialize + DeserializeOwned + Default,
 {
     Figment::from(Serialized::defaults(defaults))
         .merge(Serialized::defaults(cli))
         .extract()
-        .unwrap_or_default()
 }

--- a/ortho_config/tests/merge_utils.rs
+++ b/ortho_config/tests/merge_utils.rs
@@ -19,12 +19,44 @@ fn cli_overrides_defaults() {
         a: None,
         b: Some("cli".into()),
     };
-    let merged = merge_cli_over_defaults(&defaults, &cli);
+    let merged = merge_cli_over_defaults(&defaults, &cli).expect("merge");
     assert_eq!(
         merged,
         Sample {
             a: Some(1),
             b: Some("cli".into())
+        }
+    );
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
+struct Nested {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    inner: Option<Sample>,
+}
+
+#[test]
+fn nested_structs_merge_deeply() {
+    let defaults = Nested {
+        inner: Some(Sample {
+            a: Some(1),
+            b: Some("def".into()),
+        }),
+    };
+    let cli = Nested {
+        inner: Some(Sample {
+            a: None,
+            b: Some("cli".into()),
+        }),
+    };
+    let merged = merge_cli_over_defaults(&defaults, &cli).expect("merge");
+    assert_eq!(
+        merged,
+        Nested {
+            inner: Some(Sample {
+                a: Some(1),
+                b: Some("cli".into()),
+            })
         }
     );
 }


### PR DESCRIPTION
## Summary
- refactor `merge_cli_over_defaults` to use Figment's `Serialized` provider
- update example and tests for new reference-based API

## Testing
- `cargo clippy --workspace --tests -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6847540c18b88322a3e344eb64dbb3f2

## Summary by Sourcery

Refactor merge_cli_over_defaults to leverage Figment’s Serialized provider with error handling and update tests and examples to use the new API.

Enhancements:
- Change merge_cli_over_defaults to accept references, return Result<T, figment::Error>, and use Figment’s Serialized provider for merging
- Add serde skip_serializing_if attributes to optional fields in structs to omit nulls during serialization
- Update example registry_ctl.rs to handle the Result from merge_cli_over_defaults and map errors to strings

Tests:
- Adjust merge_utils tests to call merge_cli_over_defaults by reference and unwrap the Result
- Add nested_structs_merge_deeply test to verify deep merging of optional nested structs