### PR TITLE
Refactor attribute parsing and type helpers

### DIFF
--- a/docs/ddlint-gap-analysis.md
+++ b/docs/ddlint-gap-analysis.md
@@ -1,8 +1,8 @@
 # Gap Analysis: OrthoConfig vs ddlint Configuration Requirements
 
-This document compares OrthoConfig's current capabilities with the
-command-line and configuration interface described in the
-[ddlint design document](https://raw.githubusercontent.com/leynos/ddlint/refs/heads/main/docs/ddlint-design-and-road-map.md).
+This document compares OrthoConfig's current capabilities with the command-line
+and configuration interface described in the [ddlint design
+document](https://raw.githubusercontent.com/leynos/ddlint/refs/heads/main/docs/ddlint-design-and-road-map.md).
 
 ## Relevant ddlint Requirements
 
@@ -26,13 +26,13 @@ ddlint explain <RULE_NAME>
 
 The configuration schema includes:
 
-> | Key | Type | Default | Description |
-> | --- | --- | --- | --- |
-> | extends | String | (none) | A path to a base configuration file. Settings from the current file will override settings from the extended file. |
-> | ignore_patterns | Array of Strings | [".git/", "build/", "target/"] | Patterns of files and directories to exclude from linting. |
-> | [rules] | Table | (empty) | Location for configuring rule severities and options. |
-> | [rules].`<rule-name>` | String | (rule default) | Sets the severity for a rule (`allow`, `warn`, or `error`). |
-> | [rules.consistent-casing] | Table | { level = "allow", relation_style = "PascalCase" } | Example of a rule with options. |
+| Key                       | Type             | Default                                            | Description                                                                                                        |
+| ------------------------- | ---------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| extends                   | String           | (none)                                             | A path to a base configuration file. Settings from the current file will override settings from the extended file. |
+| ignore_patterns           | Array of Strings | [".git/", "build/", "target/"]                     | Patterns of files and directories to exclude from linting.                                                         |
+| [rules]                   | Table            | (empty)                                            | Location for configuring rule severities and options.                                                              |
+| [rules].`<rule-name>`     | String           | (rule default)                                     | Sets the severity for a rule (`allow`, `warn`, or `error`).                                                        |
+| [rules.consistent-casing] | Table            | { level = "allow", relation_style = "PascalCase" } | Example of a rule with options.                                                                                    |
 
 ## Current OrthoConfig Features
 
@@ -42,19 +42,19 @@ earlier ones:
 1. **Application-Defined Defaults:** Specified using
    `#[ortho_config(default =...)]` or `Option<T>` fields (which default to
    `None`).
-1. **Configuration File:** Resolved in this order:
+2. **Configuration File:** Resolved in this order:
    1. `--config-path` CLI option
-   1. `[PREFIX]CONFIG_PATH` environment variable
-   1. `.<prefix>.toml` in the current directory
-   1. `.<prefix>.toml` in the user's home directory (where `<prefix>` comes from
+   2. `[PREFIX]CONFIG_PATH` environment variable
+   3. `.<prefix>.toml` in the current directory
+   4. `.<prefix>.toml` in the user's home directory (where `<prefix>` comes from
       `#[ortho_config(prefix = "...")]` and defaults to `config`). JSON5 and
       YAML support are feature gated.
-1. **Environment Variables:** Variables prefixed with the string specified in
+3. **Environment Variables:** Variables prefixed with the string specified in
    `#[ortho_config(prefix = "...")]` (e.g., `APP_`). Nested struct fields are
    typically accessed using double underscores (e.g., `APP_DATABASE__URL` if
    `prefix = "APP"` on `AppConfig` and no prefix on `DatabaseConfig`, or
    `APP_DB_URL` with `#` on `DatabaseConfig`).
-1. **Command-Line Arguments:** Parsed using `clap` conventions. Long flags are
+4. **Command-Line Arguments:** Parsed using `clap` conventions. Long flags are
    derived from field names (e.g., `my_field` becomes `--my-field`).
 
 Subcommands can load defaults from a `cmds` namespace. The helper below merges
@@ -90,11 +90,14 @@ features: Vec<String>
 
 ## Observed Gaps
 
-- [ ] **Array Environment Variables** – support comma-separated lists such as `DDLINT_RULES=A,B,C`.
-- [ ] **Extends Support** – implement an `extends` mechanism for configuration inheritance.
+- [ ] **Array Environment Variables** – support comma-separated lists such as
+  `DDLINT_RULES=A,B,C`.
+- [ ] **Extends Support** – implement an `extends` mechanism for configuration
+  inheritance.
 - [ ] **Custom Option Names** – document renaming `--config-path` to `--config`.
 - [ ] **Dynamic Rule Tables** – use a map type to accept arbitrary rule entries.
-- [ ] **Ignore Patterns** – allow comma-separated lists for environment variables.
+- [ ] **Ignore Patterns** – allow comma-separated lists for environment
+  variables.
 
 Overall, OrthoConfig covers layered loading and CLI integration. It would need
 enhancements for string list parsing and configuration extension to fully
@@ -108,8 +111,8 @@ The following steps are ordered by impact on ddlint's user experience:
    environment variables as string lists. This allows `DDLINT_RULES=A,B,C`
    without JSON syntax.
 2. **Configuration Inheritance** – design an `extends` mechanism so one file can
-   pull defaults from another. Leverage the existing layering logic described in
-   `docs/design.md`.
+   pull defaults from another. Leverage the existing layering logic described
+   in `docs/design.md`.
 3. **Flag Name Overrides** – provide examples showing how to rename
    `--config-path` to `--config` using struct field attributes.
 4. **Dynamic Tables** – explore using a map type (e.g., `BTreeMap`) to handle

--- a/ortho_config_macros/src/derive/parse.rs
+++ b/ortho_config_macros/src/derive/parse.rs
@@ -1,6 +1,9 @@
 //! Parsing utilities for the `OrthoConfig` derive macro.
 
-use syn::{Attribute, Data, DeriveInput, Expr, Fields, GenericArgument, Lit, PathArguments, Type};
+use syn::{
+    Attribute, Data, DeriveInput, Expr, Fields, GenericArgument, Lit, PathArguments, Type,
+    spanned::Spanned,
+};
 
 #[derive(Default)]
 pub(crate) struct StructAttrs {
@@ -50,8 +53,13 @@ pub(crate) fn parse_struct_attrs(attrs: &[Attribute]) -> Result<StructAttrs, syn
             } else {
                 return Err(syn::Error::new(val.span(), "prefix must be a string"));
             }
+            Ok(())
+        } else {
+            Err(syn::Error::new(
+                meta.path.span(),
+                "unexpected ortho_config key",
+            ))
         }
-        Ok(())
     })?;
     Ok(out)
 }
@@ -66,6 +74,7 @@ pub(crate) fn parse_field_attrs(attrs: &[Attribute]) -> Result<FieldAttrs, syn::
             } else {
                 return Err(syn::Error::new(val.span(), "cli_long must be a string"));
             }
+            Ok(())
         } else if meta.path.is_ident("cli_short") {
             let val = meta.value()?.parse::<Lit>()?;
             if let Lit::Char(c) = val {
@@ -73,9 +82,11 @@ pub(crate) fn parse_field_attrs(attrs: &[Attribute]) -> Result<FieldAttrs, syn::
             } else {
                 return Err(syn::Error::new(val.span(), "cli_short must be a char"));
             }
+            Ok(())
         } else if meta.path.is_ident("default") {
             let expr = meta.value()?.parse::<Expr>()?;
             out.default = Some(expr);
+            Ok(())
         } else if meta.path.is_ident("merge_strategy") {
             let val = meta.value()?.parse::<Lit>()?;
             if let Lit::Str(s) = val {
@@ -86,17 +97,42 @@ pub(crate) fn parse_field_attrs(attrs: &[Attribute]) -> Result<FieldAttrs, syn::
                     "merge_strategy must be a string",
                 ));
             }
+            Ok(())
+        } else {
+            Err(syn::Error::new(
+                meta.path.span(),
+                "unexpected ortho_config key",
+            ))
         }
-        Ok(())
     })?;
     Ok(out)
 }
 
-/// Generic extraction of `Wrapper<T>`.
+/// Returns the generic parameter if `ty` is the provided wrapper.
+///
+/// The check is shallow: it inspects only the outermost path and supports
+/// common fully-qualified forms like `std::option::Option<T>`. The function is
+/// not recursive.
 fn type_inner<'a>(ty: &'a Type, wrapper: &str) -> Option<&'a Type> {
     if let Type::Path(p) = ty {
-        if let Some(seg) = p.path.segments.last() {
-            if seg.ident == wrapper {
+        let segs: Vec<_> = p
+            .path
+            .segments
+            .iter()
+            .map(|s| s.ident.to_string())
+            .collect();
+        let matches_wrapper = match segs.as_slice() {
+            [id] => id == wrapper,
+            [first, mid, last] => {
+                (first == "std" || first == "core" || first == "alloc")
+                    && last == wrapper
+                    && ((wrapper == "Option" && mid == "option")
+                        || (wrapper == "Vec" && mid == "vec"))
+            }
+            _ => false,
+        };
+        if matches_wrapper {
+            if let Some(seg) = p.path.segments.last() {
                 if let PathArguments::AngleBracketed(args) = &seg.arguments {
                     if let Some(GenericArgument::Type(inner)) = args.args.first() {
                         return Some(inner);
@@ -108,6 +144,10 @@ fn type_inner<'a>(ty: &'a Type, wrapper: &str) -> Option<&'a Type> {
     None
 }
 
+/// Returns the inner type if `ty` is `Option<T>`.
+///
+/// This uses [`type_inner`], which is **not recursive**. It only inspects the
+/// outermost layer, so `Option<Vec<T>>` yields `Vec<T>` rather than `T`.
 pub(crate) fn option_inner(ty: &Type) -> Option<&Type> {
     type_inner(ty, "Option")
 }


### PR DESCRIPTION
## Summary
- reduce duplicated attribute parsing
- unify wrapper type extraction

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6876447b2288832294fe1be8ba36febb

## Summary by Sourcery

Refactor attribute parsing and wrapper type helpers to reduce duplication and unify logic, and improve markdown formatting in the gap analysis documentation.

Enhancements:
- Centralize `ortho_config` attribute iteration with a `parse_ortho_config` helper
- Simplify `parse_struct_attrs` and `parse_field_attrs` to use the new helper and add error handling for unexpected keys
- Unify generic wrapper type extraction by introducing `type_inner` and updating `option_inner` and `vec_inner` accordingly

Documentation:
- Refine table formatting and list numbering in docs/ddlint-gap-analysis.md