### PR TITLE
Fix windows home path test

### DIFF
--- a/ortho_config/tests/subcommand.rs
+++ b/ortho_config/tests/subcommand.rs
@@ -101,6 +101,8 @@ fn loads_from_home() {
         let home = j.create_dir("home")?;
         j.create_file(home.join(".app.toml"), "[cmds.test]\nfoo = \"home\"")?;
         j.set_env("HOME", home.to_str().unwrap());
+        #[cfg(windows)]
+        j.set_env("USERPROFILE", home.to_str().unwrap());
         Ok(())
     });
     assert_eq!(cfg.foo.as_deref(), Some("home"));
@@ -112,6 +114,8 @@ fn local_overrides_home() {
         let home = j.create_dir("home")?;
         j.create_file(home.join(".app.toml"), "[cmds.test]\nfoo = \"home\"")?;
         j.set_env("HOME", home.to_str().unwrap());
+        #[cfg(windows)]
+        j.set_env("USERPROFILE", home.to_str().unwrap());
         j.create_file(".app.toml", "[cmds.test]\nfoo = \"local\"")?;
         Ok(())
     });


### PR DESCRIPTION
## Summary
- ensure home directory tests set USERPROFILE for Windows

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6854bfdb7f948322b97fd59570e0c6aa

## Summary by Sourcery

Ensure home directory tests set USERPROFILE on Windows to correctly simulate the home path

Bug Fixes:
- Fix home path tests on Windows by setting the USERPROFILE environment variable

Tests:
- Update loads_from_home and local_overrides_home tests to set USERPROFILE under cfg(windows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test coverage on Windows by ensuring the home directory is correctly detected using both `HOME` and `USERPROFILE` environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->