### PR TITLE
Add coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,28 @@
+name: Coverage
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@cargo-llvm-cov@v2
+      - name: Generate coverage
+        run: |
+          cargo llvm-cov --workspace --all-features \
+                         --lcov --output-path lcov.info \
+                         --codecov --output-path codecov.json
+      - uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info,codecov.json
+          fail_ci_if_error: true
+          flags: unittests
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch:
+      target: 80%
+    project:
+      threshold: 0.5%
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"


### PR DESCRIPTION
## Summary
- enable code coverage on GitHub pull requests using Codecov
- enforce 80% patch coverage and project drop threshold of 0.5%

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6848adea01848322a1965c4f2b89425c