### PR TITLE
Switch to shared Rust setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,32 +21,13 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            cache-path: |
-              ~/.cargo/registry
-              ~/.cargo/git
-              target
             coverage: true
           - os: windows-latest
-            cache-path: |
-              ~/.cargo/registry
-              ~/.cargo/git
-              target
             coverage: false
     steps:
       - uses: actions/checkout@v4
-      - name: Install rust stable
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-        with:
-            toolchain: stable
-            override: true
-            components: rustfmt, clippy
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: ${{ matrix['cache-path'] }}
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@v1
       - name: Cache CodeScene CLI
         if: matrix.coverage && env.CS_ACCESS_TOKEN
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- use the `leynos/shared-actions` setup-rust composite action
- remove unused cargo caching paths

## Testing
- `markdownlint README.md docs/*.md`
- `nixie README.md docs/*.md`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --tests`


------
https://chatgpt.com/codex/tasks/task_e_6854bf9213808322bf1b36e04f494f3a

## Summary by Sourcery

Switch GitHub CI to use a shared Rust setup action and remove manual cargo caching

CI:
- Use leynos/shared-actions/setup-rust composite action in place of actions-rs/toolchain
- Remove custom cargo registry, git, and target directory caching configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified the CI workflow for improved efficiency and maintainability. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->