### PR TITLE
Deprecate load_subcommand_config

### DIFF
--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -84,8 +84,13 @@ fn load_from_files(paths: &[PathBuf], name: &str) -> Result<Figment, OrthoError>
 /// # Errors
 ///
 /// Returns an [`OrthoError`] if file loading or deserialization fails.
+///
+/// # Deprecated
+///
+/// Use [`load_and_merge_subcommand`] or [`load_and_merge_subcommand_for`] instead
+/// to load defaults and apply CLI overrides in one step.
 #[allow(clippy::result_large_err)]
-#[deprecated(note = "use `load_and_merge_subcommand` instead")]
+#[deprecated(note = "use `load_and_merge_subcommand` or `load_and_merge_subcommand_for` instead")]
 pub fn load_subcommand_config<T>(prefix: &str, name: &str) -> Result<T, OrthoError>
 where
     T: DeserializeOwned + Default,


### PR DESCRIPTION
## Summary
- mark `load_subcommand_config` as deprecated
- document that `load_and_merge_subcommand` or its wrapper are preferred

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/*.md` *(fails: many warnings)*
- `nixie docs/*.md README.md`

------
https://chatgpt.com/codex/tasks/task_e_684c9f15c6588322a43975425c427cf4

## Summary by Sourcery

Deprecate the `load_subcommand_config` function and update its documentation and deprecation note to recommend using `load_and_merge_subcommand` or `load_and_merge_subcommand_for`.

Enhancements:
- Add `# Deprecated` doc comments to `load_subcommand_config` pointing to the new merged-loading functions.
- Update the `#[deprecated]` attribute message to include both `load_and_merge_subcommand` and `load_and_merge_subcommand_for`.