### PR TITLE
Introduce merged subcommand helper

### DIFF
--- a/docs/clap-dispatch-and-ortho-config-integration.md
+++ b/docs/clap-dispatch-and-ortho-config-integration.md
@@ -616,8 +616,7 @@ impl Run for ListArgs {
 }
 
 // --- Merging Logic ---
-// `ortho_config` provides a helper to merge CLI values over defaults.
-use ortho_config::merge_cli_over_defaults;
+use ortho_config::load_and_merge_subcommand_for;
 
 
 fn main() -> Result<(), String> {
@@ -630,11 +629,8 @@ fn main() -> Result<(), String> {
     // 3. Determine subcommand and merge configurations
     let final_command = match cli_args.command {
         Commands::List(clap_parsed_list_args) => {
-            // 4. Get subcommand defaults from ortho-config
-            let ortho_default_list_args: ListArgs = ortho_config_store.get_subcommand_config_struct("list");
-
-            // 5. Merge clap-parsed args over ortho-config defaults
-            let final_list_args = merge_cli_over_defaults(ortho_default_list_args, clap_parsed_list_args);
+            // 4. Merge CLI values over ortho-config defaults for the subcommand
+            let final_list_args = load_and_merge_subcommand_for("list", &clap_parsed_list_args)?;
             Commands::List(final_list_args)
         }
         // Commands::Add(clap_parsed_add_args) => { /* similar logic for Add command */ }
@@ -649,7 +645,7 @@ fn main() -> Result<(), String> {
 }
 ```
 
-This conceptual code illustrates the key stages: loading `ortho-config` defaults, parsing CLI arguments with `clap`, merging these layers with defined precedence, and finally dispatching the command using the method provided by `clap-dispatch`. The critical merging step now uses `merge_cli_over_defaults`, which inspects which CLI arguments were actually provided by the user (often by checking if `Option` fields in the `clap`-parsed struct are `Some(...)`) to ensure CLI values override `ortho-config` values. A more generic merging strategy might involve reflection or a trait implemented by all argument structs.
+This conceptual code illustrates the key stages: loading `ortho-config` defaults, parsing CLI arguments with `clap`, merging these layers with defined precedence, and finally dispatching the command using the method provided by `clap-dispatch`. The critical merging step now uses `load_and_merge_subcommand_for`, which loads the subcommand defaults and applies any CLI overrides. A more generic merging strategy might involve reflection or a trait implemented by all argument structs.
 
 ### E. Benefits and Rationale for the Proposed Design
 

--- a/examples/registry_ctl.rs
+++ b/examples/registry_ctl.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use clap_dispatch::clap_dispatch;
 use serde::Deserialize;
-use ortho_config::{load_subcommand_config_for, merge_cli_over_defaults, OrthoConfig};
+use ortho_config::{load_and_merge_subcommand_for, OrthoConfig};
 
 #[derive(Parser, Deserialize, Default, Debug, Clone, OrthoConfig)]
 #[ortho_config(prefix = "REGCTL_")]
@@ -58,17 +58,12 @@ fn main() -> Result<(), String> {
     let db_url = "postgres://user:pass@localhost/registry";
     let final_cmd = match cli {
         Commands::AddUser(args) => {
-            let defaults: AddUserArgs =
-                load_subcommand_config_for::<AddUserArgs>("add-user").unwrap_or_default();
-            let merged = merge_cli_over_defaults(&defaults, &args)
+            let merged = load_and_merge_subcommand_for::<AddUserArgs>("add-user", &args)
                 .map_err(|e| e.to_string())?;
             Commands::AddUser(merged)
         }
         Commands::ListItems(args) => {
-            // `ListItems` becomes `list-items` when parsed by clap
-            let defaults: ListItemsArgs =
-                load_subcommand_config_for::<ListItemsArgs>("list-items").unwrap_or_default();
-            let merged = merge_cli_over_defaults(&defaults, &args)
+            let merged = load_and_merge_subcommand_for::<ListItemsArgs>("list-items", &args)
                 .map_err(|e| e.to_string())?;
             Commands::ListItems(merged)
         }

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -10,8 +10,13 @@ mod error;
 mod file;
 mod merge;
 pub mod subcommand;
+#[allow(deprecated)]
 pub use merge::merge_cli_over_defaults;
-pub use subcommand::{load_subcommand_config, load_subcommand_config_for};
+#[allow(deprecated)]
+pub use subcommand::{
+    load_and_merge_subcommand, load_and_merge_subcommand_for, load_subcommand_config,
+    load_subcommand_config_for,
+};
 
 /// Normalize a prefix by trimming trailing underscores and converting
 /// to lowercase ASCII.

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -11,6 +11,7 @@ use serde::{Serialize, de::DeserializeOwned};
 ///
 /// Returns any [`figment::Error`] produced while extracting the merged
 /// configuration.
+#[deprecated(note = "use `load_and_merge_subcommand` instead")]
 #[allow(clippy::result_large_err)]
 pub fn merge_cli_over_defaults<T>(defaults: &T, cli: &T) -> Result<T, figment::Error>
 where

--- a/ortho_config/tests/merge_utils.rs
+++ b/ortho_config/tests/merge_utils.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use ortho_config::merge_cli_over_defaults;
 use serde::{Deserialize, Serialize};
 

--- a/ortho_config/tests/subcommand.rs
+++ b/ortho_config/tests/subcommand.rs
@@ -12,55 +12,84 @@ struct CmdCfg {
     bar: Option<bool>,
 }
 
-#[test]
-fn file_and_env_loading() {
+fn with_cfg<F>(setup: F) -> CmdCfg
+where
+    F: FnOnce(&mut figment::Jail) -> figment::error::Result<()>,
+{
+    use std::cell::RefCell;
+
+    let result = RefCell::new(None);
     figment::Jail::expect_with(|j| {
-        j.create_file(".app.toml", "[cmds.test]\nfoo = \"file\"\nbar = true")?;
-        j.set_env("APP_CMDS_TEST_FOO", "env");
-        let cfg: CmdCfg = load_subcommand_config("APP_", "test").expect("load");
-        assert_eq!(cfg.foo.as_deref(), Some("env"));
-        assert_eq!(cfg.bar, Some(true));
+        setup(j)?;
+        let cfg = load_subcommand_config("APP_", "test").expect("load");
+        result.replace(Some(cfg));
         Ok(())
     });
+    result.into_inner().unwrap()
+}
+
+fn with_cfg_wrapper<F, T>(setup: F) -> T
+where
+    F: FnOnce(&mut figment::Jail) -> figment::error::Result<()>,
+    T: OrthoConfig + Default,
+{
+    use std::cell::RefCell;
+
+    let result = RefCell::new(None);
+    figment::Jail::expect_with(|j| {
+        setup(j)?;
+        let cfg = load_subcommand_config_for::<T>("test").expect("load");
+        result.replace(Some(cfg));
+        Ok(())
+    });
+    result.into_inner().unwrap()
+}
+
+#[test]
+fn file_and_env_loading() {
+    let cfg = with_cfg(|j| {
+        j.create_file(".app.toml", "[cmds.test]\nfoo = \"file\"\nbar = true")?;
+        j.set_env("APP_CMDS_TEST_FOO", "env");
+        Ok(())
+    });
+    assert_eq!(cfg.foo.as_deref(), Some("env"));
+    assert_eq!(cfg.bar, Some(true));
 }
 
 #[test]
 fn loads_from_home() {
-    figment::Jail::expect_with(|j| {
+    let cfg = with_cfg(|j| {
         let home = j.create_dir("home")?;
         j.create_file(home.join(".app.toml"), "[cmds.test]\nfoo = \"home\"")?;
         j.set_env("HOME", home.to_str().unwrap());
-        let cfg: CmdCfg = load_subcommand_config("APP_", "test").expect("load");
-        assert_eq!(cfg.foo.as_deref(), Some("home"));
         Ok(())
     });
+    assert_eq!(cfg.foo.as_deref(), Some("home"));
 }
 
 #[test]
 fn local_overrides_home() {
-    figment::Jail::expect_with(|j| {
+    let cfg = with_cfg(|j| {
         let home = j.create_dir("home")?;
         j.create_file(home.join(".app.toml"), "[cmds.test]\nfoo = \"home\"")?;
         j.set_env("HOME", home.to_str().unwrap());
         j.create_file(".app.toml", "[cmds.test]\nfoo = \"local\"")?;
-        let cfg: CmdCfg = load_subcommand_config("APP_", "test").expect("load");
-        assert_eq!(cfg.foo.as_deref(), Some("local"));
         Ok(())
     });
+    assert_eq!(cfg.foo.as_deref(), Some("local"));
 }
 
 #[test]
 fn loads_from_xdg_config() {
-    figment::Jail::expect_with(|j| {
+    let cfg = with_cfg(|j| {
         let xdg = j.create_dir("xdg")?;
         let abs = std::fs::canonicalize(&xdg).unwrap();
         j.create_dir(abs.join("app"))?;
         j.create_file(abs.join("app/config.toml"), "[cmds.test]\nfoo = \"xdg\"")?;
         j.set_env("XDG_CONFIG_HOME", abs.to_str().unwrap());
-        let cfg: CmdCfg = load_subcommand_config("APP_", "test").expect("load");
-        assert_eq!(cfg.foo.as_deref(), Some("xdg"));
         Ok(())
     });
+    assert_eq!(cfg.foo.as_deref(), Some("xdg"));
 }
 
 #[derive(Debug, Deserialize, OrthoConfig, Default, PartialEq)]
@@ -72,24 +101,22 @@ struct PrefixedCfg {
 
 #[test]
 fn wrapper_uses_struct_prefix() {
-    figment::Jail::expect_with(|j| {
+    let cfg: PrefixedCfg = with_cfg_wrapper(|j| {
         j.create_file(".app.toml", "[cmds.test]\nfoo = \"val\"")?;
         j.set_env("APP_CMDS_TEST_FOO", "env");
-        let cfg: PrefixedCfg = load_subcommand_config_for("test").expect("load");
-        assert_eq!(cfg.foo.as_deref(), Some("env"));
         Ok(())
     });
+    assert_eq!(cfg.foo.as_deref(), Some("env"));
 }
 
 #[cfg(feature = "yaml")]
 #[test]
 fn loads_yaml_file() {
-    figment::Jail::expect_with(|j| {
+    let cfg = with_cfg(|j| {
         j.create_file(".app.yml", "cmds:\n  test:\n    foo: yaml")?;
-        let cfg: CmdCfg = load_subcommand_config("APP_", "test").expect("load");
-        assert_eq!(cfg.foo.as_deref(), Some("yaml"));
         Ok(())
     });
+    assert_eq!(cfg.foo.as_deref(), Some("yaml"));
 }
 
 #[derive(Debug, Deserialize, serde::Serialize, Default, PartialEq)]


### PR DESCRIPTION
## Summary
- add `load_and_merge_subcommand` helper and wrapper
- deprecate `load_subcommand_config` and `merge_cli_over_defaults`
- update example and docs for new API
- adjust tests for new helper

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `nixie README.md docs/clap-dispatch-and-ortho-config-integration.md`


------
https://chatgpt.com/codex/tasks/task_e_6848ad2cbf348322bea9973cb99c8868