### PR TITLE
Infer subcommand name from clap parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = AddUserArgs::parse();
 
     // Reads `[cmds.add-user]` sections and `APP_CMDS_ADD_USER_*` variables then merges with CLI
-    let args = load_and_merge_subcommand_for("add-user", &cli)?;
+    let args = load_and_merge_subcommand_for::<AddUserArgs>(&cli)?;
 
     println!("Final args: {args:?}");
     Ok(())
@@ -265,10 +265,10 @@ fn main() -> Result<(), String> {
     // merge per-command defaults
     let cmd = match cli {
         Commands::AddUser(args) => {
-            Commands::AddUser(load_and_merge_subcommand_for("add-user", &args)?)
+            Commands::AddUser(load_and_merge_subcommand_for::<AddUserArgs>(&args)?)
         }
         Commands::ListItems(args) => {
-            Commands::ListItems(load_and_merge_subcommand_for("list-items", &args)?)
+            Commands::ListItems(load_and_merge_subcommand_for::<ListItemsArgs>(&args)?)
         }
     };
 

--- a/docs/clap-dispatch-and-ortho-config-integration.md
+++ b/docs/clap-dispatch-and-ortho-config-integration.md
@@ -630,7 +630,7 @@ fn main() -> Result<(), String> {
     let final_command = match cli_args.command {
         Commands::List(clap_parsed_list_args) => {
             // 4. Merge CLI values over ortho-config defaults for the subcommand
-            let final_list_args = load_and_merge_subcommand_for("list", &clap_parsed_list_args)?;
+            let final_list_args = load_and_merge_subcommand_for::<ListArgs>(&clap_parsed_list_args)?;
             Commands::List(final_list_args)
         }
         // Commands::Add(clap_parsed_add_args) => { /* similar logic for Add command */ }

--- a/examples/registry_ctl.rs
+++ b/examples/registry_ctl.rs
@@ -58,12 +58,12 @@ fn main() -> Result<(), String> {
     let db_url = "postgres://user:pass@localhost/registry";
     let final_cmd = match cli {
         Commands::AddUser(args) => {
-            let merged = load_and_merge_subcommand_for::<AddUserArgs>("add-user", &args)
+            let merged = load_and_merge_subcommand_for::<AddUserArgs>(&args)
                 .map_err(|e| e.to_string())?;
             Commands::AddUser(merged)
         }
         Commands::ListItems(args) => {
-            let merged = load_and_merge_subcommand_for::<ListItemsArgs>("list-items", &args)
+            let merged = load_and_merge_subcommand_for::<ListItemsArgs>(&args)
                 .map_err(|e| e.to_string())?;
             Commands::ListItems(merged)
         }

--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -2,6 +2,7 @@
 use crate::merge_cli_over_defaults;
 use crate::normalize_prefix;
 use crate::{OrthoError, load_config_file};
+use clap::CommandFactory;
 use figment::{Figment, providers::Env};
 use serde::de::DeserializeOwned;
 use std::path::PathBuf;
@@ -133,12 +134,13 @@ where
 ///
 /// Returns an [`OrthoError`] if file loading or deserialization fails.
 #[allow(clippy::result_large_err)]
-pub fn load_and_merge_subcommand<T>(prefix: &str, name: &str, cli: &T) -> Result<T, OrthoError>
+pub fn load_and_merge_subcommand<T>(prefix: &str, cli: &T) -> Result<T, OrthoError>
 where
-    T: serde::Serialize + DeserializeOwned + Default,
+    T: serde::Serialize + DeserializeOwned + Default + CommandFactory,
 {
+    let name = T::command().get_name().to_owned();
     #[allow(deprecated)]
-    let defaults: T = load_subcommand_config(prefix, name)?;
+    let defaults: T = load_subcommand_config(prefix, &name)?;
     #[allow(deprecated)]
     merge_cli_over_defaults(&defaults, cli).map_err(OrthoError::Gathering)
 }
@@ -149,9 +151,9 @@ where
 ///
 /// Returns an [`OrthoError`] if file loading or deserialization fails.
 #[allow(clippy::result_large_err)]
-pub fn load_and_merge_subcommand_for<T>(name: &str, cli: &T) -> Result<T, OrthoError>
+pub fn load_and_merge_subcommand_for<T>(cli: &T) -> Result<T, OrthoError>
 where
-    T: crate::OrthoConfig + serde::Serialize + Default,
+    T: crate::OrthoConfig + serde::Serialize + Default + CommandFactory,
 {
-    load_and_merge_subcommand(T::prefix(), name, cli)
+    load_and_merge_subcommand(T::prefix(), cli)
 }

--- a/ortho_config/tests/subcommand.rs
+++ b/ortho_config/tests/subcommand.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(deprecated)]
+use clap::Parser;
 use ortho_config::OrthoConfig;
 use ortho_config::load_subcommand_config;
 use ortho_config::load_subcommand_config_for;
@@ -119,7 +120,8 @@ fn loads_yaml_file() {
     assert_eq!(cfg.foo.as_deref(), Some("yaml"));
 }
 
-#[derive(Debug, Deserialize, serde::Serialize, Default, PartialEq)]
+#[derive(Debug, Deserialize, serde::Serialize, Default, PartialEq, Parser)]
+#[command(name = "test")]
 struct MergeArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     foo: Option<String>,
@@ -135,14 +137,15 @@ fn merge_helper_combines_defaults_and_cli() {
             foo: Some("cli".into()),
             bar: None,
         };
-        let merged: MergeArgs = load_and_merge_subcommand("APP_", "test", &cli).expect("merge");
+        let merged: MergeArgs = load_and_merge_subcommand("APP_", &cli).expect("merge");
         assert_eq!(merged.foo.as_deref(), Some("cli"));
         assert_eq!(merged.bar, None);
         Ok(())
     });
 }
 
-#[derive(Debug, Deserialize, serde::Serialize, OrthoConfig, Default, PartialEq)]
+#[derive(Debug, Deserialize, serde::Serialize, OrthoConfig, Default, PartialEq, Parser)]
+#[command(name = "test")]
 #[ortho_config(prefix = "APP_")]
 struct MergePrefixed {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -154,7 +157,7 @@ fn merge_wrapper_respects_prefix() {
     figment::Jail::expect_with(|j| {
         j.create_file(".app.toml", "[cmds.test]\nfoo = \"file\"")?;
         let cli = MergePrefixed { foo: None };
-        let merged = load_and_merge_subcommand_for::<MergePrefixed>("test", &cli).expect("merge");
+        let merged = load_and_merge_subcommand_for::<MergePrefixed>(&cli).expect("merge");
         assert_eq!(merged.foo.as_deref(), Some("file"));
         Ok(())
     });


### PR DESCRIPTION
## Summary
- simplify subcommand API
- infer subcommand names via `CommandFactory`
- update example and docs
- adjust tests for new API

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684c98b7c11083229697eda4ce792cb0

## Summary by Sourcery

Infer subcommand names from clap parsers and simplify the subcommand merge API

Enhancements:
- Remove manual name parameters from load_and_merge_subcommand and load_and_merge_subcommand_for, inferring names via CommandFactory
- Add CommandFactory trait bound to config types and use T::command().get_name() for config lookup

Documentation:
- Update README, examples, and integration guides to reflect the new API signature for load_and_merge_subcommand_for

Tests:
- Derive Parser and specify #[command(name = "...")] on test config structs to enable name inference
- Adjust subcommand tests to call load_and_merge_subcommand and load_and_merge_subcommand_for without explicit name arguments