### PR TITLE
Remove unused serde_json dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,6 @@ dependencies = [
  "figment-json5",
  "ortho_config_macros",
  "serde",
- "serde_json",
  "serde_yaml",
  "thiserror 1.0.69",
  "toml",

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 [dependencies]
 ortho_config_macros = { path = "../ortho_config_macros" }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 clap-dispatch = "0.1"


### PR DESCRIPTION
## Summary
- remove `serde_json` from `ortho_config` dependencies
- update lockfile

## Testing
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68478d880b1c8322889d65e49eec6e6e

## Summary by Sourcery

Remove unused serde_json dependency from ortho_config and update lockfile

Chores:
- Remove serde_json from ortho_config dependencies
- Regenerate Cargo.lock file