### PR TITLE
Improve Cargo cache isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       CARGO_TERM_COLOR: always
       CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
+      BUILD_PROFILE: debug
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- ensure CI cache path is scoped by build profile

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6876441e811c83229e8954a566bd7d83

## Summary by Sourcery

CI:
- Add BUILD_PROFILE environment variable set to 'debug' in the CI configuration