### PR TITLE
Fix markdownlint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,165 +1,202 @@
 # OrthoConfig
 
-**OrthoConfig** is a Rust configuration management library designed for simplicity and power, inspired by the flexible configuration mechanisms found in tools like `esbuild`. It allows your application to seamlessly load configuration from command-line arguments, environment variables, and configuration files, all with a clear order of precedence and minimal boilerplate.
+**OrthoConfig** is a Rust configuration management library designed for
+simplicity and power, inspired by the flexible configuration mechanisms found in
+tools like `esbuild`. It allows your application to seamlessly load
+configuration from command-line arguments, environment variables, and
+configuration files, all with a clear order of precedence and minimal
+boilerplate.
 
-The core principle is **orthographic option naming**: a single field in your Rust configuration struct can be set through idiomatic naming conventions from various sources (e.g., `--my-option` for CLI, `MY_APP_MY_OPTION` for environment variables, `my_option` in a TOML file) without requiring extensive manual aliasing.
+The core principle is **orthographic option naming**: a single field in your
+Rust configuration struct can be set through idiomatic naming conventions from
+various sources (e.g., `--my-option` for CLI, `MY_APP_MY_OPTION` for environment
+variables, `my_option` in a TOML file) without requiring extensive manual
+aliasing.
 
 ## Core Features
 
-  * **Layered Configuration:** Sources configuration from multiple places with a well-defined precedence:
-    1.  Command-Line Arguments (Highest)
-    2.  Environment Variables
-    3.  Configuration File (e.g., `config.toml`)
-    4.  Application-Defined Defaults (Lowest)
-  * **Orthographic Option Naming:** Automatically maps diverse external naming conventions (kebab-case, UPPER\_SNAKE\_CASE, etc.) to your Rust struct's snake\_case fields.
-  * **Type-Safe Deserialization:** Uses `serde` to deserialize configuration into your strongly-typed Rust structs.
-  * **Easy to Use:** A simple `#[derive(OrthoConfig)]` macro gets you started quickly.
-  * **Customizable:** Field-level attributes allow fine-grained control over naming, defaults, and merging behavior.
-  * **Nested Configuration:** Naturally supports nested structs for organized configuration.
-  * **Sensible Defaults:** Aims for intuitive behavior out-of-the-box.
+- **Layered Configuration:** Sources configuration from multiple places with a
+  well-defined precedence:
+  1. Command-Line Arguments (Highest)
+  1. Environment Variables
+  1. Configuration File (e.g., `config.toml`)
+  1. Application-Defined Defaults (Lowest)
+- **Orthographic Option Naming:** Automatically maps diverse external naming
+  conventions (kebab-case, UPPER_SNAKE_CASE, etc.) to your Rust struct's
+  snake_case fields.
+- **Type-Safe Deserialization:** Uses `serde` to deserialize configuration into
+  your strongly-typed Rust structs.
+- **Easy to Use:** A simple `#[derive(OrthoConfig)]` macro gets you started
+  quickly.
+- **Customizable:** Field-level attributes allow fine-grained control over
+  naming, defaults, and merging behavior.
+- **Nested Configuration:** Naturally supports nested structs for organized
+  configuration.
+- **Sensible Defaults:** Aims for intuitive behavior out-of-the-box.
 
 ## Quick Start
 
-1.  **Add `OrthoConfig` to your `Cargo.toml`:**
+1. **Add `OrthoConfig` to your `Cargo.toml`:**
 
-    ```toml
-    [dependencies]
-    ortho_config = "0.2.0" # Replace with the latest version
-    serde = { version = "1.0", features = ["derive"] }
-    ```
+   ```toml
+   [dependencies]
+   ortho_config = "0.2.0" # Replace with the latest version
+   serde = { version = "1.0", features = ["derive"] }
+   ```
 
-4.  **Define your configuration struct:**
+1. **Define your configuration struct:**
 
-    ```rust
-    use ortho_config::{OrthoConfig, OrthoError};
-    use serde::{Deserialize, Serialize}; // Required for OrthoConfig derive
+   ```rust
+   use ortho_config::{OrthoConfig, OrthoError};
+   use serde::{Deserialize, Serialize}; // Required for OrthoConfig derive
 
-    #[derive(Debug, Clone, Deserialize, Serialize, OrthoConfig)]
-    #[ortho_config(prefix = "DB")] // Nested prefix: e.g., APP_DB_URL
-    struct DatabaseConfig {
-        // Automatically maps to:
-        // CLI: --database-url <value> (if clap flattens) or via file/env
-        // Env: APP_DB_URL=<value>
-        // File: [database] url = <value>
-        url: String,
+   #[derive(Debug, Clone, Deserialize, Serialize, OrthoConfig)]
+   #[ortho_config(prefix = "DB")] // Nested prefix: e.g., APP_DB_URL
+   struct DatabaseConfig {
+       // Automatically maps to:
+       // CLI: --database-url <value> (if clap flattens) or via file/env
+       // Env: APP_DB_URL=<value>
+       // File: [database] url = <value>
+       url: String,
 
-        #[ortho_config(default = 5)]
-        pool_size: Option<u32>, // Optional value, defaults to `Some(5)`
-    }
+       #[ortho_config(default = 5)]
+       pool_size: Option<u32>, // Optional value, defaults to `Some(5)`
+   }
 
-    impl std::str::FromStr for DatabaseConfig {
-        type Err = String;
+   impl std::str::FromStr for DatabaseConfig {
+       type Err = String;
 
-        fn from_str(s: &str) -> Result<Self, Self::Err> {
-            let mut parts = s.splitn(2, ',');
-            let url = parts
-                .next()
-                .ok_or_else(|| "missing url".to_string())?
-                .to_string();
-            let pool_size = parts
-                .next()
-                .and_then(|p| p.parse::<u32>().ok());
-            Ok(DatabaseConfig { url, pool_size })
-        }
-    }
+       fn from_str(s: &str) -> Result<Self, Self::Err> {
+           let mut parts = s.splitn(2, ',');
+           let url = parts
+               .next()
+               .ok_or_else(|| "missing url".to_string())?
+               .to_string();
+           let pool_size = parts
+               .next()
+               .and_then(|p| p.parse::<u32>().ok());
+           Ok(DatabaseConfig { url, pool_size })
+       }
+   }
 
-    #[derive(Debug, Deserialize, Serialize, OrthoConfig)]
-    #[ortho_config(prefix = "APP")] // Prefix for environment variables (e.g., APP_LOG_LEVEL)
-    struct AppConfig {
-        log_level: String,
+   #[derive(Debug, Deserialize, Serialize, OrthoConfig)]
+   #[ortho_config(prefix = "APP")] // Prefix for environment variables (e.g., APP_LOG_LEVEL)
+   struct AppConfig {
+       log_level: String,
 
-        // Automatically maps to:
-        // CLI: --port <value>
-        // Env: APP_PORT=<value>
-        // File: port = <value>
-        #[ortho_config(default = 8080)]
-        port: u16,
+       // Automatically maps to:
+       // CLI: --port <value>
+       // Env: APP_PORT=<value>
+       // File: port = <value>
+       #[ortho_config(default = 8080)]
+       port: u16,
 
-        #[ortho_config(merge_strategy = "append")] // Default for Vec<T> is append
-        features: Vec<String>,
+       #[ortho_config(merge_strategy = "append")] // Default for Vec<T> is append
+       features: Vec<String>,
 
-        // Nested configuration
-        database: DatabaseConfig,
+       // Nested configuration
+       database: DatabaseConfig,
 
-        #[ortho_config(cli_short = 'v')] // Enable a short flag: -v
-        verbose: bool, // Defaults to false if not specified
-    }
+       #[ortho_config(cli_short = 'v')] // Enable a short flag: -v
+       verbose: bool, // Defaults to false if not specified
+   }
 
-    fn main() -> Result<(), OrthoError> {
-        let config = AppConfig::load()?; // Load configuration
+   fn main() -> Result<(), OrthoError> {
+       let config = AppConfig::load()?; // Load configuration
 
-        println!("Loaded configuration: {:#?}", config);
+       println!("Loaded configuration: {:#?}", config);
 
-        if config.verbose {
-            println!("Verbose mode enabled!");
-        }
-        println!("Log level: {}", config.log_level);
-        println!("Listening on port: {}", config.port);
-        println!("Enabled features: {:?}", config.features);
-        println!("Database URL: {}", config.database.url);
-        println!("Database pool size: {:?}", config.database.pool_size);
+       if config.verbose {
+           println!("Verbose mode enabled!");
+       }
+       println!("Log level: {}", config.log_level);
+       println!("Listening on port: {}", config.port);
+       println!("Enabled features: {:?}", config.features);
+       println!("Database URL: {}", config.database.url);
+       println!("Database pool size: {:?}", config.database.pool_size);
 
-        Ok(())
-    }
-    ```
+       Ok(())
+   }
+   ```
 
-5.  **Run your application:**
+1. **Run your application:**
 
-      * With CLI arguments: `cargo run -- --log-level debug --port 3000 -v --features extra_cli_feature`
-      * With environment variables: `APP_LOG_LEVEL=warn APP_PORT=4000 APP_DB_URL="postgres://localhost/mydb" APP_FEATURES="env_feat1,env_feat2" cargo run`
-     * With a `.app.toml` file (assuming `#[ortho_config(prefix = "APP_")]`; adjust for your prefix):
-        ```toml
-        # .app.toml
-        log_level = "file_level"
-        port = 5000
-        features = ["file_feat_a", "file_feat_b"]
+   - With CLI arguments:
+     `cargo run -- --log-level debug --port 3000 -v --features extra_cli_feature`
+   - With environment variables:
+     `APP_LOG_LEVEL=warn APP_PORT=4000`
+       `APP_DB_URL="postgres://localhost/mydb"`
+       `APP_FEATURES="env_feat1,env_feat2" cargo run`
+   - With a `.app.toml` file (assuming `#[ortho_config(prefix = "APP_")]`;
+     adjust for your prefix):
 
-        [database]
-        url = "mysql://localhost/prod_db"
-        pool_size = 10
-        ```
+     ```toml
+     # .app.toml
+     log_level = "file_level"
+     port = 5000
+     features = ["file_feat_a", "file_feat_b"]
+
+     [database]
+     url = "mysql://localhost/prod_db"
+     pool_size = 10
+     ```
 
 ## Configuration Sources and Precedence
 
-OrthoConfig loads configuration from the following sources, with later sources overriding earlier ones:
+OrthoConfig loads configuration from the following sources, with later sources
+overriding earlier ones:
 
-1.  **Application-Defined Defaults:** Specified using `#[ortho_config(default =...)]` or `Option<T>` fields (which default to `None`).
-2.  **Configuration File:** Resolved in this order:
-    1. `--config-path` CLI option
-    2. `[PREFIX]CONFIG_PATH` environment variable
-    3. `.<prefix>.toml` in the current directory
-    4. `.<prefix>.toml` in the user's home directory
-    (where `<prefix>` comes from `#[ortho_config(prefix = "...")]` and defaults to `config`). JSON5 and YAML support are feature gated.
-3.  **Environment Variables:** Variables prefixed with the string specified in `#[ortho_config(prefix = "...")]` (e.g., `APP_`). Nested struct fields are typically accessed using double underscores (e.g., `APP_DATABASE__URL` if `prefix = "APP"` on `AppConfig` and no prefix on `DatabaseConfig`, or `APP_DB_URL` with `#` on `DatabaseConfig`).
-4.  **Command-Line Arguments:** Parsed using `clap` conventions. Long flags are derived from field names (e.g., `my_field` becomes `--my-field`).
+1. **Application-Defined Defaults:** Specified using
+   `#[ortho_config(default =...)]` or `Option<T>` fields (which default to
+   `None`).
+1. **Configuration File:** Resolved in this order:
+   1. `--config-path` CLI option
+   1. `[PREFIX]CONFIG_PATH` environment variable
+   1. `.<prefix>.toml` in the current directory
+   1. `.<prefix>.toml` in the user's home directory (where `<prefix>` comes from
+      `#[ortho_config(prefix = "...")]` and defaults to `config`). JSON5 and
+      YAML support are feature gated.
+1. **Environment Variables:** Variables prefixed with the string specified in
+   `#[ortho_config(prefix = "...")]` (e.g., `APP_`). Nested struct fields are
+   typically accessed using double underscores (e.g., `APP_DATABASE__URL` if
+   `prefix = "APP"` on `AppConfig` and no prefix on `DatabaseConfig`, or
+   `APP_DB_URL` with `#` on `DatabaseConfig`).
+1. **Command-Line Arguments:** Parsed using `clap` conventions. Long flags are
+   derived from field names (e.g., `my_field` becomes `--my-field`).
 
 ### File Format Support
 
-TOML parsing is enabled by default. Enable the `json5` and `yaml` features to support additional formats:
+TOML parsing is enabled by default. Enable the `json5` and `yaml` features to
+support additional formats:
 
 ```toml
 [dependencies]
 ortho_config = { version = "0.2.0", features = ["json5", "yaml"] }
 ```
 
-The file loader selects the parser based on the extension (`.toml`, `.json`, `.json5`, `.yaml`, `.yml`).
-When the `json5` feature is active, both `.json` and `.json5` files are parsed
-using the JSON5 format. Standard JSON is valid JSON5, so existing `.json` files
-continue to work. Without this feature enabled, attempting to load a `.json` or
-`.json5` file will result in an error.
-When the `yaml` feature is enabled, `.yaml` and `.yml` files are also discovered and parsed. Without this feature, those extensions are ignored during path discovery.
+The file loader selects the parser based on the extension (`.toml`, `.json`,
+`.json5`, `.yaml`, `.yml`). When the `json5` feature is active, both `.json` and
+`.json5` files are parsed using the JSON5 format. Standard JSON is valid JSON5,
+so existing `.json` files continue to work. Without this feature enabled,
+attempting to load a `.json` or `.json5` file will result in an error. When the
+`yaml` feature is enabled, `.yaml` and `.yml` files are also discovered and
+parsed. Without this feature, those extensions are ignored during path
+discovery.
 
 JSON5 extends JSON with conveniences such as comments, trailing commas,
 single-quoted strings, and unquoted keys.
 
 ## Orthographic Naming
 
-A key goal of OrthoConfig is to make configuration natural from any source. A field like `max_connections: u32` in your Rust struct will, by default, be configurable via:
+A key goal of OrthoConfig is to make configuration natural from any source. A
+field like `max_connections: u32` in your Rust struct will, by default, be
+configurable via:
 
-  * CLI: `--max-connections <value>`
-  * Environment (assuming `#[ortho_config(prefix = "MYAPP")]`): `MYAPP_MAX_CONNECTIONS=<value>`
-  * TOML file: `max_connections = <value>`
-  * JSON5 file: `max_connections` or `maxConnections` (configurable)
+- CLI: `--max-connections <value>`
+- Environment (assuming `#[ortho_config(prefix = "MYAPP")]`):
+  `MYAPP_MAX_CONNECTIONS=<value>`
+- TOML file: `max_connections = <value>`
+- JSON5 file: `max_connections` or `maxConnections` (configurable)
 
 You can customize these mappings using `#[ortho_config(...)]` attributes.
 
@@ -167,13 +204,21 @@ You can customize these mappings using `#[ortho_config(...)]` attributes.
 
 Customize behavior for each field:
 
-  * `#[ortho_config(default =...)]`: Sets a default value. Can be a literal (e.g., `"debug"`, `123`, `true`) or a path to a function (e.g., `default = "my_default_fn"`).
-  * `#[ortho_config(cli_long = "custom-name")]`: Specifies a custom long CLI flag (e.g., `--custom-name`).
-  * `#[ortho_config(cli_short = 'c')]`: Specifies a short CLI flag (e.g., `-c`).
-  * `#`: Specifies a custom environment variable suffix (appended to the struct-level prefix).
-  * `#[ortho_config(file_key = "customKey")]`: Specifies a custom key name for configuration files.
-  * `#[ortho_config(merge_strategy = "append")]`: For `Vec<T>` fields, defines how values from different sources are combined. Defaults to `"append"`.
-  * `#[ortho_config(flatten)]`: Similar to `serde(flatten)`, useful for inlining fields from a nested struct into the parent's namespace for CLI or environment variables.
+- `#[ortho_config(default =...)]`: Sets a default value. Can be a literal (e.g.,
+  `"debug"`, `123`, `true`) or a path to a function (e.g.,
+  `default = "my_default_fn"`).
+- `#[ortho_config(cli_long = "custom-name")]`: Specifies a custom long CLI flag
+  (e.g., `--custom-name`).
+- `#[ortho_config(cli_short = 'c')]`: Specifies a short CLI flag (e.g., `-c`).
+- `#`: Specifies a custom environment variable suffix (appended to the
+  struct-level prefix).
+- `#[ortho_config(file_key = "customKey")]`: Specifies a custom key name for
+  configuration files.
+- `#[ortho_config(merge_strategy = "append")]`: For `Vec<T>` fields, defines how
+  values from different sources are combined. Defaults to `"append"`.
+- `#[ortho_config(flatten)]`: Similar to `serde(flatten)`, useful for inlining
+  fields from a nested struct into the parent's namespace for CLI or environment
+  variables.
 
 ## Subcommand Configuration
 
@@ -278,19 +323,24 @@ fn main() -> Result<(), String> {
 
 ## Why OrthoConfig?
 
-  * **Reduced Boilerplate:** Define your configuration schema once and let OrthoConfig handle the multi-source loading and mapping.
-  * **Developer Ergonomics:** Intuitive mapping from external sources to your Rust code.
-  * **Flexibility:** Users of your application can configure it in the way that best suits their environment (CLI for quick overrides, env vars for CI/CD, files for persistent settings).
-  * **Clear Precedence:** Predictable configuration resolution.
+- **Reduced Boilerplate:** Define your configuration schema once and let
+  OrthoConfig handle the multi-source loading and mapping.
+- **Developer Ergonomics:** Intuitive mapping from external sources to your Rust
+  code.
+- **Flexibility:** Users of your application can configure it in the way that
+  best suits their environment (CLI for quick overrides, env vars for CI/CD,
+  files for persistent settings).
+- **Clear Precedence:** Predictable configuration resolution.
 
 ## Migrating from 0.1 to 0.2
 
 Version 0.2 introduces a small API refinement:
 
-* `load_subcommand_config_for` now only loads default values from files and
-  environment variables. Use [`load_and_merge_subcommand_for`](#subcommand-configuration)
-  to merge these defaults with CLI arguments.
-* Types deriving `OrthoConfig` expose an associated `prefix()` function. Use
+- `load_subcommand_config_for` now only loads default values from files and
+  environment variables. Use
+  [`load_and_merge_subcommand_for`](#subcommand-configuration) to merge these
+  defaults with CLI arguments.
+- Types deriving `OrthoConfig` expose an associated `prefix()` function. Use
   this if you need the configured prefix directly.
 
 Update your `Cargo.toml` to depend on `ortho_config = "0.2"` and adjust code to
@@ -298,7 +348,8 @@ call `load_and_merge_subcommand_for` instead of manually merging defaults.
 
 ## Contributing
 
-Contributions are welcome\! Please feel free to submit issues, fork the repository, and send pull requests.
+Contributions are welcome! Please feel free to submit issues, fork the
+repository, and send pull requests.
 
 ## License
 

--- a/docs/clap-dispatch-and-ortho-config-integration.md
+++ b/docs/clap-dispatch-and-ortho-config-integration.md
@@ -1,153 +1,231 @@
-# Ergonomic Subcommand Handling with `clap-dispatch` and a Design Proposal for `ortho-config` Integration
+# Ergonomic CLI Handling with `clap-dispatch` and `ortho-config` Integration
 
 ## I. Introduction
 
-Command-Line Interface (CLI) applications are a cornerstone of software development and system administration. In the Rust ecosystem, the `clap` crate stands out as a powerful and widely adopted library for parsing command-line arguments, offering features like automatic help generation, subcommand support, and robust validation.1 As CLIs grow in complexity, particularly those with numerous subcommands that perform variations of a common task, managing the dispatch logic can become cumbersome.
+Command-Line Interface (CLI) applications are a cornerstone of software
+development and system administration. In the Rust ecosystem, the `clap` crate
+stands out as a powerful and widely adopted library for parsing command-line
+arguments, offering features like automatic help generation, subcommand support,
+and robust validation.1 As CLIs grow in complexity, particularly those with
+numerous subcommands that perform variations of a common task, managing the
+dispatch logic can become cumbersome.
 
-The `clap-dispatch` crate aims to alleviate this by providing an ergonomic mechanism for dispatching CLI subcommands.3 It leverages Rust's trait system and procedural macros to reduce boilerplate and improve code organization when subcommands represent different ways of performing a similar action.
+The `clap-dispatch` crate aims to alleviate this by providing an ergonomic
+mechanism for dispatching CLI subcommands.3 It leverages Rust's trait system and
+procedural macros to reduce boilerplate and improve code organization when
+subcommands represent different ways of performing a similar action.
 
-This report serves a dual purpose. Firstly, it provides comprehensive, step-by-step guidance on utilizing `clap-dispatch` for creating and managing subcommands, complete with worked examples and command-line usage demonstrations. Secondly, it presents a detailed design proposal for incorporating `clap-dispatch` into the `ortho-config` library. The `ortho-config` library, as per its design philosophy, facilitates layered, orthographic configuration where settings can be defined consistently across command-line arguments, environment variables, and configuration files. The proposal outlines how subcommand configurations can be seamlessly integrated into this orthographic model, primarily through a dedicated "cmds" namespace.
+This report serves a dual purpose. Firstly, it provides comprehensive,
+step-by-step guidance on utilizing `clap-dispatch` for creating and managing
+subcommands, complete with worked examples and command-line usage
+demonstrations. Secondly, it presents a detailed design proposal for
+incorporating `clap-dispatch` into the `ortho-config` library. The
+`ortho-config` library, as per its design philosophy, facilitates layered,
+orthographic configuration where settings can be defined consistently across
+command-line arguments, environment variables, and configuration files. The
+proposal outlines how subcommand configurations can be seamlessly integrated
+into this orthographic model, primarily through a dedicated "cmds" namespace.
 
 ## II. Understanding `clap-dispatch`
 
-`clap-dispatch` is a Rust crate designed to simplify the implementation of command-line interfaces where multiple subcommands essentially trigger different variations of the same underlying action or function.3 Its utility becomes particularly apparent in applications with a growing number of subcommands or nested subcommand structures.
+`clap-dispatch` is a Rust crate designed to simplify the implementation of
+command-line interfaces where multiple subcommands essentially trigger different
+variations of the same underlying action or function.3 Its utility becomes
+particularly apparent in applications with a growing number of subcommands or
+nested subcommand structures.
 
 ### A. Purpose and Motivation
 
-The primary motivation behind `clap-dispatch` is to reduce the boilerplate code typically associated with matching on an enum of subcommands and then calling the appropriate function for each variant. When a CLI has several subcommands, each requiring specific argument parsing (handled by `clap`) but ultimately leading to a common operational signature (e.g., processing data, interacting with a service), the `main` function or a central dispatcher can become cluttered with `match` statements. `clap-dispatch` offers a more streamlined approach by abstracting this dispatch logic.3 It is particularly useful when these subcommands, despite their unique arguments, are conceptually variants of a single, definable action.
+The primary motivation behind `clap-dispatch` is to reduce the boilerplate code
+typically associated with matching on an enum of subcommands and then calling
+the appropriate function for each variant. When a CLI has several subcommands,
+each requiring specific argument parsing (handled by `clap`) but ultimately
+leading to a common operational signature (e.g., processing data, interacting
+with a service), the `main` function or a central dispatcher can become
+cluttered with `match` statements. `clap-dispatch` offers a more streamlined
+approach by abstracting this dispatch logic.3 It is particularly useful when
+these subcommands, despite their unique arguments, are conceptually variants of
+a single, definable action.
 
 ### B. Core Concept: Trait-Based Dispatch
 
-The fundamental mechanism employed by `clap-dispatch` is trait-based dispatch. It allows developers to define a common interface (a Rust trait) that all related subcommands must implement. This interface typically consists of a single method representing the core action these subcommands perform.3
+The fundamental mechanism employed by `clap-dispatch` is trait-based dispatch.
+It allows developers to define a common interface (a Rust trait) that all
+related subcommands must implement. This interface typically consists of a
+single method representing the core action these subcommands perform.3
 
-For instance, if a CLI has subcommands for `quicksort` and `mergesort`, both are types of sorting operations. `clap-dispatch` enables defining a `Sort` trait with a `sort(...)` method. Each subcommand's argument structure (`QuickArgs`, `MergeArgs`) would then implement this `Sort` trait.3 This approach promotes a clean separation of concerns: `clap` handles the parsing of arguments unique to `quicksort` (e.g., pivot selection strategy) or `mergesort` (e.g., parallel execution flag), while the `Sort` trait ensures they both conform to a common execution pattern. The library then automates the process of calling the correct implementation based on the subcommand parsed by `clap`.
+For instance, if a CLI has subcommands for `quicksort` and `mergesort`, both are
+types of sorting operations. `clap-dispatch` enables defining a `Sort` trait
+with a `sort(...)` method. Each subcommand's argument structure (`QuickArgs`,
+`MergeArgs`) would then implement this `Sort` trait.3 This approach promotes a
+clean separation of concerns: `clap` handles the parsing of arguments unique to
+`quicksort` (e.g., pivot selection strategy) or `mergesort` (e.g., parallel
+execution flag), while the `Sort` trait ensures they both conform to a common
+execution pattern. The library then automates the process of calling the correct
+implementation based on the subcommand parsed by `clap`.
 
 ### C. The `#[clap_dispatch]` Macro and Generated Trait
 
-The central component of `clap-dispatch` is its procedural macro, `#[clap_dispatch(...)]`. This macro is applied to a Rust enum where each variant typically encapsulates an argument struct parsed by `clap::Parser` (representing a specific subcommand).3
+The central component of `clap-dispatch` is its procedural macro,
+`#[clap_dispatch(...)]`. This macro is applied to a Rust enum where each variant
+typically encapsulates an argument struct parsed by `clap::Parser` (representing
+a specific subcommand).3
 
-When the macro is invoked, for example, as `#` on an enum `CliCommands`, it performs two key actions:
+When the macro is invoked, for example, as `#` on an enum `CliCommands`, it
+performs two key actions:
 
-1. **Trait Definition:** It automatically defines a new Rust trait. The name of this trait is derived from the function name provided in the macro attribute (e.g., `execute` would lead to a trait named `Execute`). The signature of the method(s) in this trait matches the function signature specified in the macro attribute.
-2. **Enum Implementation:** It automatically implements this newly defined trait for the enum itself (e.g., `impl Execute for CliCommands`). This implementation contains the `match` logic that dispatches the method call to the appropriate variant of the enum. So, calling `cli_commands_instance.execute(...)` will internally match on the specific variant of `cli_commands_instance` and call the `execute` method on that variant's contained data.
+1. **Trait Definition:** It automatically defines a new Rust trait. The name of
+   this trait is derived from the function name provided in the macro attribute
+   (e.g., `execute` would lead to a trait named `Execute`). The signature of the
+   method(s) in this trait matches the function signature specified in the macro
+   attribute.
+2. **Enum Implementation:** It automatically implements this newly defined trait
+   for the enum itself (e.g., `impl Execute for CliCommands`). This
+   implementation contains the `match` logic that dispatches the method call to
+   the appropriate variant of the enum. So, calling
+   `cli_commands_instance.execute(...)` will internally match on the specific
+   variant of `cli_commands_instance` and call the `execute` method on that
+   variant's contained data.
 
-The developer's responsibility is then to implement this generated trait (e.g., `Execute`) for each of the argument structs corresponding to the enum's variants (e.g., `impl Execute for QuickArgs`, `impl Execute for MergeArgs`).3 The dependencies `syn` and `quote`, listed for `clap-dispatch`, are standard tools for procedural macros, used to parse the Rust code (the function signature) and generate the new trait and implementation code, respectively.3
+The developer's responsibility is then to implement this generated trait (e.g.,
+`Execute`) for each of the argument structs corresponding to the enum's variants
+(e.g., `impl Execute for QuickArgs`, `impl Execute for MergeArgs`).3 The
+dependencies `syn` and `quote`, listed for `clap-dispatch`, are standard tools
+for procedural macros, used to parse the Rust code (the function signature) and
+generate the new trait and implementation code, respectively.3
 
 ### D. Advantages in Complex CLI Scenarios
 
-In CLIs with numerous subcommands or deeply nested subcommand trees, `clap-dispatch` offers significant advantages:
+In CLIs with numerous subcommands or deeply nested subcommand trees,
+`clap-dispatch` offers significant advantages:
 
-- **Improved Code Organization:** It centralizes the dispatch logic definition (via the macro) and encourages a clear separation between argument parsing (handled by `clap` structs) and command execution logic (handled by trait implementations).
-- **Reduced Boilerplate:** It eliminates repetitive `match` statements for dispatching subcommand actions.3
-- **Enhanced Maintainability:** Adding new subcommands that fit the established action pattern becomes simpler, primarily involving defining a new argument struct, adding a variant to the enum, and implementing the dispatch trait.
-- **Promotion of a Common Interface Pattern:** The library encourages treating subcommands as distinct implementations of a shared conceptual action. This abstraction is powerful for managing complexity, as highlighted by its utility when subcommands "do the same kind of action, just in a different way".3
-- **Increased Testability:** The core logic of each subcommand, encapsulated within its implementation of the dispatch trait method, can be unit-tested more easily. For example, the `sort` method of `QuickArgs` can be called directly with test data, isolating its logic from the CLI parsing and main dispatch mechanisms. This facilitates focused testing of each subcommand's specific behavior.
+- **Improved Code Organization:** It centralizes the dispatch logic definition
+  (via the macro) and encourages a clear separation between argument parsing
+  (handled by `clap` structs) and command execution logic (handled by trait
+  implementations).
+- **Reduced Boilerplate:** It eliminates repetitive `match` statements for
+  dispatching subcommand actions.3
+- **Enhanced Maintainability:** Adding new subcommands that fit the established
+  action pattern becomes simpler, primarily involving defining a new argument
+  struct, adding a variant to the enum, and implementing the dispatch trait.
+- **Promotion of a Common Interface Pattern:** The library encourages treating
+  subcommands as distinct implementations of a shared conceptual action. This
+  abstraction is powerful for managing complexity, as highlighted by its utility
+  when subcommands "do the same kind of action, just in a different way".3
+- **Increased Testability:** The core logic of each subcommand, encapsulated
+  within its implementation of the dispatch trait method, can be unit-tested
+  more easily. For example, the `sort` method of `QuickArgs` can be called
+  directly with test data, isolating its logic from the CLI parsing and main
+  dispatch mechanisms. This facilitates focused testing of each subcommand's
+  specific behavior.
 
 ## III. Practical Guide: Implementing Subcommands with `clap-dispatch`
 
-This section provides a step-by-step guide to using `clap-dispatch` for building CLIs with dispatchable subcommands.
+This section provides a step-by-step guide to using `clap-dispatch` for building
+CLIs with dispatchable subcommands.
 
 ### A. Project Setup and Dependencies
 
-To begin, ensure your Rust project is set up with the necessary dependencies. You will need `clap` for argument parsing (specifically with the `derive` feature for ergonomic struct-based parsing) and `clap-dispatch` itself.
+To begin, ensure your Rust project is set up with the necessary dependencies.
+You will need `clap` for argument parsing (specifically with the `derive`
+feature for ergonomic struct-based parsing) and `clap-dispatch` itself.
 
 Add the following to your `Cargo.toml` file:
 
-Ini, TOML
-
-```
+```toml
 [dependencies]
 clap = { version = "4.5", features = ["derive"] } # Use a recent version of clap
 clap-dispatch = "0.1.1" # Or the latest version available on crates.io [3]
 ```
 
-The command `cargo add clap -F derive` can be used to add `clap` with the derive feature.5 `clap-dispatch` itself depends on crates like `syn`, `quote`, and `proc-macro2` for its procedural macro functionality, but these are transitive dependencies and do not need to be added explicitly by the end-user.3
+The command `cargo add clap -F derive` can be used to add `clap` with the derive
+feature.5 `clap-dispatch` itself depends on crates like `syn`, `quote`, and
+`proc-macro2` for its procedural macro functionality, but these are transitive
+dependencies and do not need to be added explicitly by the end-user.3
 
 ### B. Defining Argument Structs with `clap::Parser`
 
-For each subcommand your CLI will have, define a Rust struct to hold its specific arguments and options. This struct should derive `clap::Parser`, allowing `clap` to automatically generate the parsing logic.
+For each subcommand your CLI will have, define a Rust struct to hold its
+specific arguments and options. This struct should derive `clap::Parser`,
+allowing `clap` to automatically generate the parsing logic.
 
 Example:
 
-Rust
+```rust
 
-```
-use clap::Parser;
-
-#
 pub struct EncodeArgs {
-    #[arg(short, long)]
     pub input: String,
     #[arg(long, default_value_t = 8)]
     pub strength: u32,
 }
 
-#
 pub struct DecodeArgs {
-    #[arg(short, long)]
     pub input: String,
     #[arg(long)]
     pub fast_mode: bool,
 }
 ```
 
-These structs (`EncodeArgs`, `DecodeArgs`) will encapsulate the arguments unique to the `encode` and `decode` subcommands, respectively. This is a standard approach when using `clap`'s derive API.5
+These structs (`EncodeArgs`, `DecodeArgs`) will encapsulate the arguments unique
+to the `encode` and `decode` subcommands, respectively. This is a standard
+approach when using `clap`'s derive API.5
 
 ### C. Structuring CLI with an Enum for Subcommands
 
-Next, define a top-level enum where each variant corresponds to one of your subcommands. Each variant will hold an instance of the argument struct defined in the previous step. This enum will also derive `clap::Parser` (if it's the top-level CLI definition) or `clap::Subcommand` (if it's part of a larger `clap` structure).
+Next, define a top-level enum where each variant corresponds to one of your
+subcommands. Each variant will hold an instance of the argument struct defined
+in the previous step. This enum will also derive `clap::Parser` (if it's the
+top-level CLI definition) or `clap::Subcommand` (if it's part of a larger `clap`
+structure).
 
 Example:
 
-Rust
-
-```
+```rust
 use clap::Parser;
-// Assuming EncodeArgs and DecodeArgs are defined as above
 
-#
 #[command(name = "mytool", version = "0.2.0", about = "A tool with dispatched subcommands")]
 pub enum MyToolCli {
     Encode(EncodeArgs),
     Decode(DecodeArgs),
-}
 ```
 
 This `MyToolCli` enum is the structure upon which `clap-dispatch` will operate.3
 
 ### D. Applying `#[clap_dispatch]` to the Subcommand Enum
 
-Now, apply the `#[clap_dispatch(...)]` macro to the subcommand enum. In the macro attribute, specify the function signature that all dispatched subcommands must implement. This signature defines the common "action" interface.
+Now, apply the `#[clap_dispatch(...)]` macro to the subcommand enum. In the
+macro attribute, specify the function signature that all dispatched subcommands
+must implement. This signature defines the common "action" interface.
 
 Example:
 
-Rust
-
-```
+```rust
 use clap::Parser;
 use clap_dispatch::clap_dispatch;
-// Assuming EncodeArgs, DecodeArgs, and MyToolCli (without clap_dispatch yet) are defined
+// Assuming EncodeArgs, DecodeArgs, and MyToolCli (without clap_dispatch yet) are
+defined
 
-#
 #[command(name = "mytool", version = "0.2.0", about = "A tool with dispatched subcommands")]
-#
 pub enum MyToolCli {
     Encode(EncodeArgs),
     Decode(DecodeArgs),
 }
 ```
 
-This invocation tells `clap-dispatch` to generate a trait (which will be named `Process` based on the function name `process`) with a method `fn process(self, output_prefix: &str) -> Result<(), String>`. It will also implement `Process` for `MyToolCli` to handle the dispatch.
+This invocation tells `clap-dispatch` to generate a trait (which will be named
+`Process` based on the function name `process`) with a method
+`fn process(self, output_prefix: &str) -> Result<(), String>`. It will also
+implement `Process` for `MyToolCli` to handle the dispatch.
 
 ### E. Implementing the `Dispatch` Trait for Each Subcommand's Logic
 
-With the trait generated by `clap-dispatch`, you must now implement this trait for each of your subcommand argument structs (e.g., `EncodeArgs`, `DecodeArgs`). This is where the specific logic for each subcommand resides.
+With the trait generated by `clap-dispatch`, you must now implement this trait
+for each of your subcommand argument structs (e.g., `EncodeArgs`, `DecodeArgs`).
+This is where the specific logic for each subcommand resides.
 
 Example:
 
-Rust
-
-```
+```rust
 // Continuing from the previous example
 // The #[clap_dispatch(...)] macro implicitly defines a trait, let's call it `Process`
 // for this example, though the actual name is `Process` due to `fn process`.
@@ -175,47 +253,50 @@ impl Process for DecodeArgs {
 }
 ```
 
-As stated in the `clap-dispatch` documentation, implementing this trait for the argument structs is the primary remaining task for the developer after applying the macro.3
+As stated in the `clap-dispatch` documentation, implementing this trait for the
+argument structs is the primary remaining task for the developer after applying
+the macro.3
 
 ### F. Parsing Arguments and Invoking the Dispatched Function in `main`
 
-Finally, in your `main.rs` function, parse the command-line arguments using `clap::Parser::parse()` on your main CLI enum. Then, you can directly call the dispatched function (e.g., `process`) on the parsed enum instance.
+Finally, in your `main.rs` function, parse the command-line arguments using
+`clap::Parser::parse()` on your main CLI enum. Then, you can directly call the
+dispatched function (e.g., `process`) on the parsed enum instance.
 
 Example:
 
-Rust
-
-```
+```rust
 // main.rs
 // Ensure necessary structs and impls from above are in scope
 
 fn main() -> Result<(), String> {
-    let cli_instance = MyToolCli::parse(); // Parses arguments into MyToolCli::Encode or MyToolCli::Decode
+    let cli_instance = MyToolCli::parse(); // Parses arguments into MyToolCli::Encode
+or MyToolCli::Decode
 
     let prefix_for_output = "OPERATION";
 
     // Call the dispatched method.
     // clap-dispatch handles routing this to EncodeArgs::process or DecodeArgs::process.
-    cli_instance.process(prefix_for_output)
+cli_instance.process(prefix_for_output)
 }
 ```
 
-This demonstrates the conciseness achieved: instead of a `match` statement on `cli_instance`, a direct method call is used, with `clap-dispatch` managing the underlying dispatch.3
+This demonstrates the conciseness achieved: instead of a `match` statement on
+`cli_instance`, a direct method call is used, with `clap-dispatch` managing the
+underlying dispatch.3
 
 ### G. Worked Example 1: Basic Command Dispatch (e.g., "action" command)
 
-This example illustrates a simple CLI tool `mytool` with `encode` and `decode` subcommands, both performing an "operation" defined by the `process` method.
+This example illustrates a simple CLI tool `mytool` with `encode` and `decode`
+subcommands, both performing an "operation" defined by the `process` method.
 
 **Full** `src/main.rs`**:**
 
-Rust
-
-```
+```rust
 use clap::Parser;
 use clap_dispatch::clap_dispatch;
 
 // 1. Define Argument Structs
-#
 pub struct EncodeArgs {
     #[arg(short, long)]
     pub input: String,
@@ -223,7 +304,6 @@ pub struct EncodeArgs {
     pub strength: u32,
 }
 
-#
 pub struct DecodeArgs {
     #[arg(short, long)]
     pub input: String,
@@ -232,9 +312,7 @@ pub struct DecodeArgs {
 }
 
 // 2. Define Subcommand Enum and Apply clap_dispatch
-#
 #[command(name = "mytool", version = "0.2.0", about = "A tool with dispatched subcommands")]
-#
 pub enum MyToolCli {
     Encode(EncodeArgs),
     Decode(DecodeArgs),
@@ -274,30 +352,41 @@ fn main() -> Result<(), String> {
 
 **Command-line invocation and expected output:**
 
+````text
 - `cargo run -- encode --input "hello world" --strength 10`
   - Output: `Encoding 'hello world' with strength 10 to 'FILE_encoded.dat'`
 - `cargo run -- decode --input "secretdata" --fast-mode`
   - Output: `Decoding 'secretdata' (fast_mode: true) to 'FILE_decoded.dat'`
 - `cargo run -- decode --input "otherdata"`
-  - Output: `Decoding 'otherdata' (fast_mode: false) to 'FILE_decoded.dat'` (since `fast_mode` is a bool flag, it defaults to false if not present)
+  - Output: `Decoding 'otherdata' (fast_mode: false) to 'FILE_decoded.dat'`
+    (since `fast_mode` is a bool flag, it defaults to false if not present)
 
-This example clearly demonstrates the reduction in boilerplate. Without `clap-dispatch`, the `main` function would require a `match cli_instance { MyToolCli::Encode(args) => args.process_encoding_logic(prefix_for_output), MyToolCli::Decode(args) => args.process_decoding_logic(prefix_for_output) }`. `clap-dispatch` abstracts this matching away into the `cli_instance.process(...)` call.
+This example clearly demonstrates the reduction in boilerplate. Without
+`clap-dispatch`, the `main` function would require a long `match` expression:
+`match cli_instance {
+    MyToolCli::Encode(args) => args.process_encoding_logic(prefix_for_output),
+    MyToolCli::Decode(args) => args.process_decoding_logic(prefix_for_output)
+}`.
+`clap-dispatch` abstracts this matching away into the `cli_instance.process(...)`
+call.
 
-### H. Worked Example 2: Subcommands with More Distinct Arguments (e.g., a "manage" command)
+### H. Worked Example 2: Subcommands with More Distinct Arguments (e.g., a "manage"
+command)
 
-This example demonstrates `clap-dispatch`'s flexibility when subcommands under the same dispatch group have varied arguments. The commonality is in the *action signature* of the dispatched method, not necessarily in the CLI arguments themselves.
+This example demonstrates `clap-dispatch`'s flexibility when subcommands under the
+same dispatch group have varied arguments. The commonality is in the *action signature*
+of the dispatched method, not necessarily in the CLI arguments themselves.
 
 **Scenario:** A CLI `registry-ctl` with subcommands `add-user` and `list-items`.
-
 - `add-user` takes `--username <String>` and an optional `--admin` flag.
 - `list-items` takes an optional `--category <String>` and an optional `--all` flag.
-- Both are dispatched via `fn execute(&self, db_connection_url: &str) -> Result<(), String>`.
+- Both are dispatched via `fn execute(&self, db_connection_url: &str) -> Result<(),
+String>`.
 
 **Full** `src/main.rs`**:**
 
-Rust
 
-```
+```rust
 use clap::Parser;
 use clap_dispatch::clap_dispatch;
 
@@ -314,15 +403,15 @@ impl DbPool {
     }
     fn list_items(&self, category: Option<&String>, list_all: bool) {
         match category {
-            Some(cat) => println!("Listing items in category '{}', All: {}", cat, list_all),
+            Some(cat) => println!("Listing items in category '{}', All: {}", cat,
+list_all),
             None => println!("Listing items (no category specified), All: {}", list_all),
-        }
+}
     }
 }
 
 
 // 1. Define Argument Structs
-#
 pub struct AddUserArgs {
     #[arg(long)]
     pub username: String,
@@ -330,7 +419,6 @@ pub struct AddUserArgs {
     pub admin: bool, // Using bool makes it a flag, true if present, false otherwise.
 }
 
-#
 pub struct ListItemsArgs {
     #[arg(long)]
     pub category: Option<String>,
@@ -339,9 +427,7 @@ pub struct ListItemsArgs {
 }
 
 // 2. Define Subcommand Enum and Apply clap_dispatch
-#
 #[command(name = "registry-ctl", version = "0.2.0", about = "Manages a registry")]
-#
 pub enum RegistryCommands {
     AddUser(AddUserArgs),
     ListItems(ListItemsArgs),
@@ -370,14 +456,14 @@ fn main() -> Result<(), String> {
     let db_url = "postgres://user:pass@localhost/registry";
     cli_instance.execute(db_url)
 }
-```
+````
 
 **Command-line invocation and expected output:**
 
 - `cargo run -- add-user --username alice --admin`
   - Output:
 
-    ```
+````text
     Connecting to database at: postgres://user:pass@localhost/registry
     Adding user: alice, Admin: true
     
@@ -385,7 +471,7 @@ fn main() -> Result<(), String> {
 - `cargo run -- list-items --category electronics`
   - Output:
 
-    ```
+```text
     Connecting to database at: postgres://user:pass@localhost/registry
     Listing items in category 'electronics', All: false
     
@@ -393,33 +479,59 @@ fn main() -> Result<(), String> {
 - `cargo run -- list-items --all`
   - Output:
 
-    ```
+```text
     Connecting to database at: postgres://user:pass@localhost/registry
     Listing items (no category specified), All: true
     
     ```
 
-This example highlights a key aspect: while the *dispatched function signature* (`fn execute(&self, db_connection_url: &str)`) is common, the `self` parameter (which resolves to either `AddUserArgs` or `ListItemsArgs`) contains all the unique arguments parsed by `clap` for that specific subcommand. `clap-dispatch` does not impose restrictions on the subcommand's own arguments; it standardizes the call signature *after* `clap` has parsed those unique arguments into their respective structs. The `clap-dispatch` documentation notes that "The `self` is there so that they can make use of the special arguments passed for the respective algorithm" 3, underscoring that the unique, subcommand-specific parsed data is available within the trait implementation.
+This example highlights a key aspect: while the *dispatched function signature* (`fn
+execute(&self, db_connection_url: &str)`) is common, the `self` parameter (which
+resolves to either `AddUserArgs` or `ListItemsArgs`) contains all the unique arguments
+parsed by `clap` for that specific subcommand. `clap-dispatch` does not impose restrictions
+on the subcommand's own arguments; it standardizes the call signature *after* `clap`
+has parsed those unique arguments into their respective structs. The `clap-dispatch`
+documentation notes that "The `self` is there so that they can make use of the special
+arguments passed for the respective algorithm" 3, underscoring that the unique, subcommand-specific
+parsed data is available within the trait implementation.
 
 ## IV. Design Proposal: Integrating `clap-dispatch` into `ortho-config`
 
-The `ortho-config` library aims to provide an "orthographic" configuration system, where configuration values maintain a consistent identity and can be sourced from command-line arguments, environment variables, or configuration files. This section proposes a design for extending this orthographic principle to subcommand configurations, leveraging `clap-dispatch` for subcommand execution.
+The `ortho-config` library aims to provide an "orthographic" configuration system,
+where configuration values maintain a consistent identity and can be sourced from
+command-line arguments, environment variables, or configuration files. This section
+proposes a design for extending this orthographic principle to subcommand configurations,
+leveraging `clap-dispatch` for subcommand execution.
 
 ### A. Understanding `ortho-config`'s Orthographic Configuration
 
-`ortho-config`'s core tenet is layered configuration with consistent naming across sources. This is conceptually similar to libraries like `config-rs`, which support merging configurations from various file formats (TOML, YAML, JSON) and environment variables, allowing access to nested fields via a path-like string.6 The "orthographic" aspect implies that a configuration parameter, say `feature_x.enabled`, would have a predictable representation whether specified as a CLI flag (`--feature-x-enabled`), an environment variable (`APP_FEATURE_X_ENABLED`), or an entry in a config file (`[feature_x] enabled = true`). This consistency suggests that `ortho-config` likely employs a hierarchical data structure internally (e.g., a map or a `serde_json::Value`-like structure) to store the merged configuration, enabling this path-based access and consistent interpretation. The goal is to extend this existing paradigm to subcommand-specific configurations.
+`ortho-config`'s core tenet is layered configuration with consistent naming across
+sources. This is conceptually similar to libraries like `config-rs`, which support
+merging configurations from various file formats (TOML, YAML, JSON) and environment
+variables, allowing access to nested fields via a path-like string.6 The "orthographic"
+aspect implies that a configuration parameter, say `feature_x.enabled`, would have
+a predictable representation whether specified as a CLI flag (`--feature-x-enabled`),
+an environment variable (`APP_FEATURE_X_ENABLED`), or an entry in a config file (`[feature_x]
+enabled = true`). This consistency suggests that `ortho-config` likely employs a
+hierarchical data structure internally (e.g., a map or a `serde_json::Value`-like
+structure) to store the merged configuration, enabling this path-based access and
+consistent interpretation. The goal is to extend this existing paradigm to subcommand-specific
+configurations.
 
 ### B. Proposed "cmds" Namespace for Subcommand Configuration
 
-To integrate subcommand configuration orthographically, a dedicated namespace within the configuration structure is proposed: `cmds`. This namespace will reside at the root level of the `ortho-config` hierarchy. Each key directly under `cmds` will correspond to a subcommand's name (e.g., `list`, `add`). The value associated with each such key will be a table or map containing the specific configuration options for that subcommand.
+To integrate subcommand configuration orthographically, a dedicated namespace within
+the configuration structure is proposed: `cmds`. This namespace will reside at the
+root level of the `ortho-config` hierarchy. Each key directly under `cmds` will correspond
+to a subcommand's name (e.g., `list`, `add`). The value associated with each such
+key will be a table or map containing the specific configuration options for that
+subcommand.
 
 1\. Configuration File Structure (TOML Example)
 
 Following the user's request, a TOML configuration file might look like this:
 
-Ini, TOML
-
-```
+```toml
 # Global or core application configurations
 # main_option = "global_value"
 # log_level = "info"
@@ -433,13 +545,16 @@ page_size = 20
 default_priority = 10
 enable_confirmation = false
 # api_key = "from_file_for_add_cmd"
-```
+````
 
-Here, `[cmds.list]` and `[cmds.add]` define configuration blocks specific to the `list` and `add` subcommands, respectively.
+Here, `[cmds.list]` and `[cmds.add]` define configuration blocks specific to the
+`list` and `add` subcommands, respectively.
 
 2\. Environment Variable Naming Convention
 
-Environment variables for subcommand options will follow a consistent pattern: MYAPP_CMDS\_&lt;SUBCOMMAND_NAME&gt;\_&lt;OPTION_NAME&gt;=value. The MYAPP\_ prefix would be specific to the application.
+Environment variables for subcommand options will follow a consistent pattern:
+MYAPP_CMDS\_\<SUBCOMMAND_NAME>\_\<OPTION_NAME>=value. The MYAPP\_ prefix would
+be specific to the application.
 
 Examples:
 
@@ -447,67 +562,104 @@ Examples:
 - `MYAPP_CMDS_LIST_DEFAULT_FORMAT=csv`
 - `MYAPP_CMDS_ADD_DEFAULT_PRIORITY=5`
 
-This convention ensures that environment variables map clearly and predictably to the nested structure defined in the configuration files.
+This convention ensures that environment variables map clearly and predictably
+to the nested structure defined in the configuration files.
 
-3\. Illustrative Mapping (CLI -&gt; Config -&gt; Env)
+3\. Illustrative Mapping (CLI -> Config -> Env)
 
-The following table demonstrates how a single conceptual option for a subcommand is represented across different configuration layers and how it would map to a field in a Rust struct used by clap.
+The following table demonstrates how a single conceptual option for a subcommand
+is represented across different configuration layers and how it would map to a
+field in a Rust struct used by clap.
 
-<table class="not-prose border-collapse table-auto w-full" style="min-width: 125px">
-<colgroup><col style="min-width: 25px"><col style="min-width: 25px"><col style="min-width: 25px"><col style="min-width: 25px"><col style="min-width: 25px"></colgroup><tbody><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Feature</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>CLI Example</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Config File (TOML)</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Environment Variable</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>clap Struct Field (Conceptual)</strong></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>List: Hide Foo</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mycli list --hide-foo</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">[cmds.list]</code>&lt;br&gt;<code class="code-inline">hide_foo = true</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">MYCLI_CMDS_LIST_HIDE_FOO=true</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">hide_foo: bool</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>List: Show Bar</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mycli list --show-bar</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">[cmds.list]</code>&lt;br&gt;<code class="code-inline">show_bar = true</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">MYCLI_CMDS_LIST_SHOW_BAR=true</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">show_bar: bool</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>List: Page Size</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mycli list --page-size 30</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">[cmds.list]</code>&lt;br&gt;<code class="code-inline">page_size = 20</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">MYCLI_CMDS_LIST_PAGE_SIZE=20</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">page_size: u32</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Add: Priority</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mycli add item --priority 5</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">[cmds.add]</code>&lt;br&gt;<code class="code-inline">priority = 10</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">MYCLI_CMDS_ADD_PRIORITY=10</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">priority: u32</code></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Add: Confirm (no CLI)</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">mycli add item</code> (uses config)</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">[cmds.add]</code>&lt;br&gt;<code class="code-inline">enable_confirmation = false</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">MYCLI_CMDS_ADD_ENABLE_CONFIRMATION=false</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">enable_confirmation: bool</code></p></td></tr></tbody>
-</table>
+| Feature               | CLI Example                              | Config File (TOML)                       | Environment Variable                     | clap Struct Field (Conceptual) |
+| --------------------- | ---------------------------------------- | ---------------------------------------- | ---------------------------------------- | ------------------------------ |
+| List: Hide Foo        | mycli list --hide-foo                    | [cmds.list] hide_foo = true              | MYCLI_CMDS_LIST_HIDE_FOO=true            | hide_foo: bool                 |
+| List: Show Bar        | mycli list --show-bar                    | [cmds.list] show_bar = true              | MYCLI_CMDS_LIST_SHOW_BAR=true            | show_bar: bool                 |
+| List: Page Size       | mycli list --page-size 30                | [cmds.list] page_size = 20               | MYCLI_CMDS_LIST_PAGE_SIZE=20             | page_size: u32                 |
+| Add: Priority         | mycli add item --priority 5              | [cmds.add] priority = 10                 | MYCLI_CMDS_ADD_PRIORITY=10               | priority: u32                  |
+| Add: Confirm (no CLI) | mycli add item (uses config)             | [cmds.add] enable_confirmation = false   | MYCLI_CMDS_ADD_ENABLE_CONFIRMATION=false | enable_confirmation: bool      |
 
-This table is instrumental in visualizing the orthographic principle applied to subcommands. It clarifies how an option like `hide_foo` for the `list` subcommand maintains its semantic identity across the CLI, environment variables, and configuration files, ultimately mapping to a field within a Rust data structure. This systematic approach is key to the proposed design's clarity and predictability.
+This table is instrumental in visualizing the orthographic principle applied to
+subcommands. It clarifies how an option like `hide_foo` for the `list`
+subcommand maintains its semantic identity across the CLI, environment
+variables, and configuration files, ultimately mapping to a field within a Rust
+data structure. This systematic approach is key to the proposed design's clarity
+and predictability.
 
 ### C. Bridging `clap-dispatch` Arguments with `ortho-config`
 
-The integration requires a mechanism for `ortho-config`'s loaded values to inform the argument structs that `clap` parses and `clap-dispatch` uses.
+The integration requires a mechanism for `ortho-config`'s loaded values to
+inform the argument structs that `clap` parses and `clap-dispatch` uses.
 
 1\. Populating clap-parsed structs from ortho-config sources.
 
-The argument structs used by clap (e.g., ListArgs, AddArgs from the table above) must derive serde::Deserialize in addition to clap::Parser. The workflow would be:
+The argument structs used by clap (e.g., ListArgs, AddArgs from the table above)
+must derive serde::Deserialize in addition to clap::Parser. The workflow would
+be:
 
-a. ortho-config loads all configurations from files and environment variables into its internal, hierarchical representation.
+a. ortho-config loads all configurations from files and environment variables
+into its internal, hierarchical representation.
 
-b. When a subcommand is invoked (e.g., mycli list), ortho-config extracts the relevant configuration section (e.g., the data under cmds.list).
+b. When a subcommand is invoked (e.g., mycli list), ortho-config extracts the
+relevant configuration section (e.g., the data under cmds.list).
 
-c. This extracted section is then deserialized by serde into an instance of the corresponding argument struct (e.g., ListArgs). This instance now holds the default values sourced from files and environment variables.
+c. This extracted section is then deserialized by serde into an instance of the
+corresponding argument struct (e.g., ListArgs). This instance now holds the
+default values sourced from files and environment variables.
 
 d. clap then parses the actual command-line arguments.
 
-e. A merging step is required: CLI-provided values take precedence over values loaded by ortho-config.
+e. A merging step is required: CLI-provided values take precedence over values
+loaded by ortho-config.
 
-2\. Layered Configuration Precedence for Subcommands
+Layered Configuration Precedence for Subcommands
 
 The order of precedence for configuration values must be clearly defined:
 
-1\. Command-line arguments: Values explicitly provided on the command line (parsed by clap) have the highest precedence.
+1. Command-line arguments: Values explicitly provided on the command line
+   (parsed by clap) have the highest precedence.
 
-2\. Environment variables: Values sourced from environment variables (e.g., MYAPP_CMDS_LIST_HIDE_FOO, parsed by ortho-config).
+2. Environment variables: Values sourced from environment variables (e.g.,
+   MYAPP_CMDS_LIST_HIDE_FOO, parsed by ortho-config).
 
-3\. Configuration file values: Values from configuration files (e.g., \[cmds.list\] hide_foo = true, parsed by ortho-config).
+3. Configuration file values: Values from configuration files (e.g., [cmds.list]
+   hide_foo = true, parsed by ortho-config).
 
-4\. Hardcoded defaults in clap structs: Defaults defined using #\[arg(default_value = "...")\] or default_value_t in the clap argument struct definitions have the lowest precedence.
+4. Hardcoded defaults in clap structs: defaults defined using
+   `[arg(default_value = "...")]` or `default_value_t` in the clap argument
+   struct have the lowest precedence.
 
-This layering implies a careful interaction between clap's defaulting mechanisms and ortho-config. For ortho-config defaults to correctly slot in between CLI arguments and clap's hardcoded defaults, fields in the clap argument structs that can be configured by ortho-config should ideally be Option&lt;T&gt;. This allows distinguishing between a value not being set, being set to a specific value by clap's parser (either from CLI or a clap default), or needing a default from ortho-config.
+This layering implies a careful interaction between clap's defaulting mechanisms
+and ortho-config. For ortho-config defaults to correctly slot in between CLI
+arguments and clap's hardcoded defaults, fields in the clap argument structs
+that can be configured by ortho-config should ideally be Option\<T>. This allows
+distinguishing between a value not being set, being set to a specific value by
+clap's parser (either from CLI or a clap default), or needing a default from
+ortho-config.
 
 The process would be:
 
-i. ortho-config loads its configuration, potentially yielding Some(config_default) for a field.
+1. ortho-config loads its configuration, potentially yielding
+   Some(config_default) for a field.
+2. clap parses arguments. If a CLI argument is given for an Option\<T> field, it
+   becomes Some(cli_value). If no CLI argument is given and no clap default is
+   set for that Option\<T> field, it remains None. If a clap default_value_t is
+   specified for an Option\<T> field, clap might fill it if no CLI arg is
+   present.
+3. A merge step then resolves the final value: CLI value > Environment value >
+   File value > clap's default_value_t (if applicable and not overridden by
+   CLI/Env/File) > Code-defined default (e.g. Option::unwrap_or_else).
 
-ii. clap parses arguments. If a CLI argument is given for an Option&lt;T&gt; field, it becomes Some(cli_value). If no CLI argument is given and no clap default is set for that Option&lt;T&gt; field, it remains None. If a clap default_value_t is specified for an Option&lt;T&gt; field, clap might fill it if no CLI arg is present.
-
-iii. A merge step then resolves the final value: CLI value &gt; Environment value &gt; File value &gt; clap's default_value_t (if applicable and not overridden by CLI/Env/File) &gt; Code-defined default (e.g. Option::unwrap_or_else).
-
-This nuanced handling ensures that ortho-config provides a flexible layer of defaults without interfering with clap's primary role of parsing explicit user input.
+This nuanced handling ensures that ortho-config provides a flexible layer of
+defaults without interfering with clap's primary role of parsing explicit user
+input.
 
 3\. Handling serde::Deserialize for argument structs.
 
-The argument structs (e.g., ListArgs, AddArgs) must derive both # (for ortho-config) and #\[derive(clap::Parser)\] (for clap).
+The argument structs (e.g., ListArgs, AddArgs) must derive both # (for
+ortho-config) and #[derive(clap::Parser)] (for clap).
 
-Rust
-
-```
+```rust
 use clap::Parser;
 use serde::Deserialize;
 
@@ -526,15 +678,22 @@ pub struct ListArgs {
 }
 ```
 
-Fields in these structs should correspond to the keys used in the TOML/JSON configuration and the suffixes of environment variables. `serde` attributes like `#[serde(default)]` (to use `Default::default()` for missing fields during deserialization from config files/env vars) or `#[serde(rename = "other-name")]` can be used to map Rust field names to different configuration key names if necessary. The `Default` trait is also useful for creating an initial "empty" or "base default" instance before layering configurations.
+Fields in these structs should correspond to the keys used in the TOML/JSON
+configuration and the suffixes of environment variables. `serde` attributes like
+`#[serde(default)]` (to use `Default::default()` for missing fields during
+deserialization from config files/env vars) or `#[serde(rename = "other-name")]`
+can be used to map Rust field names to different configuration key names if
+necessary. The `Default` trait is also useful for creating an initial "empty" or
+"base default" instance before layering configurations.
 
 ### D. Conceptual Code Snippets for Integration Logic
 
-The following conceptual sketch illustrates how `ortho-config` might load configurations and prepare arguments for `clap-dispatch`. This is a simplified representation; actual implementation would involve more robust error handling and generic type management.
+The following conceptual sketch illustrates how `ortho-config` might load
+configurations and prepare arguments for `clap-dispatch`. This is a simplified
+representation; actual implementation would involve more robust error handling
+and generic type management.
 
-Rust
-
-```
+```rust
 use clap::Parser;
 use serde::Deserialize;
 use clap_dispatch::clap_dispatch;
@@ -551,9 +710,10 @@ impl OrthoConfigStore {
     fn load(app_name: &str) -> Result<Self, String> {
         // In a real scenario, this loads from files and environment variables.
         // Populates global_config and subcommand_configs (e.g., from [cmds.*] sections)
-        println!("OrthoConfigStore: Loading for app '{}'", app_name);
+println!("OrthoConfigStore: Loading for app '{}'", app_name);
         // Example:
-        // let list_conf_json = serde_json::json!({ "hide_foo": true, "default_format": "env_json" });
+        // let list_conf_json = serde_json::json!({ "hide_foo": true, "default_format":
+"env_json" });
         // let mut list_cmd_conf = HashMap::new();
         // if let serde_json::Value::Object(map) = list_conf_json {
         //     for (k, v) in map {
@@ -565,23 +725,24 @@ impl OrthoConfigStore {
 
         Ok(Self {
             global_config: HashMap::new(), // Populate with global settings
-            subcommand_configs: HashMap::new(), // Populate with subcommand settings from [cmds.*]
+            subcommand_configs: HashMap::new(), // Populate with subcommand settings
+from [cmds.*]
         })
     }
 
-    fn get_subcommand_config_struct<T: for<'de> Deserialize<'de> + Default>(&self, cmd_name: &str) -> T {
+    fn get_subcommand_config_struct<T: for<'de> Deserialize<'de> + Default>(&self,
+cmd_name: &str) -> T {
         self.subcommand_configs.get(cmd_name)
            .and_then(|config_map| {
                 // Convert HashMap<String, serde_json::Value> to a single serde_json::Value::Object
-                let json_object = serde_json::Value::Object(config_map.clone().into_iter().collect());
-                serde_json::from_value(json_object).ok()
+let json_object = serde_json::Value::Object(config_map.clone().into_iter().collect());
+serde_json::from_value(json_object).ok()
             })
            .unwrap_or_default()
     }
 }
 
 // --- Application Structs ---
-#
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -591,13 +752,11 @@ struct Cli {
 }
 
 # // Clone for merging example
-#
 enum Commands {
     List(ListArgs),
     // Add(AddArgs), // AddArgs would be defined similarly to ListArgs
 }
 
-#
 #[serde(default)]
 pub struct ListArgs {
    #[arg(long)]
@@ -609,9 +768,10 @@ pub struct ListArgs {
 impl Run for ListArgs {
     fn run(&self, _global_conf_val: &serde_json::Value) -> Result<(), String> {
         println!("Running List command:");
-        println!("  Hide Foo: {:?}", self.hide_foo.unwrap_or(false)); // Example of final resolution
+        println!("  Hide Foo: {:?}", self.hide_foo.unwrap_or(false)); // Example
+of final resolution
         println!("  Default Format: {:?}", self.default_format.as_deref().unwrap_or("text"));
-        Ok(())
+Ok(())
     }
 }
 
@@ -630,14 +790,16 @@ fn main() -> Result<(), String> {
     let final_command = match cli_args.command {
         Commands::List(clap_parsed_list_args) => {
             // 4. Merge CLI values over ortho-config defaults for the subcommand
-            let final_list_args = load_and_merge_subcommand_for::<ListArgs>(&clap_parsed_list_args)?;
-            Commands::List(final_list_args)
+let final_list_args = load_and_merge_subcommand_for::<ListArgs>(&clap_parsed_list_args)?;
+Commands::List(final_list_args)
         }
-        // Commands::Add(clap_parsed_add_args) => { /* similar logic for Add command */ }
+        // Commands::Add(clap_parsed_add_args) => { /* similar logic for Add command
+*/ }
     };
 
     // 6. Dispatch using clap-dispatch
-    //    Pass any global configuration loaded by ortho-config if needed by the run methods.
+    //    Pass any global configuration loaded by ortho-config if needed by the run
+methods.
     let dummy_global_conf = serde_json::Value::Null; // Placeholder
     final_command.run(&dummy_global_conf)?;
 
@@ -645,32 +807,84 @@ fn main() -> Result<(), String> {
 }
 ```
 
-This conceptual code illustrates the key stages: loading `ortho-config` defaults, parsing CLI arguments with `clap`, merging these layers with defined precedence, and finally dispatching the command using the method provided by `clap-dispatch`. The critical merging step now uses `load_and_merge_subcommand_for`, which loads the subcommand defaults and applies any CLI overrides. A more generic merging strategy might involve reflection or a trait implemented by all argument structs.
+This conceptual code illustrates the key stages: loading `ortho-config`
+defaults, parsing CLI arguments with `clap`, merging these layers with defined
+precedence, and finally dispatching the command using the method provided by
+`clap-dispatch`. The critical merging step now uses
+`load_and_merge_subcommand_for`, which loads the subcommand defaults and applies
+any CLI overrides. A more generic merging strategy might involve reflection or a
+trait implemented by all argument structs.
 
 ### E. Benefits and Rationale for the Proposed Design
 
 This design offers several advantages:
 
-- **Consistency:** Extends `ortho-config`'s orthographic configuration principle to subcommands, providing a uniform user experience.
-- **Flexibility:** Users can configure subcommand behavior via their preferred method: CLI flags for ad-hoc changes, environment variables for CI/CD or containerized environments, or configuration files for persistent settings.
-- **Reduced Boilerplate:** `clap-dispatch` handles the command dispatch logic, while `ortho-config` centralizes configuration loading and merging.
-- **Clarity:** The `cmds` namespace offers a clear and intuitive structure for subcommand configurations within files and environment variables.
-- **Maintainability:** Decouples argument parsing (`clap`), configuration management (`ortho-config`), and actual command logic (trait implementations), leading to more modular and maintainable code.
+- **Consistency:** Extends `ortho-config`'s orthographic configuration principle
+  to subcommands, providing a uniform user experience.
+- **Flexibility:** Users can configure subcommand behavior via their preferred
+  method: CLI flags for ad-hoc changes, environment variables for CI/CD or
+  containerized environments, or configuration files for persistent settings.
+- **Reduced Boilerplate:** `clap-dispatch` handles the command dispatch logic,
+  while `ortho-config` centralizes configuration loading and merging.
+- **Clarity:** The `cmds` namespace offers a clear and intuitive structure for
+  subcommand configurations within files and environment variables.
+- **Maintainability:** Decouples argument parsing (`clap`), configuration
+  management (`ortho-config`), and actual command logic (trait implementations),
+  leading to more modular and maintainable code.
 
 ### F. Considerations and Potential Implementation Challenges
 
 Several aspects require careful consideration during implementation:
 
-- **Complexity of Merging Logic:** As highlighted, correctly implementing the precedence (CLI &gt; Env &gt; File &gt; Code Default) when merging values from `clap`-parsed structs and `ortho-config`-loaded structs is non-trivial. This is especially true if `clap` structs use `Option<T>` extensively and `clap`'s own `default_value` attributes are also in play. The merge logic must accurately determine if a CLI flag was explicitly provided.
-- **Error Handling:** A robust strategy for aggregating and reporting errors from both `clap` parsing and `ortho-config` loading (e.g., file not found, malformed config, invalid environment variable) is essential.
-- **Dynamic Subcommands:** The proposed design, relying on `clap-dispatch`, assumes subcommands are statically defined at compile time (as variants of a Rust enum). If `ortho-config` were to support defining *new* subcommands entirely through configuration files (not known at compile time), `clap-dispatch` would not be directly applicable, and a different dispatch mechanism would be needed. This proposal focuses on statically defined subcommands.
-- **Performance:** For CLIs with extremely complex configurations or a vast number of configuration sources, the initial load and parsing time by `ortho-config` could be a factor, though likely minor for most applications.
-- **Interaction with** `clap`**'s** `flatten` **attribute:** If global options (applicable to all subcommands or the main app) are also loaded via `ortho-config` and then `#[clap(flatten)]`-ed into `clap`'s main argument struct, ensuring these interact predictably with subcommand-specific configurations from the `cmds` namespace will be important.
+- **Complexity of Merging Logic:** As highlighted, correctly implementing the
+  precedence (CLI > Env > File > Code Default) when merging values from
+  `clap`-parsed structs and `ortho-config`-loaded structs is non-trivial. This
+  is especially true if `clap` structs use `Option<T>` extensively and `clap`'s
+  own `default_value` attributes are also in play. The merge logic must
+  accurately determine if a CLI flag was explicitly provided.
+- **Error Handling:** A robust strategy for aggregating and reporting errors
+  from both `clap` parsing and `ortho-config` loading (e.g., file not found,
+  malformed config, invalid environment variable) is essential.
+- **Dynamic Subcommands:** The proposed design, relying on `clap-dispatch`,
+  assumes subcommands are statically defined at compile time (as variants of a
+  Rust enum). If `ortho-config` were to support defining *new* subcommands
+  entirely through configuration files (not known at compile time),
+  `clap-dispatch` would not be directly applicable, and a different dispatch
+  mechanism would be needed. This proposal focuses on statically defined
+  subcommands.
+- **Performance:** For CLIs with extremely complex configurations or a vast
+  number of configuration sources, the initial load and parsing time by
+  `ortho-config` could be a factor, though likely minor for most applications.
+- **Interaction with** `clap`**'s** `flatten` **attribute:** If global options
+  (applicable to all subcommands or the main app) are also loaded via
+  `ortho-config` and then `#[clap(flatten)]`-ed into `clap`'s main argument
+  struct, ensuring these interact predictably with subcommand-specific
+  configurations from the `cmds` namespace will be important.
 
 ## V. Conclusion
 
-`clap-dispatch` offers a compelling solution for Rust developers seeking to create more ergonomic and maintainable CLIs with multiple subcommands that share a common action pattern. By leveraging trait-based dispatch and procedural macros, it significantly reduces boilerplate and promotes cleaner code architecture.3 The practical examples provided illustrate its ease of use and effectiveness in structuring subcommand logic.
+`clap-dispatch` offers a compelling solution for Rust developers seeking to
+create more ergonomic and maintainable CLIs with multiple subcommands that share
+a common action pattern. By leveraging trait-based dispatch and procedural
+macros, it significantly reduces boilerplate and promotes cleaner code
+architecture.3 The practical examples provided illustrate its ease of use and
+effectiveness in structuring subcommand logic.
 
-The proposed integration of `clap-dispatch` with `ortho-config` via a "cmds" namespace aims to extend `ortho-config`'s powerful orthographic configuration capabilities to subcommands. This design promises enhanced consistency, allowing users to configure subcommand behavior through CLI arguments, environment variables, or configuration files in a predictable manner. The layering of these configuration sources, with clear precedence rules, ensures flexibility while maintaining control.
+The proposed integration of `clap-dispatch` with `ortho-config` via a "cmds"
+namespace aims to extend `ortho-config`'s powerful orthographic configuration
+capabilities to subcommands. This design promises enhanced consistency, allowing
+users to configure subcommand behavior through CLI arguments, environment
+variables, or configuration files in a predictable manner. The layering of these
+configuration sources, with clear precedence rules, ensures flexibility while
+maintaining control.
 
-While the implementation, particularly the merging logic between `clap`-parsed arguments and `ortho-config` defaults, presents challenges, the benefits in terms of developer ergonomics, user flexibility, and overall application maintainability are substantial. By adopting such a structured approach, `ortho-config` can evolve into an even more comprehensive framework for building sophisticated and highly configurable command-line applications in Rust. The path forward involves careful implementation of the merging strategy and robust error handling to realize the full potential of this integrated system, ultimately leading to a CLI framework that is both powerful for the end-user and a pleasure for the developer to work with.
+While the implementation, particularly the merging logic between `clap`-parsed
+arguments and `ortho-config` defaults, presents challenges, the benefits in
+terms of developer ergonomics, user flexibility, and overall application
+maintainability are substantial. By adopting such a structured approach,
+`ortho-config` can evolve into an even more comprehensive framework for building
+sophisticated and highly configurable command-line applications in Rust. The
+path forward involves careful implementation of the merging strategy and robust
+error handling to realize the full potential of this integrated system,
+ultimately leading to a CLI framework that is both powerful for the end-user and
+a pleasure for the developer to work with.

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,43 +2,85 @@
 
 ## 1. Motivation & Vision
 
-**1.1. The Problem:** Rust application configuration is powerful but fragmented. Developers typically hand-roll solutions by combining `clap` for CLI, `serde` for deserialization, and `figment` or `config-rs` for layered file/environment loading. This process involves significant boilerplate, manual mapping of disparate naming conventions (e.g., `--kebab-case` vs. `SNAKE_CASE`), and complex merge logic, all of which must be recreated for each new project.
+**1.1. The Problem:** Rust application configuration is powerful but fragmented.
+Developers typically hand-roll solutions by combining `clap` for CLI, `serde`
+for deserialization, and `figment` or `config-rs` for layered file/environment
+loading. This process involves significant boilerplate, manual mapping of
+disparate naming conventions (e.g., `--kebab-case` vs. `SNAKE_CASE`), and
+complex merge logic, all of which must be recreated for each new project.
 
-**1.2. The Vision:** `OrthoConfig` will provide a "batteries-included" configuration solution inspired by the developer experience of tools like `esbuild`. By using a single `derive` macro, developers will define their configuration *once* in a plain Rust struct. The crate will then handle the entire lifecycle of parsing, layering, merging, and deserializing from command-line arguments, environment variables, and configuration files.
+**1.2. The Vision:** `OrthoConfig` will provide a "batteries-included"
+configuration solution inspired by the developer experience of tools like
+`esbuild`. By using a single `derive` macro, developers will define their
+configuration *once* in a plain Rust struct. The crate will then handle the
+entire lifecycle of parsing, layering, merging, and deserializing from
+command-line arguments, environment variables, and configuration files.
 
 **1.3. Foreseen Benefits:**
-* **For End-Users (of the application):** A consistent and predictable configuration experience. They can use the most convenient method (CLI, env, file) to configure the application, and the rules of precedence will be clear and unambiguous.
-* **For Developers (using `OrthoConfig`):** A dramatic reduction in boilerplate and cognitive load. It abstracts away the tedious integration details, allowing developers to focus on their application's logic rather than configuration plumbing. This will lead to faster development, fewer bugs, and improved maintainability.
+
+- **For End-Users (of the application):** A consistent and predictable
+  configuration experience. They can use the most convenient method (CLI, env,
+  file) to configure the application, and the rules of precedence will be clear
+  and unambiguous.
+- **For Developers (using `OrthoConfig`):** A dramatic reduction in boilerplate
+  and cognitive load. It abstracts away the tedious integration details,
+  allowing developers to focus on their application's logic rather than
+  configuration plumbing. This will lead to faster development, fewer bugs, and
+  improved maintainability.
 
 ## 2. Core Principles & Goals
 
 The implementation must adhere to the following principles:
 
-* **Convention over Configuration:** The crate should have sensible defaults for everything: CLI flag names, environment variable names, file discovery paths, and merge strategies. The user should only need to add attributes for exceptional cases.
-* **Ergonomic API:** The primary user-facing API will be a single procedural macro, `#[derive(OrthoConfig)]`. All functionality should flow from this.
-* **Transparency:** While the crate abstracts complexity, it must not be a black box. Error messages must be rich, informative, and clearly attribute issues to their original source (e.g., "Error in `config.toml` at line 5: invalid type for `port`").
-* **Performance:** The configuration process happens once at startup, so raw performance is secondary to correctness and developer experience. However, the implementation should be reasonably efficient and avoid unnecessary allocations or processing.
+- **Convention over Configuration:** The crate should have sensible defaults for
+  everything: CLI flag names, environment variable names, file discovery paths,
+  and merge strategies. The user should only need to add attributes for
+  exceptional cases.
+- **Ergonomic API:** The primary user-facing API will be a single procedural
+  macro, `#[derive(OrthoConfig)]`. All functionality should flow from this.
+- **Transparency:** While the crate abstracts complexity, it must not be a black
+  box. Error messages must be rich, informative, and clearly attribute issues to
+  their original source (e.g., "Error in `config.toml` at line 5: invalid type
+  for `port`").
+- **Performance:** The configuration process happens once at startup, so raw
+  performance is secondary to correctness and developer experience. However, the
+  implementation should be reasonably efficient and avoid unnecessary
+  allocations or processing.
 
 ## 3. High-Level Architecture
 
 The crate will be composed of three main parts:
 
-1.  **Procedural Macro (`ortho_config_macros`):** The `#[derive(OrthoConfig)]` macro. It will be responsible for parsing the user's struct definition and its attributes, then generating the necessary code.
-2.  **Core Crate (`ortho_config`):** The runtime component. It will contain the `OrthoConfig` trait, the core loading and merging logic, error types, and necessary helper functions.
-3.  **Dependencies:** It will be built upon the shoulders of established community crates: `clap`, `figment`, `serde`, and `syn`/`quote`.
+1. **Procedural Macro (`ortho_config_macros`):** The `#[derive(OrthoConfig)]`
+   macro. It will be responsible for parsing the user's struct definition and
+   its attributes, then generating the necessary code.
+2. **Core Crate (`ortho_config`):** The runtime component. It will contain the
+   `OrthoConfig` trait, the core loading and merging logic, error types, and
+   necessary helper functions.
+3. **Dependencies:** It will be built upon the shoulders of established
+   community crates: `clap`, `figment`, `serde`, and `syn`/`quote`.
 
 The primary data flow for a user calling `AppConfig::load()` will be:
 
-1.  The call invokes the `load` method on the `OrthoConfig` trait, implemented by the derive macro.
-2.  The implementation first uses `clap` to parse command-line arguments into a temporary, partial `clap`-specific struct.
-3.  It then constructs a `figment` instance, adding providers in reverse order of precedence:
-    * **Defaults Provider:** A struct containing default values defined in `#[ortho_config(default = ...)]`.
-    * **File Provider:** A `Toml` (or other format) provider that discovers and loads the configuration file.
-    * **Environment Provider:** An `Env` provider configured with the correct prefix and key-mapping rules.
-    * **CLI Provider:** The `clap`-parsed arguments are serialized into a `figment` provider and merged last.
-4.  `figment`'s `extract()` method is called to deserialize the merged configuration into the user's `AppConfig` struct.
-5.  Array merging logic is applied post-deserialization if the "append" strategy is used.
-6.  The result, either `Ok(AppConfig)` or `Err(OrthoError)`, is returned.
+1. The call invokes the `load` method on the `OrthoConfig` trait, implemented by
+   the derive macro.
+2. The implementation first uses `clap` to parse command-line arguments into a
+   temporary, partial `clap`-specific struct.
+3. It then constructs a `figment` instance, adding providers in reverse order of
+   precedence:
+   - **Defaults Provider:** A struct containing default values defined in
+     `#[ortho_config(default = ...)]`.
+   - **File Provider:** A `Toml` (or other format) provider that discovers and
+     loads the configuration file.
+   - **Environment Provider:** An `Env` provider configured with the correct
+     prefix and key-mapping rules.
+   - **CLI Provider:** The `clap`-parsed arguments are serialized into a
+     `figment` provider and merged last.
+4. `figment`'s `extract()` method is called to deserialize the merged
+   configuration into the user's `AppConfig` struct.
+5. Array merging logic is applied post-deserialization if the "append" strategy
+   is used.
+6. The result, either `Ok(AppConfig)` or `Err(OrthoError)`, is returned.
 
 ## 4. Component Deep Dive
 
@@ -63,33 +105,59 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
 
 ### 4.2. The `#[derive(OrthoConfig)]` Macro
 
-This is the most complex component. It needs to perform the following using `syn` and `quote`:
+This is the most complex component. It needs to perform the following using
+`syn` and `quote`:
 
-1.  **Parse Attributes:** Define `#[ortho_config(...)]` attributes for both struct-level (e.g., `prefix`, `file_name`) and field-level (e.g., `cli_long`, `env`, `default`, `merge_strategy`).
-2.  **Generate a `clap`-aware Struct:** In the generated code, create a hidden struct derived from `clap::Parser`. Its fields should correspond to the main struct's fields but be wrapped in `Option<T>` to capture only user-provided values. The macro will translate `#[ortho_config(cli_long="...")]` into `#[clap(long="...")]`.
-3.  **Generate `impl OrthoConfig for UserStruct`:**
-    * This block will contain the `load()` method.
-    * The generated `load()` will perform the architectural flow described in section 3.
-    * It will need to dynamically generate the `figment` profile based on the parsed attributes. For example, it will use the `prefix` attribute for `figment::providers::Env::prefixed(...)`.
+1. **Parse Attributes:** Define `#[ortho_config(...)]` attributes for both
+   struct-level (e.g., `prefix`, `file_name`) and field-level (e.g., `cli_long`,
+   `env`, `default`, `merge_strategy`).
+2. **Generate a `clap`-aware Struct:** In the generated code, create a hidden
+   struct derived from `clap::Parser`. Its fields should correspond to the main
+   struct's fields but be wrapped in `Option<T>` to capture only user-provided
+   values. The macro will translate `#[ortho_config(cli_long="...")]` into
+   `#[clap(long="...")]`.
+3. **Generate `impl OrthoConfig for UserStruct`:**
+   - This block will contain the `load()` method.
+   - The generated `load()` will perform the architectural flow described in
+     section 3.
+   - It will need to dynamically generate the `figment` profile based on the
+     parsed attributes. For example, it will use the `prefix` attribute for
+     `figment::providers::Env::prefixed(...)`.
 
 ### 4.3. Orthographic Name Mapping
 
 The macro must enforce naming conventions automatically.
 
-* **Struct Field to CLI Flag:** A field `listen_port` should automatically become `--listen-port` unless overridden by `#[ortho_config(cli_long = "...")]`. This involves converting `snake_case` to `kebab-case`.
-* **Struct Field to Env Var:** A field `listen_port` within a struct with `#[ortho_config(prefix = "MY_APP")]` should become `MY_APP_LISTEN_PORT`. Nested structs (e.g., `database.url`) should become `MY_APP_DATABASE__URL` (using a configurable delimiter). This involves converting `snake_case` to `UPPER_SNAKE_CASE`.
-* **Struct Field to File Key:** This is handled by `serde` and `figment`. By default, `serde` expects file keys to match Rust field names (`snake_case`). We can consider adding a struct-level attribute `#[ortho_config(rename_all = "kebab-case")]` which would pass the corresponding `#[serde(rename_all = "...")]` attribute to the user's struct.
+- **Struct Field to CLI Flag:** A field `listen_port` should automatically
+  become `--listen-port` unless overridden by
+  `#[ortho_config(cli_long = "...")]`. This involves converting `snake_case` to
+  `kebab-case`.
+- **Struct Field to Env Var:** A field `listen_port` within a struct with
+  `#[ortho_config(prefix = "MY_APP")]` should become `MY_APP_LISTEN_PORT`.
+  Nested structs (e.g., `database.url`) should become `MY_APP_DATABASE__URL`
+  (using a configurable delimiter). This involves converting `snake_case` to
+  `UPPER_SNAKE_CASE`.
+- **Struct Field to File Key:** This is handled by `serde` and `figment`. By
+  default, `serde` expects file keys to match Rust field names (`snake_case`).
+  We can consider adding a struct-level attribute
+  `#[ortho_config(rename_all = "kebab-case")]` which would pass the
+  corresponding `#[serde(rename_all = "...")]` attribute to the user's struct.
 
 ### 4.4. Array (`Vec<T>`) Merging
 
 This is a key user-experience feature.
 
-* **`merge_strategy = "append"` (Default):** The generated `load()` function cannot simply use `figment::extract()` when merging arrays. It must:
-    1.  Create separate `figment` instances for each source layer (File, Env, CLI).
-    2.  Extract the `Vec<T>` field from each layer individually, ignoring errors if the field is absent.
-    3.  Concatenate the resulting `Vec`s in the correct order (File -> Env -> CLI).
-    4.  Create a final "override" `figment` provider containing only the merged `Vec`.
-    5.  Merge this override provider on top of the main `figment` instance before calling `extract()` on the final result. This ensures the combined `Vec` is present for deserialization.
+- **`merge_strategy = "append"` (Default):** The generated `load()` function
+  cannot simply use `figment::extract()` when merging arrays. It must:
+  1. Create separate `figment` instances for each source layer (File, Env, CLI).
+  2. Extract the `Vec<T>` field from each layer individually, ignoring errors if
+     the field is absent.
+  3. Concatenate the resulting `Vec`s in the correct order (File -> Env -> CLI).
+  4. Create a final "override" `figment` provider containing only the merged
+     `Vec`.
+  5. Merge this override provider on top of the main `figment` instance before
+     calling `extract()` on the final result. This ensures the combined `Vec` is
+     present for deserialization.
 
 ### 4.5. Error Handling
 
@@ -123,53 +191,74 @@ pub enum OrthoError {
     },
 }
 ```
-The implementation must be careful to wrap errors from `clap`, `figment`, and file IO into this enum, adding contextual information (like file paths) where possible.
+
+The implementation must be careful to wrap errors from `clap`, `figment`, and
+file IO into this enum, adding contextual information (like file paths) where
+possible.
 
 ## 5. Dependency Strategy
 
-* **`ortho_config_macros`:**
-    * `syn`: To parse Rust code and attributes.
-    * `quote`: To generate Rust code.
-    * `proc-macro2`: For improved procedural macro APIs.
-* **`ortho_config` (Core):**
-    * `clap`: For CLI parsing. Choose a version with the `derive` feature.
-    * `figment`: As the core layering engine.
-    * `serde`: For serialization/deserialization.
-    * `toml`, `figment-json5`, `serde_yaml`: As optional feature-gated dependencies for different file formats. `toml` should be a default feature. The `json5` feature uses `figment-json5` to parse `.json` and `.json5` files; loading these formats without enabling `json5` should produce an error so users aren't surprised by silent TOML parsing.
-    * `thiserror`: For ergonomic error type definitions.
+- **`ortho_config_macros`:**
+  - `syn`: To parse Rust code and attributes.
+  - `quote`: To generate Rust code.
+  - `proc-macro2`: For improved procedural macro APIs.
+- **`ortho_config` (Core):**
+  - `clap`: For CLI parsing. Choose a version with the `derive` feature.
+  - `figment`: As the core layering engine.
+  - `serde`: For serialization/deserialization.
+  - `toml`, `figment-json5`, `serde_yaml`: As optional feature-gated
+    dependencies for different file formats. `toml` should be a default feature.
+    The `json5` feature uses `figment-json5` to parse `.json` and `.json5`
+    files; loading these formats without enabling `json5` should produce an
+    error so users aren't surprised by silent TOML parsing.
+  - `thiserror`: For ergonomic error type definitions.
 
 ## 6. Implementation Roadmap
 
-1.  **V0.1 (Scaffolding):**
-    * Set up the workspace with the two crates.
-    * Define the `OrthoConfig` trait and `OrthoError` enum.
-    * Create a basic derive macro that implements `OrthoConfig` with an empty `load` method.
+1. **V0.1 (Scaffolding):**
 
-2.  **V0.2 (Core Layering):**
-    * Implement the `load` method using `figment` to layer hardcoded TOML file and environment sources.
-    * Implement `snake_case` to `UPPER_SNAKE_CASE` mapping for the `Env` provider.
-    * Ensure basic deserialization works.
+   - Set up the workspace with the two crates.
+   - Define the `OrthoConfig` trait and `OrthoError` enum.
+   - Create a basic derive macro that implements `OrthoConfig` with an empty
+     `load` method.
 
-3.  **V0.3 (`clap` Integration):**
-    * Add `clap` as a dependency.
-    * Update the derive macro to generate the hidden `clap`-aware struct.
-    * Integrate the parsed CLI arguments as the highest-precedence `figment` layer.
-    * Implement `snake_case` to `kebab-case` mapping for CLI flag generation.
+2. **V0.2 (Core Layering):**
 
-4.  **V0.4 (Attribute Handling):**
-    * Flesh out the attribute parsing logic in the macro for `prefix`, `default`, `cli_long`, etc.
-    * Make the generated code respect these attributes.
+   - Implement the `load` method using `figment` to layer hardcoded TOML file
+     and environment sources.
+   - Implement `snake_case` to `UPPER_SNAKE_CASE` mapping for the `Env`
+     provider.
+   - Ensure basic deserialization works.
 
-5.  **V0.5 (Advanced Features & Polish):**
-    * Implement the `merge_strategy = "append"` logic for `Vec<T>`.
-    * Refine error messages to be maximally helpful.
-    * Add extensive documentation and examples.
-    * Feature-gate the file format support (`json5`, `yaml`).
+3. **V0.3 (`clap` Integration):**
+
+   - Add `clap` as a dependency.
+   - Update the derive macro to generate the hidden `clap`-aware struct.
+   - Integrate the parsed CLI arguments as the highest-precedence `figment`
+     layer.
+   - Implement `snake_case` to `kebab-case` mapping for CLI flag generation.
+
+4. **V0.4 (Attribute Handling):**
+
+   - Flesh out the attribute parsing logic in the macro for `prefix`, `default`,
+     `cli_long`, etc.
+   - Make the generated code respect these attributes.
+
+5. **V0.5 (Advanced Features & Polish):**
+
+   - Implement the `merge_strategy = "append"` logic for `Vec<T>`.
+   - Refine error messages to be maximally helpful.
+   - Add extensive documentation and examples.
+   - Feature-gate the file format support (`json5`, `yaml`).
 
 ## 7. Future Work
 
-* **Async Support:** A version of `load` that uses non-blocking IO.
-* **Custom Sources:** An API for users to add their own `figment` providers (e.g., from a database or a remote service like Vault).
-* **Live Reloading:** A mechanism to watch configuration files for changes and reload the configuration at runtime.
+- **Async Support:** A version of `load` that uses non-blocking IO.
+- **Custom Sources:** An API for users to add their own `figment` providers
+  (e.g., from a database or a remote service like Vault).
+- **Live Reloading:** A mechanism to watch configuration files for changes and
+  reload the configuration at runtime.
 
-This design provides a clear path forward for implementing `OrthoConfig`. By building on a solid foundation of existing crates and focusing on the developer experience, we can create a highly valuable addition to the Rust ecosystem.
+This design provides a clear path forward for implementing `OrthoConfig`. By
+building on a solid foundation of existing crates and focusing on the developer
+experience, we can create a highly valuable addition to the Rust ecosystem.


### PR DESCRIPTION
## Summary
- fix linting in README and docs

## Testing
- `markdownlint docs/clap-dispatch-and-ortho-config-integration.md`
- `markdownlint README.md`


------
https://chatgpt.com/codex/tasks/task_e_685057381be48322b87994f932564c6a

## Summary by Sourcery

Fix markdownlint warnings across documentation

Documentation:
- Reflow text and normalize paragraph formatting for consistent line lengths
- Standardize code fences with language specifiers across all code blocks
- Correct list syntax and numbering for uniform style
- Fix table markup and inline code formatting for proper rendering
- Adjust headings and remove trailing spaces to satisfy markdownlint rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reformatted and clarified documentation for improved readability and consistency, including README and design documents.
  - Enhanced structure, indentation, and bullet point usage across all docs.
  - Expanded and clarified explanations in the CLI integration guide without changing technical content.
  - No changes to code functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->