### PR TITLE
Fix unused Format import

### DIFF
--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -157,7 +157,7 @@ pub(crate) fn build_load_impl(args: &LoadImplArgs<'_>) -> proc_macro2::TokenStre
                 I::Item: AsRef<std::ffi::OsStr>,
             {
                 use clap::Parser as _;
-                use figment::{Figment, providers::{Toml, Env, Serialized, Format}, Profile};
+                use figment::{Figment, providers::{Toml, Env, Serialized}, Profile};
                 #[cfg(feature = "json5")] use figment_json5::Json5;
                 #[cfg(feature = "yaml")] use figment::providers::Yaml;
                 use uncased::Uncased;

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -116,12 +116,12 @@ pub(crate) fn build_merge_section(
         ..
     } = tokens;
     quote! {
-        let mut fig = figment::Figment::new();
+        let mut fig = Figment::new();
         let defaults = #defaults_ident { #( #default_struct_init, )* };
 
         let mut overrides = #override_init_ts;
 
-        fig = fig.merge(figment::providers::Serialized::defaults(&defaults));
+        fig = fig.merge(Serialized::defaults(&defaults));
 
         if let Some(ref f) = file_fig {
             fig = fig.merge(f);
@@ -129,11 +129,11 @@ pub(crate) fn build_merge_section(
 
         fig = fig
             .merge(env_provider.clone())
-            .merge(figment::providers::Serialized::from(&cli, figment::Profile::Default));
+            .merge(Serialized::from(&cli, Profile::Default));
 
         #append_logic
 
-        fig = fig.merge(figment::providers::Serialized::defaults(overrides));
+        fig = fig.merge(Serialized::defaults(overrides));
 
         fig.extract().map_err(ortho_config::OrthoError::Gathering)
     }


### PR DESCRIPTION
## Summary
- remove unused `Format` from figment import

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint docs/*.md`


------
https://chatgpt.com/codex/tasks/task_e_68756fc4d6688322a0b9820316afa337

## Summary by Sourcery

Bug Fixes:
- Remove unused Format import from figment providers to fix warnings