### PR TITLE
Add windows job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ on:
 
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     env:
@@ -47,11 +50,13 @@ jobs:
       - name: Test
         run: RUSTFLAGS="-D warnings" cargo test --tests
       - name: Install cargo-tarpaulin
+        if: matrix.os == 'ubuntu-latest'
         run: cargo install cargo-tarpaulin --version 0.32.7
       - name: Run coverage
+        if: matrix.os == 'ubuntu-latest'
         run: cargo tarpaulin --out lcov
       - name: Install CodeScene coverage tool
-        if: env.CS_ACCESS_TOKEN
+        if: env.CS_ACCESS_TOKEN && matrix.os == 'ubuntu-latest'
         run: |
           set -euo pipefail
           curl -fsSL -o install-cs-coverage-tool.sh https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
@@ -61,5 +66,5 @@ jobs:
           bash install-cs-coverage-tool.sh -y
           rm install-cs-coverage-tool.sh
       - name: Upload coverage data to CodeScene
-        if: env.CS_ACCESS_TOKEN
+        if: env.CS_ACCESS_TOKEN && matrix.os == 'ubuntu-latest'
         run: cs-coverage upload --format "lcov" --metric "line-coverage" "lcov.info"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Test
         run: RUSTFLAGS="-D warnings" cargo test --tests
+        shell: bash
       - name: Install cargo-tarpaulin
         if: matrix.os == 'ubuntu-latest'
         run: cargo install cargo-tarpaulin --version 0.32.7


### PR DESCRIPTION
## Summary
- test on Windows and Ubuntu in CI

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --tests`
- `markdownlint docs/*.md README.md`
- `nixie docs/*.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_68544e310754832296b6ae182d629c9c

## Summary by Sourcery

Extend GitHub Actions build-test workflow to run on Windows in addition to Ubuntu, while keeping code coverage and CodeScene uploads limited to Ubuntu.

CI:
- Add Windows (windows-latest) to the CI matrix for build-test
- Conditionally install and run cargo-tarpaulin on Ubuntu only
- Restrict CodeScene coverage tool installation and upload steps to Ubuntu when CS_ACCESS_TOKEN is set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated testing to run on both Ubuntu and Windows operating systems.
  - Adjusted code coverage steps to run only on Ubuntu when the appropriate access token is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->