### PR TITLE
Fix docs and merge test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ fn main() -> Result<(), OrthoError> {
 }
 ```
 
-3. **Run the application:**
+3. **Running the application**:
 
 - With CLI arguments:
     `cargo run -- --log-level debug --port 3000 -v --features extra_cli_feature`
@@ -157,9 +157,9 @@ overriding earlier ones:
    1. `--config-path` CLI option
    2. `[PREFIX]CONFIG_PATH` environment variable
    3. `.<prefix>.toml` in the current directory
-   4. `.<prefix>.toml` in the user's home directory (where `<prefix>` comes from
-      `#[ortho_config(prefix = "...")]` and defaults to `config`). JSON5 and
-      YAML support are feature gated.
+   4. `.<prefix>.toml` in the user's home directory
+      (where `<prefix>` comes from `#[ortho_config(prefix = "…")]` and defaults
+      to `config`). JSON5 and YAML support are feature gated.
 3. **Environment Variables:** Variables prefixed with the string specified in
    `#[ortho_config(prefix = "...")]` (e.g., `APP_`). Nested struct fields are
    typically accessed using double underscores (e.g., `APP_DATABASE__URL` if

--- a/docs/clap-dispatch-and-ortho-config-integration.md
+++ b/docs/clap-dispatch-and-ortho-config-integration.md
@@ -127,10 +127,11 @@ building CLIs with dispatchable subcommands.
 
 ### A. Project Setup and Dependencies
 
-Begin by adding the required dependencies: `clap` for argument parsing (with
-the `derive` feature) and `clap-dispatch`.
+Begin by setting up the Rust project with the required dependencies. The
+project needs `clap` for argument parsing (with the `derive` feature for
+ergonomic struct-based parsing) and `clap-dispatch`.
 
-Add the following to your `Cargo.toml` file:
+Add the following to the project’s `Cargo.toml` file:
 
 ```toml
 [dependencies]
@@ -138,10 +139,10 @@ clap = { version = "4.5", features = ["derive"] } # Use a recent version of clap
 clap-dispatch = "0.1.1" # Or the latest version available on crates.io [3]
 ```
 
-Run `cargo add clap -F derive` to add `clap` with the derive feature.5
-`clap-dispatch` itself depends on crates like `syn`, `quote`, and `proc-macro2`
-for its procedural macro functionality, but these are transitive dependencies
-and do not need to be added explicitly by the end-user.3
+The command `cargo add clap -F derive` adds `clap` with the derive feature.
+`clap-dispatch` depends on crates such as `syn`, `quote`, and `proc-macro2` for
+its procedural macro functionality, but these dependencies are transitive and
+do not need to be added manually.3
 
 ### B. Defining Argument Structs with `clap::Parser`
 

--- a/docs/ddlint-gap-analysis.md
+++ b/docs/ddlint-gap-analysis.md
@@ -123,5 +123,7 @@ The following steps are ordered by impact on ddlint's user experience:
 These improvements will align OrthoConfig with ddlint's planned interface while
 maintaining compatibility with the crate's existing architecture.
 
+<!-- markdownlint-disable-next-line MD013 -->
+
 [ddlint-design]:
 https://raw.githubusercontent.com/leynos/ddlint/refs/heads/main/docs/ddlint-design-and-road-map.md


### PR DESCRIPTION
## Summary
- remove obsolete docs and update README
- clarify clap-dispatch integration guide and tweak ddlint doc
- add helpers for merging subcommand configs in tests
- use new helpers in subcommand tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687af14b058483229df43ce62cb13034

## Summary by Sourcery

Remove obsolete inline docs, refine user-facing guides, introduce test utilities for merging subcommand configurations, and update tests to use these helpers

New Features:
- Add with_merged_subcommand_cli and with_merged_subcommand_cli_for helpers to streamline merging of subcommand configs in tests

Documentation:
- Clarify and rephrase setup instructions in clap-dispatch integration guide and README
- Disable markdownlint rule and tweak formatting in ddlint-gap-analysis documentation

Tests:
- Refactor subcommand tests to use the new merging helpers and clean up related imports