### PR TITLE
Update config discovery docs

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -196,6 +196,18 @@ The implementation must be careful to wrap errors from `clap`, `figment`, and
 file IO into this enum, adding contextual information (like file paths) where
 possible.
 
+### 4.6. Configuration File Discovery
+
+On Unix-like systems and Redox, the crate uses the `xdg` crate to locate
+configuration directories. It respects `XDG_CONFIG_HOME` and falls back to
+`$HOME/.config` when the variable is unset.
+
+On Windows and other platforms, the `directories` crate provides the standard
+paths. These paths currently ignore `XDG_CONFIG_HOME` entirely.
+
+Support for `XDG_CONFIG_HOME` on Windows could be added later using
+`directories` to mimic the XDG specification.
+
 ## 5. Dependency Strategy
 
 - **`ortho_config_macros`:**

--- a/docs/design.md
+++ b/docs/design.md
@@ -203,7 +203,10 @@ configuration directories. It respects `XDG_CONFIG_HOME` and falls back to
 `$HOME/.config` when the variable is unset.
 
 On Windows and other platforms, the `directories` crate provides the standard
-paths. These paths currently ignore `XDG_CONFIG_HOME` entirely.
+paths for configuration files. On Windows this uses the Known Folder API and
+resolves to `%APPDATA%` (a.k.a. `FOLDERID_RoamingAppData`) and
+`%LOCALAPPDATA%` (`FOLDERID_LocalAppData`). The crate does not consult
+`XDG_CONFIG_HOME` at all.
 
 Support for `XDG_CONFIG_HOME` on Windows could be added later using
 `directories` to mimic the XDG specification.


### PR DESCRIPTION
## Summary
- document how config files are discovered on each platform

## Testing
- `markdownlint docs/design.md`
- `nixie docs/design.md`
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6854bac2b7108322946119b443ce41f6

## Summary by Sourcery

Documentation:
- Document configuration file discovery using the `xdg` crate on Unix-like systems with XDG_CONFIG_HOME fallback and using the `directories` crate on Windows, noting potential future XDG_CONFIG_HOME support on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new section detailing how configuration file locations are determined across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->