### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@v1.0.2
+        uses: leynos/shared-actions/.github/actions/setup-rust@v1.0.3
       - name: Cache CodeScene CLI
         if: matrix.coverage && env.CS_ACCESS_TOKEN
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@v1
+        uses: leynos/shared-actions/.github/actions/setup-rust@v1.0.2
       - name: Cache CodeScene CLI
         if: matrix.coverage && env.CS_ACCESS_TOKEN
         uses: actions/cache@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ortho_config"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "clap-dispatch",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "ortho_config_macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Payton McIntosh <pmcintosh@df12.net>"]
 edition = "2024"
 license = "ISC"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ aliasing.
 
    ```toml
    [dependencies]
-   ortho_config = "0.2.0" # Replace with the latest version
+   ortho_config = "0.3.0" # Replace with the latest version
    serde = { version = "1.0", features = ["derive"] }
    ```
 
@@ -171,7 +171,7 @@ support additional formats:
 
 ```toml
 [dependencies]
-ortho_config = { version = "0.2.0", features = ["json5", "yaml"] }
+ortho_config = { version = "0.3.0", features = ["json5", "yaml"] }
 ```
 
 The file loader selects the parser based on the extension (`.toml`, `.json`,

--- a/docs/clap-dispatch-and-ortho-config-integration.md
+++ b/docs/clap-dispatch-and-ortho-config-integration.md
@@ -183,7 +183,7 @@ Example:
 ```rust
 use clap::Parser;
 
-#[command(name = "mytool", version = "0.2.0", about = "A tool with dispatched subcommands")]
+#[command(name = "mytool", version = "0.3.0", about = "A tool with dispatched subcommands")]
 pub enum MyToolCli {
     Encode(EncodeArgs),
     Decode(DecodeArgs),
@@ -205,7 +205,7 @@ use clap_dispatch::clap_dispatch;
 // Assuming EncodeArgs, DecodeArgs, and MyToolCli (without clap_dispatch yet) are
 defined
 
-#[command(name = "mytool", version = "0.2.0", about = "A tool with dispatched subcommands")]
+#[command(name = "mytool", version = "0.3.0", about = "A tool with dispatched subcommands")]
 pub enum MyToolCli {
     Encode(EncodeArgs),
     Decode(DecodeArgs),
@@ -312,7 +312,7 @@ pub struct DecodeArgs {
 }
 
 // 2. Define Subcommand Enum and Apply clap_dispatch
-#[command(name = "mytool", version = "0.2.0", about = "A tool with dispatched subcommands")]
+#[command(name = "mytool", version = "0.3.0", about = "A tool with dispatched subcommands")]
 pub enum MyToolCli {
     Encode(EncodeArgs),
     Decode(DecodeArgs),
@@ -427,7 +427,7 @@ pub struct ListItemsArgs {
 }
 
 // 2. Define Subcommand Enum and Apply clap_dispatch
-#[command(name = "registry-ctl", version = "0.2.0", about = "Manages a registry")]
+#[command(name = "registry-ctl", version = "0.3.0", about = "Manages a registry")]
 pub enum RegistryCommands {
     AddUser(AddUserArgs),
     ListItems(ListItemsArgs),

--- a/examples/registry_ctl.rs
+++ b/examples/registry_ctl.rs
@@ -48,7 +48,7 @@ impl Run for ListItemsArgs {
 }
 
 #[derive(Parser)]
-#[command(name = "registry-ctl", version = "0.2.0", about = "Manages a registry")]
+#[command(name = "registry-ctl", version = "0.3.0", about = "Manages a registry")]
 #[clap_dispatch(fn run(self, db_url: &str) -> Result<(), String>)]
 enum Commands {
     AddUser(AddUserArgs),

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ortho_config"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 

--- a/ortho_config_macros/Cargo.toml
+++ b/ortho_config_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ortho_config_macros"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [lints]


### PR DESCRIPTION
## Summary
- bump version numbers from 0.2.0 to 0.3.0
- update README and docs with new version
- update example version annotations

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/*.md`
- `nixie README.md docs/*.md`


------
https://chatgpt.com/codex/tasks/task_e_68552a16d79c8322a6f0ba545fe28a66

## Summary by Sourcery

Bump project version to 0.3.0 and update all version references accordingly

Documentation:
- Update README and documentation examples to reference version 0.3.0

Chores:
- Bump version in workspace and crate Cargo.toml files to 0.3.0
- Update example source files to use version 0.3.0 in clap attributes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated version numbers from "0.2.0" to "0.3.0" in user-facing documentation and code examples to reflect the latest release.

- **Chores**
  - Bumped package versions to "0.3.0" across relevant configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->