### PR TITLE
Add Windows CI job and fix xdg import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ on:
 
 jobs:
   build-test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -31,8 +28,8 @@ jobs:
             coverage: true
           - os: windows-latest
             cache-path: |
-              ~\\.cargo\\registry
-              ~\\.cargo\\git
+              ~/.cargo/registry
+              ~/.cargo/git
               target
             coverage: false
     steps:
@@ -65,15 +62,17 @@ jobs:
       - name: Test
         shell: bash
         run: RUSTFLAGS="-D warnings" cargo test --tests
-        shell: bash
       - name: Install cargo-tarpaulin
         if: matrix.coverage
+        shell: bash
         run: cargo install cargo-tarpaulin --version 0.32.7
       - name: Run coverage
         if: matrix.coverage
+        shell: bash
         run: cargo tarpaulin --out lcov
       - name: Install CodeScene coverage tool
         if: matrix.coverage && env.CS_ACCESS_TOKEN
+        shell: bash
         run: |
           set -euo pipefail
           curl -fsSL -o install-cs-coverage-tool.sh https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
@@ -84,5 +83,6 @@ jobs:
           rm install-cs-coverage-tool.sh
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN && matrix.os == 'ubuntu-latest'
+        shell: bash
         run: cs-coverage upload --format "lcov" --metric "line-coverage" "lcov.info"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,37 @@ jobs:
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
         run: cs-coverage upload --format "lcov" --metric "line-coverage" "lcov.info"
+
+  build-test-windows:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install rust stable
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+        with:
+            toolchain: stable
+            override: true
+            components: rustfmt, clippy
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~\.cargo\registry
+            ~\.cargo\git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Format
+        shell: bash
+        run: cargo fmt --all -- --check
+      - name: Lint
+        shell: bash
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Test
+        shell: bash
+        run: RUSTFLAGS="-D warnings" cargo test --tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,29 @@ on:
 
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     env:
       CARGO_TERM_COLOR: always
       CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cache-path: |
+              ~/.cargo/registry
+              ~/.cargo/git
+              target
+            coverage: true
+          - os: windows-latest
+            cache-path: |
+              ~\\.cargo\\registry
+              ~\\.cargo\\git
+              target
+            coverage: false
     steps:
       - uses: actions/checkout@v4
       - name: Install rust stable
@@ -27,31 +43,33 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
+          path: ${{ matrix['cache-path'] }}
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: Cache CodeScene CLI
-        if: env.CS_ACCESS_TOKEN
+        if: matrix.coverage && env.CS_ACCESS_TOKEN
         uses: actions/cache@v4
         with:
           path: ~/.local/bin/cs-coverage
           key: ${{ runner.os }}-cs-cli-${{ env.CODESCENE_CLI_SHA256 }}
       - name: Format
+        shell: bash
         run: cargo fmt --all -- --check
       - name: Lint
+        shell: bash
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Test
+        shell: bash
         run: RUSTFLAGS="-D warnings" cargo test --tests
       - name: Install cargo-tarpaulin
+        if: matrix.coverage
         run: cargo install cargo-tarpaulin --version 0.32.7
       - name: Run coverage
+        if: matrix.coverage
         run: cargo tarpaulin --out lcov
       - name: Install CodeScene coverage tool
-        if: env.CS_ACCESS_TOKEN
+        if: matrix.coverage && env.CS_ACCESS_TOKEN
         run: |
           set -euo pipefail
           curl -fsSL -o install-cs-coverage-tool.sh https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
@@ -61,39 +79,6 @@ jobs:
           bash install-cs-coverage-tool.sh -y
           rm install-cs-coverage-tool.sh
       - name: Upload coverage data to CodeScene
-        if: env.CS_ACCESS_TOKEN
+        if: matrix.coverage && env.CS_ACCESS_TOKEN
         run: cs-coverage upload --format "lcov" --metric "line-coverage" "lcov.info"
 
-  build-test-windows:
-    runs-on: windows-latest
-    permissions:
-      contents: read
-    env:
-      CARGO_TERM_COLOR: always
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install rust stable
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-        with:
-            toolchain: stable
-            override: true
-            components: rustfmt, clippy
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~\.cargo\registry
-            ~\.cargo\git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-      - name: Format
-        shell: bash
-        run: cargo fmt --all -- --check
-      - name: Lint
-        shell: bash
-        run: cargo clippy --all-targets --all-features -- -D warnings
-      - name: Test
-        shell: bash
-        run: RUSTFLAGS="-D warnings" cargo test --tests

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -15,13 +15,15 @@ clap = { version = "4", features = ["derive"] }
 clap-dispatch = "0.1"
 figment = { version = "0.10", default-features = false, features = ["env", "test"] }
 uncased = "0.9"
-xdg = "3"
 toml = { version = "0.8", optional = true }
 figment-json5 = { version = "0.1", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 
 [target.'cfg(not(any(unix, target_os = "redox")))'.dependencies]
 directories = "6"
+
+[target.'cfg(any(unix, target_os = "redox"))'.dependencies]
+xdg = "3"
 
 [features]
 default = ["toml"]


### PR DESCRIPTION
## Summary
- add a Windows build and test job to CI
- gate `xdg` dependency to Unix/Redox targets

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --tests`


------
https://chatgpt.com/codex/tasks/task_e_68544dc1701c8322a6277d280edff438

## Summary by Sourcery

Introduce a Windows CI job and conditionally gate the xdg dependency to Unix and Redox targets

Bug Fixes:
- Restrict the xdg crate to Unix and Redox targets in Cargo.toml

CI:
- Add a Windows build-and-test job to the GitHub Actions CI workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added Windows build and test checks to the continuous integration workflow.
  - Updated dependency management to limit the `xdg` library to Unix and Redox platforms only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->