### PR TITLE
Limit XDG config tests to Unix

### DIFF
--- a/ortho_config/tests/clap_integration.rs
+++ b/ortho_config/tests/clap_integration.rs
@@ -119,6 +119,7 @@ fn missing_config_file_is_ignored() {
     });
 }
 
+// Windows lacks XDG support
 #[cfg(any(unix, target_os = "redox"))]
 #[test]
 fn loads_from_xdg_config() {
@@ -138,6 +139,7 @@ fn loads_from_xdg_config() {
     });
 }
 
+// Windows lacks XDG support
 #[cfg(any(unix, target_os = "redox"))]
 #[cfg(feature = "yaml")]
 #[test]

--- a/ortho_config/tests/subcommand.rs
+++ b/ortho_config/tests/subcommand.rs
@@ -118,6 +118,7 @@ fn local_overrides_home() {
     assert_eq!(cfg.foo.as_deref(), Some("local"));
 }
 
+// Windows lacks XDG support
 #[cfg(any(unix, target_os = "redox"))]
 #[test]
 fn loads_from_xdg_config() {


### PR DESCRIPTION
## Summary
- ensure XDG config related tests only run on Unix and Redox

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `cargo clippy --target x86_64-pc-windows-gnu -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --target x86_64-pc-windows-gnu` *(fails: Error calling dlltool)*

------
https://chatgpt.com/codex/tasks/task_e_6854acfff69c83229d6df63c545334fc

## Summary by Sourcery

Enhancements:
- Annotate XDG config loading tests with cfg to only run on Unix and target_os = "redox"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Restricted certain configuration loading tests to run only on Unix-like systems and Redox OS, ensuring platform-appropriate test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->