### PR TITLE
Add YAML config discovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ When the `json5` feature is active, both `.json` and `.json5` files are parsed
 using the JSON5 format. Standard JSON is valid JSON5, so existing `.json` files
 continue to work. Without this feature enabled, attempting to load a `.json` or
 `.json5` file will result in an error.
+When the `yaml` feature is enabled, `.yaml` and `.yml` files are also discovered and parsed. Without this feature, those extensions are ignored during path discovery.
 
 JSON5 extends JSON with conveniences such as comments, trailing commas,
 single-quoted strings, and unquoted keys.

--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -13,7 +13,13 @@ fn candidate_paths(prefix: &str) -> Vec<PathBuf> {
 
     if let Some(home) = std::env::var_os("HOME") {
         let home = PathBuf::from(home);
-        for ext in ["toml", "json5"] {
+        paths.push(home.join(format!(".{base}.toml")));
+        #[cfg(feature = "json5")]
+        for ext in ["json", "json5"] {
+            paths.push(home.join(format!(".{base}.{ext}")));
+        }
+        #[cfg(feature = "yaml")]
+        for ext in ["yaml", "yml"] {
             paths.push(home.join(format!(".{base}.{ext}")));
         }
     }
@@ -23,13 +29,29 @@ fn candidate_paths(prefix: &str) -> Vec<PathBuf> {
     } else {
         BaseDirectories::with_prefix(&base)
     };
-    for ext in ["toml", "json5"] {
+    if let Some(p) = xdg_dirs.find_config_file("config.toml") {
+        paths.push(p);
+    }
+    #[cfg(feature = "json5")]
+    for ext in ["json", "json5"] {
+        if let Some(p) = xdg_dirs.find_config_file(format!("config.{ext}")) {
+            paths.push(p);
+        }
+    }
+    #[cfg(feature = "yaml")]
+    for ext in ["yaml", "yml"] {
         if let Some(p) = xdg_dirs.find_config_file(format!("config.{ext}")) {
             paths.push(p);
         }
     }
 
-    for ext in ["toml", "json5"] {
+    paths.push(PathBuf::from(format!(".{base}.toml")));
+    #[cfg(feature = "json5")]
+    for ext in ["json", "json5"] {
+        paths.push(PathBuf::from(format!(".{base}.{ext}")));
+    }
+    #[cfg(feature = "yaml")]
+    for ext in ["yaml", "yml"] {
         paths.push(PathBuf::from(format!(".{base}.{ext}")));
     }
 

--- a/ortho_config/tests/clap_integration.rs
+++ b/ortho_config/tests/clap_integration.rs
@@ -134,3 +134,19 @@ fn loads_from_xdg_config() {
         Ok(())
     });
 }
+
+#[cfg(feature = "yaml")]
+#[test]
+fn loads_from_xdg_yaml_config() {
+    figment::Jail::expect_with(|j| {
+        let dir = j.create_dir("xdg_yaml")?;
+        let abs = std::fs::canonicalize(&dir).unwrap();
+        j.create_file(dir.join("config.yaml"), "sample_value: xdg\nother: val")?;
+        j.set_env("XDG_CONFIG_HOME", abs.to_str().unwrap());
+
+        let cfg = TestConfig::load_from_iter(["prog"]).expect("load");
+        assert_eq!(cfg.sample_value, "xdg");
+        assert_eq!(cfg.other, "val");
+        Ok(())
+    });
+}

--- a/ortho_config/tests/subcommand.rs
+++ b/ortho_config/tests/subcommand.rs
@@ -57,3 +57,14 @@ fn loads_from_xdg_config() {
         Ok(())
     });
 }
+
+#[cfg(feature = "yaml")]
+#[test]
+fn loads_yaml_file() {
+    figment::Jail::expect_with(|j| {
+        j.create_file(".app.yml", "cmds:\n  test:\n    foo: yaml")?;
+        let cfg: CmdCfg = load_subcommand_config("APP_", "test").expect("load");
+        assert_eq!(cfg.foo.as_deref(), Some("yaml"));
+        Ok(())
+    });
+}

--- a/ortho_config_macros/src/derive/build.rs
+++ b/ortho_config_macros/src/derive/build.rs
@@ -114,11 +114,27 @@ pub(crate) fn build_xdg_snippet(struct_attrs: &StructAttrs) -> proc_macro2::Toke
             } else {
                 xdg::BaseDirectories::with_prefix(&xdg_base)
             };
-            for ext in &["toml", "json5"] {
-                let filename = format!("config.{}", ext);
-                if let Some(p) = xdg_dirs.find_config_file(&filename) {
-                    file_fig = ortho_config::load_config_file(&p)?;
-                    break;
+            if let Some(p) = xdg_dirs.find_config_file("config.toml") {
+                file_fig = ortho_config::load_config_file(&p)?;
+            }
+            #[cfg(feature = "json5")]
+            if file_fig.is_none() {
+                for ext in &["json", "json5"] {
+                    let filename = format!("config.{}", ext);
+                    if let Some(p) = xdg_dirs.find_config_file(&filename) {
+                        file_fig = ortho_config::load_config_file(&p)?;
+                        break;
+                    }
+                }
+            }
+            #[cfg(feature = "yaml")]
+            if file_fig.is_none() {
+                for ext in &["yaml", "yml"] {
+                    let filename = format!("config.{}", ext);
+                    if let Some(p) = xdg_dirs.find_config_file(&filename) {
+                        file_fig = ortho_config::load_config_file(&p)?;
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- support YAML config files when `yaml` feature is enabled
- search for `yaml` and `yml` extensions in candidate paths and macro XDG lookup
- test YAML subcommand loading and YAML XDG config reading
- guard JSON5 path discovery behind the `json5` feature
- document YAML feature behavior

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features -q`
- `cargo test --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68478d8391e88322b22645885266f6db

## Summary by Sourcery

Add optional YAML config discovery and parsing behind the `yaml` feature, feature-gate JSON5 discovery, and update tests and documentation accordingly.

New Features:
- Support discovering and parsing `.yaml` and `.yml` config files when the `yaml` feature is enabled.

Enhancements:
- Guard JSON5 config file discovery behind the `json5` feature flag.
- Refactor config path lookup to check for TOML first, then JSON5, and finally YAML based on enabled features.

Documentation:
- Document the YAML feature behavior in the README.

Tests:
- Add integration tests for loading YAML subcommand configs and XDG YAML config files.