### PR TITLE
Fix Windows build by gating xdg support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +264,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -250,7 +282,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -317,6 +349,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,11 +393,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ortho_config"
 version = "0.2.0"
 dependencies = [
  "clap",
  "clap-dispatch",
+ "directories",
  "figment",
  "figment-json5",
  "ortho_config_macros",
@@ -515,6 +564,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,7 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -795,6 +855,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -15,6 +15,7 @@ clap-dispatch = "0.1"
 figment = { version = "0.10", default-features = false, features = ["env", "test"] }
 uncased = "0.9"
 xdg = "3"
+directories = "6"
 toml = { version = "0.8", optional = true }
 figment-json5 = { version = "0.1", optional = true }
 serde_yaml = { version = "0.9", optional = true }

--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -3,19 +3,20 @@ use crate::merge_cli_over_defaults;
 use crate::normalize_prefix;
 use crate::{OrthoError, load_config_file};
 use clap::CommandFactory;
+use directories::BaseDirs;
 use figment::{Figment, providers::Env};
 use serde::de::DeserializeOwned;
 use std::path::PathBuf;
 use uncased::Uncased;
+#[cfg(any(unix, target_os = "redox"))]
 use xdg::BaseDirectories;
 
 /// Return possible configuration file paths for a subcommand.
 fn candidate_paths(prefix: &str) -> Vec<PathBuf> {
     let base = normalize_prefix(prefix);
     let mut paths = Vec::new();
-
-    if let Some(home) = std::env::var_os("HOME") {
-        let home = PathBuf::from(home);
+    if let Some(dirs) = BaseDirs::new() {
+        let home = dirs.home_dir();
         paths.push(home.join(format!(".{base}.toml")));
         #[cfg(feature = "json5")]
         for ext in ["json", "json5"] {
@@ -25,26 +26,47 @@ fn candidate_paths(prefix: &str) -> Vec<PathBuf> {
         for ext in ["yaml", "yml"] {
             paths.push(home.join(format!(".{base}.{ext}")));
         }
-    }
 
-    let xdg_dirs = if base.is_empty() {
-        BaseDirectories::new()
-    } else {
-        BaseDirectories::with_prefix(&base)
-    };
-    if let Some(p) = xdg_dirs.find_config_file("config.toml") {
-        paths.push(p);
-    }
-    #[cfg(feature = "json5")]
-    for ext in ["json", "json5"] {
-        if let Some(p) = xdg_dirs.find_config_file(format!("config.{ext}")) {
-            paths.push(p);
+        #[cfg(any(unix, target_os = "redox"))]
+        {
+            let xdg_dirs = if base.is_empty() {
+                BaseDirectories::new()
+            } else {
+                BaseDirectories::with_prefix(&base)
+            };
+            if let Some(p) = xdg_dirs.find_config_file("config.toml") {
+                paths.push(p);
+            }
+            #[cfg(feature = "json5")]
+            for ext in ["json", "json5"] {
+                if let Some(p) = xdg_dirs.find_config_file(format!("config.{ext}")) {
+                    paths.push(p);
+                }
+            }
+            #[cfg(feature = "yaml")]
+            for ext in ["yaml", "yml"] {
+                if let Some(p) = xdg_dirs.find_config_file(format!("config.{ext}")) {
+                    paths.push(p);
+                }
+            }
         }
-    }
-    #[cfg(feature = "yaml")]
-    for ext in ["yaml", "yml"] {
-        if let Some(p) = xdg_dirs.find_config_file(format!("config.{ext}")) {
-            paths.push(p);
+
+        #[cfg(not(any(unix, target_os = "redox")))]
+        {
+            let cfg_dir = if base.is_empty() {
+                dirs.config_dir().to_path_buf()
+            } else {
+                dirs.config_dir().join(&base)
+            };
+            paths.push(cfg_dir.join("config.toml"));
+            #[cfg(feature = "json5")]
+            for ext in ["json", "json5"] {
+                paths.push(cfg_dir.join(format!("config.{ext}")));
+            }
+            #[cfg(feature = "yaml")]
+            for ext in ["yaml", "yml"] {
+                paths.push(cfg_dir.join(format!("config.{ext}")));
+            }
         }
     }
 

--- a/ortho_config_macros/src/derive/build.rs
+++ b/ortho_config_macros/src/derive/build.rs
@@ -107,6 +107,7 @@ pub(crate) fn build_dotfile_name(struct_attrs: &StructAttrs) -> proc_macro2::Tok
 pub(crate) fn build_xdg_snippet(struct_attrs: &StructAttrs) -> proc_macro2::TokenStream {
     let prefix_lit = struct_attrs.prefix.as_deref().unwrap_or("");
     quote! {
+        #[cfg(any(unix, target_os = "redox"))]
         if file_fig.is_none() {
             let xdg_base = ortho_config::normalize_prefix(#prefix_lit);
             let xdg_dirs = if xdg_base.is_empty() {


### PR DESCRIPTION
## Summary
- add `directories` crate for cross-platform path discovery
- use `BaseDirs` on non-Unix and gate `xdg` usage behind `unix` cfg
- update macro-generated code accordingly

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/*.md` *(fails: MD013, MD040, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_684e34d2c8d4832287a0789ecbf5af6d