### PR TITLE
Implement CSV env var support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,17 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "async-trait"
-version = "0.1.88"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,12 +111,6 @@ dependencies = [
  "rustc-demangle",
  "windows-targets",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -290,12 +273,11 @@ dependencies = [
 
 [[package]]
 name = "cucumber"
-version = "0.20.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5063d8cf24f4998ad01cac265da468a15ca682a8f4f826d50e661964e8d9b8"
+checksum = "6cd12917efc3a8b069a4975ef3cb2f2d835d42d04b3814d90838488f9dd9bf69"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "console",
  "cucumber-codegen",
@@ -320,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "cucumber-codegen"
-version = "0.20.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01091e28d1f566c8b31b67948399d2efd6c0a8f6228a9785519ed7b73f7f0aef"
+checksum = "9e19cd9e8e7cfd79fbf844eb6a7334117973c01f6bad35571262b00891e60f1c"
 dependencies = [
  "cucumber-expressions",
  "inflections",
@@ -630,11 +612,11 @@ dependencies = [
 
 [[package]]
 name = "globwalk"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "ignore",
  "walkdir",
 ]
@@ -716,7 +698,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -729,9 +711,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -788,7 +770,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "libc",
 ]
 
@@ -911,7 +893,7 @@ dependencies = [
  "figment",
  "figment-json5",
  "ortho_config_macros",
- "rstest",
+ "rstest 0.26.1",
  "serde",
  "serde_yaml",
  "thiserror 1.0.69",
@@ -928,7 +910,7 @@ version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "rstest",
+ "rstest 0.25.0",
  "syn",
 ]
 
@@ -1134,7 +1116,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -1197,8 +1179,19 @@ checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
 dependencies = [
  "futures-timer",
  "futures-util",
- "rstest_macros",
+ "rstest_macros 0.25.0",
  "rustc_version",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros 0.26.1",
 ]
 
 [[package]]
@@ -1206,6 +1199,24 @@ name = "rstest_macros"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
@@ -1240,7 +1251,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1806,7 +1817,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +77,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +109,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +143,22 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -119,7 +188,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a558b9547b590c876e46e301da15d3b0e93b0384fd50d2c7870f7ea86760df5"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -135,6 +204,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -143,7 +213,7 @@ version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -162,6 +232,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +254,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +286,77 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "cucumber"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5063d8cf24f4998ad01cac265da468a15ca682a8f4f826d50e661964e8d9b8"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "console",
+ "cucumber-codegen",
+ "cucumber-expressions",
+ "derive_more",
+ "drain_filter_polyfill",
+ "either",
+ "futures",
+ "gherkin",
+ "globwalk",
+ "humantime",
+ "inventory",
+ "itertools",
+ "lazy-regex",
+ "linked-hash-map",
+ "once_cell",
+ "pin-project",
+ "regex",
+ "sealed",
+ "smart-default",
+]
+
+[[package]]
+name = "cucumber-codegen"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01091e28d1f566c8b31b67948399d2efd6c0a8f6228a9785519ed7b73f7f0aef"
+dependencies = [
+ "cucumber-expressions",
+ "inflections",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+ "synthez",
+]
+
+[[package]]
+name = "cucumber-expressions"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d794fed319eea24246fb5f57632f7ae38d61195817b7eb659455aa5bdd7c1810"
+dependencies = [
+ "derive_more",
+ "either",
+ "nom",
+ "nom_locate",
+ "regex",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -210,6 +389,24 @@ dependencies = [
  "redox_users",
  "windows-sys",
 ]
+
+[[package]]
+name = "drain_filter_polyfill"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -262,10 +459,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -277,6 +516,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -296,9 +541,13 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -338,10 +587,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "gherkin"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b79820c0df536d1f3a089a2fa958f61cb96ce9e0f3f8f507f5a31179567755"
+dependencies = [
+ "heck 0.4.1",
+ "peg",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "textwrap",
+ "thiserror 1.0.69",
+ "typed-builder",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "hashbrown"
@@ -351,9 +647,37 @@ checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -366,16 +690,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
+
+[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inventory"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -395,6 +754,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,9 +788,15 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "libc",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -427,10 +815,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -456,13 +906,16 @@ version = "0.3.0"
 dependencies = [
  "clap",
  "clap-dispatch",
+ "cucumber",
  "directories",
  "figment",
  "figment-json5",
  "ortho_config_macros",
+ "rstest",
  "serde",
  "serde_yaml",
  "thiserror 1.0.69",
+ "tokio",
  "toml",
  "trybuild",
  "uncased",
@@ -526,6 +979,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "peg"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
+
+[[package]]
 name = "pest"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +1048,26 @@ dependencies = [
  "once_cell",
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -634,7 +1134,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -657,7 +1157,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -668,8 +1168,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -714,6 +1220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,12 +1240,18 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -742,10 +1260,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sealed"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a8caec23b7800fb97971a1c6ae365b6239aaeddfb934d6265f8505e795699d"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "semver"
@@ -831,6 +1370,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +1401,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synthez"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d2c2202510a1e186e63e596d9318c91a8cbe85cd1a56a7be0c333e5f59ec8d"
+dependencies = [
+ "syn",
+ "synthez-codegen",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-codegen"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f724aa6d44b7162f3158a57bccd871a77b39a4aef737e01bcdff41f4772c7746"
+dependencies = [
+ "syn",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bfa6ec52465e2425fd43ce5bbbe0f0b623964f7c63feb6b10980e816c654ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sealed",
+ "syn",
 ]
 
 [[package]]
@@ -873,6 +1462,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -909,6 +1519,32 @@ name = "thiserror-impl"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+dependencies = [
+ "backtrace",
+ "io-uring",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "slab",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -972,6 +1608,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe83c85a85875e8c4cb9ce4a890f05b23d38cd0d47647db7895d3d2a79566d2"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1655,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1683,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1128,7 +1806,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ readme = "README.md"
 keywords = ["config", "configuration", "cli", "env", "settings"]
 categories = ["config", "command-line-interface"]
 
+[workspace.dev-dependencies]
+cucumber = "0.20"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
 # `cargo clippy` lints configuration
 [workspace.lints.clippy]
 # make every pedantic lint emit a warning

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["config", "configuration", "cli", "env", "settings"]
 categories = ["config", "command-line-interface"]
 
 [workspace.dev-dependencies]
-cucumber = "0.20"
+cucumber = "0.21.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 # `cargo clippy` lints configuration

--- a/docs/design.md
+++ b/docs/design.md
@@ -225,7 +225,7 @@ resembles structured data. This preserves JSON syntax while allowing variables
 like `DDLINT_RULES=A,B,C` to deserialize as `["A", "B", "C"]`. Values
 containing literal commas must be wrapped in quotes or brackets to avoid being
 split. The derive macro now uses `CsvEnv` instead of `Env` so list handling is
-consistent across files, environment and CLI inputs.
+consistent across files, environment, and CLI inputs.
 
 ## 5. Dependency Strategy
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -220,11 +220,12 @@ Support for `XDG_CONFIG_HOME` on Windows could be added later using
 
 Environment variables often provide simple comma-separated strings for lists.
 The crate introduces a `CsvEnv` provider that wraps `figment::providers::Env`
-and converts such values into arrays unless the value already resembles
-structured data. This preserves JSON syntax while allowing variables like
-`DDLINT_RULES=A,B,C` to deserialize as `["A", "B", "C"]`. The derive macro now
-uses `CsvEnv` instead of `Env` so list handling is consistent across files,
-environment and CLI inputs.
+and converts comma-separated values into arrays unless the value already
+resembles structured data. This preserves JSON syntax while allowing variables
+like `DDLINT_RULES=A,B,C` to deserialize as `["A", "B", "C"]`. Values
+containing literal commas must be wrapped in quotes or brackets to avoid being
+split. The derive macro now uses `CsvEnv` instead of `Env` so list handling is
+consistent across files, environment and CLI inputs.
 
 ## 5. Dependency Strategy
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -216,6 +216,16 @@ resolves to `%APPDATA%` (a.k.a. `FOLDERID_RoamingAppData`) and `%LOCALAPPDATA%`
 Support for `XDG_CONFIG_HOME` on Windows could be added later using
 `directories` to mimic the XDG specification.
 
+### 4.7. Comma-Separated Environment Lists
+
+Environment variables often provide simple comma-separated strings for lists.
+The crate introduces a `CsvEnv` provider that wraps `figment::providers::Env`
+and converts such values into arrays unless the value already resembles
+structured data. This preserves JSON syntax while allowing variables like
+`DDLINT_RULES=A,B,C` to deserialize as `["A", "B", "C"]`. The derive macro now
+uses `CsvEnv` instead of `Env` so list handling is consistent across files,
+environment and CLI inputs.
+
 ## 5. Dependency Strategy
 
 - **`ortho_config_macros`:**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,37 +7,40 @@ references the relevant design guidance.
 
 - **Add a dedicated error for missing required values**
 
-  - [x] Introduce a `MissingRequiredValues` variant to `OrthoError` and update the
-    derive macro to check for missing required fields before deserialization.
+  - [x] Introduce a `MissingRequiredValues` variant to `OrthoError` and update
+    the derive macro to check for missing required fields before
+    deserialization.
     [[Improved Error Message Design](improved-error-message-design.md)]
 
-  - [x] Aggregate all missing fields, then generate a single, user‑friendly error
-    message listing each missing path and showing how to supply it via CLI
-    flags, environment variables and file entries.
+  - [x] Aggregate all missing fields, then generate a single, user‑friendly
+    error message listing each missing path and showing how to supply it via
+    CLI flags, environment variables and file entries.
     [[Improved Error Message Design](improved-error-message-design.md)]
 
-  - [x] Write unit and `trybuild` tests to ensure the new error behaves correctly.
+  - [x] Write unit and `trybuild` tests to ensure the new error behaves
+    correctly.
     [[Improved Error Message Design](improved-error-message-design.md)]
 
 - **Implement comma‑separated list parsing for environment variables**
 
-  - [ ] Update the env provider or derive macro to accept comma‑separated values
+  - [x] Update the env provider or derive macro to accept comma‑separated values
     for array fields, allowing syntax such as `DDLINT_RULES=A,B,C`.
     [[DDLint Gap Analysis](ddlint-gap-analysis.md)]
 
-  - [ ] Ensure consistent handling of list values across environment variables, CLI
-    arguments and configuration files.
+  - [x] Ensure consistent handling of list values across environment variables,
+    CLI arguments and configuration files.
 
 - **Add configuration inheritance (extends)**
 
-  - [ ] Design and implement an `extends` key for configuration files so a config
-    can inherit from a base file, with current settings overriding those from
-    the base. [[DDLint Gap Analysis](ddlint-gap-analysis.md)]
+  - [ ] Design and implement an `extends` key for configuration files so a
+    config can inherit from a base file, with current settings overriding those
+    from the base. [[DDLint Gap Analysis](ddlint-gap-analysis.md)]
 
-  - [ ] Define the layering semantics (base file → extended file → env → CLI) and
-    update the loader accordingly.
+  - [ ] Define the layering semantics (base file → extended file → env → CLI)
+    and update the loader accordingly.
 
-  - [ ] Document how inheritance interacts with prefixes and subcommand namespaces.
+  - [ ] Document how inheritance interacts with prefixes and subcommand
+    namespaces.
 
 - **Support custom option names for the configuration path**
 
@@ -53,27 +56,28 @@ references the relevant design guidance.
     structs to support dynamic rule tables such as `[rules.consistent-casing]`.
     [[DDLint Gap Analysis](ddlint-gap-analysis.md)]
 
-  - [ ] Ensure these maps deserialise correctly from files, environment variables
-    and CLI.
+  - [ ] Ensure these maps deserialise correctly from files, environment
+    variables and CLI.
 
 - **Implement ignore‑pattern list handling**
 
-  - [ ] Provide support for ignore pattern lists using comma‑separated environment
-    variables and CLI flags. [[DDLint Gap Analysis](ddlint-gap-analysis.md)]
+  - [ ] Provide support for ignore pattern lists using comma‑separated
+    environment variables and CLI flags.
+    [[DDLint Gap Analysis](ddlint-gap-analysis.md)]
 
   - [ ] Document the precedence rules and the relationship to defaults (e.g.
     `[".git/", "build/", "target/"]`).
 
 - **Refine subcommand merging behaviour**
 
-  - [ ] Simplify `load_and_merge` for subcommands to merge CLI‑provided values over
-    file/env defaults without requiring all fields to exist in the
+  - [ ] Simplify `load_and_merge` for subcommands to merge CLI‑provided values
+    over file/env defaults without requiring all fields to exist in the
     lower‑precedence layers.
     [[Subcommand Refinements](subcommand-refinements.md)]
 
-  - [ ] Remove the need for workarounds such as `load_with_reference_fallback` in
-    client applications by ensuring missing required values can be satisfied by
-    the already‑parsed CLI struct.
+  - [ ] Remove the need for workarounds such as `load_with_reference_fallback`
+    in client applications by ensuring missing required values can be satisfied
+    by the already‑parsed CLI struct.
     [[Subcommand Refinements](subcommand-refinements.md)]
 
   - [ ] Deprecate and eventually remove `load_subcommand_config` and its `_for`
@@ -81,15 +85,15 @@ references the relevant design guidance.
 
 - **Finish** `clap` **integration in the derive macro**
 
-  - [ ] Generate a hidden `clap::Parser` struct that automatically derives long and
-    short option names from field names (snake_case → kebab‑case) unless
+  - [ ] Generate a hidden `clap::Parser` struct that automatically derives long
+    and short option names from field names (snake_case → kebab‑case) unless
     overridden via `#[ortho_config(cli_long = "...")]`. [[Design](design.md)]
 
   - [ ] Ensure the macro sets appropriate `#[clap(long, short)]` attributes and
     respects default values specified in struct attributes.
 
-  - [ ] Confirm that CLI arguments override environment variables and file values
-    in the correct order. [[Design](design.md)]
+  - [ ] Confirm that CLI arguments override environment variables and file
+    values in the correct order. [[Design](design.md)]
 
 - **Improve merging and error reporting when combining CLI and configuration
   sources**
@@ -103,8 +107,8 @@ references the relevant design guidance.
     deserialization into a coherent `OrthoError` chain.
     [[Clap Dispatch](clap-dispatch-and-ortho-config-integration.md)]
 
-  - [ ] Consider interactions with `#[clap(flatten)]` and nested argument structs
-    to ensure predictable behaviour.
+  - [ ] Consider interactions with `#[clap(flatten)]` and nested argument
+    structs to ensure predictable behaviour.
     [[Clap Dispatch](clap-dispatch-and-ortho-config-integration.md)]
 
 - **Enhance documentation and examples**
@@ -113,8 +117,8 @@ references the relevant design guidance.
     extends, comma‑separated lists, dynamic tables and ignore patterns.
     [[Design](design.md)]
 
-  - [ ] Provide worked examples demonstrating how to rename the config path flag,
-    how to use subcommand defaults via the `cmds` namespace, and how to
+  - [ ] Provide worked examples demonstrating how to rename the config path
+    flag, how to use subcommand defaults via the `cmds` namespace, and how to
     interpret improved error messages.
 
 - **Address future enhancements**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,7 +32,7 @@ references the relevant design guidance.
 
 - **Add configuration inheritance (extends)**
 
-  - [ ] Design and implement an `extends` key for configuration files so a
+  - [ ] Design and implement an `extends` key for configuration files, so a
     config can inherit from a base file, with current settings overriding those
     from the base. [[DDLint Gap Analysis](ddlint-gap-analysis.md)]
 
@@ -87,7 +87,7 @@ references the relevant design guidance.
 
   - [ ] Generate a hidden `clap::Parser` struct that automatically derives long
     and short option names from field names (snake_case → kebab‑case) unless
-    overridden via `#[ortho_config(cli_long = "...")]`. [[Design](design.md)]
+    overridden via `#[ortho_config(cli_long = "…")]`. [[Design](design.md)]
 
   - [ ] Ensure the macro sets appropriate `#[clap(long, short)]` attributes and
     respects default values specified in struct attributes.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -256,6 +256,8 @@ own prefix (`DB`), then the environment variable becomes `APP_DB_URL`.
 Comma-separated values such as `DDLINT_RULES=A,B,C` are parsed as lists. The
 loader converts these strings into arrays before merging so array fields behave
 the same across environment variables, CLI arguments and configuration files.
+Values containing literal commas must be wrapped in quotes or brackets to
+disable list parsing.
 
 ## Subcommand configuration
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -254,10 +254,10 @@ example above, valid environment variables include `APP_LOG_LEVEL`, `APP_PORT`,
 own prefix (`DB`), then the environment variable becomes `APP_DB_URL`.
 
 Comma-separated values such as `DDLINT_RULES=A,B,C` are parsed as lists. The
-loader converts these strings into arrays before merging so array fields behave
-the same across environment variables, CLI arguments and configuration files.
-Values containing literal commas must be wrapped in quotes or brackets to
-disable list parsing.
+loader converts these strings into arrays before merging, so array fields
+behave the same across environment variables, CLI arguments and configuration
+files. Values containing literal commas must be wrapped in quotes or brackets
+to disable list parsing.
 
 ## Subcommand configuration
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -253,6 +253,10 @@ example above, valid environment variables include `APP_LOG_LEVEL`, `APP_PORT`,
 `APP_DATABASE__URL` and `APP_DATABASE__POOL_SIZE`. If the nested struct has its
 own prefix (`DB`), then the environment variable becomes `APP_DB_URL`.
 
+Comma-separated values such as `DDLINT_RULES=A,B,C` are parsed as lists. The
+loader converts these strings into arrays before merging so array fields behave
+the same across environment variables, CLI arguments and configuration files.
+
 ## Subcommand configuration
 
 Many CLI applications use `clap` subcommands to perform different operations.

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -35,3 +35,10 @@ yaml = ["figment/yaml", "dep:serde_yaml"]
 figment = { version = "0.10", features = ["toml", "env"] }
 serde = { version = "1", features = ["derive"] }
 trybuild = "1"
+cucumber = "0.20"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+rstest = "0.25.0"
+
+[[test]]
+name = "cucumber"
+harness = false

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -35,9 +35,9 @@ yaml = ["figment/yaml", "dep:serde_yaml"]
 figment = { version = "0.10", features = ["toml", "env"] }
 serde = { version = "1", features = ["derive"] }
 trybuild = "1"
-cucumber = "0.20"
+cucumber = "0.21.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-rstest = "0.25.0"
+rstest = "0.26.1"
 
 [[test]]
 name = "cucumber"

--- a/ortho_config/src/csv_env.rs
+++ b/ortho_config/src/csv_env.rs
@@ -1,0 +1,115 @@
+//! Environment provider that parses comma-separated lists.
+//!
+//! Wraps `figment::providers::Env` and converts values containing commas
+//! into arrays unless they look like structured data (starting with `[` or
+//! `{` or a quote). This allows environment variables such as
+//! `DDLINT_RULES=A,B,C` to be deserialised as `Vec<String>`.
+
+use figment::providers::Env;
+use figment::{
+    Profile, Provider,
+    error::Error,
+    util::nest,
+    value::{Dict, Map, Value},
+};
+use uncased::{Uncased, UncasedStr};
+
+/// Environment provider with CSV list support.
+#[derive(Clone)]
+pub struct CsvEnv {
+    inner: Env,
+}
+
+impl CsvEnv {
+    /// Create an unprefixed provider.
+    #[must_use]
+    pub fn raw() -> Self {
+        Self { inner: Env::raw() }
+    }
+
+    /// Create a provider using `prefix`.
+    #[must_use]
+    pub fn prefixed(prefix: &str) -> Self {
+        Self {
+            inner: Env::prefixed(prefix),
+        }
+    }
+
+    /// Split keys at `pattern`.
+    #[must_use]
+    pub fn split(self, pattern: &str) -> Self {
+        Self {
+            inner: self.inner.split(pattern),
+        }
+    }
+
+    /// Map keys using `mapper`.
+    #[must_use]
+    pub fn map<F>(self, mapper: F) -> Self
+    where
+        F: Fn(&UncasedStr) -> Uncased<'_> + Clone + 'static,
+    {
+        Self {
+            inner: self.inner.map(mapper),
+        }
+    }
+
+    /// Filter and map keys using `f`.
+    #[must_use]
+    pub fn filter_map<F>(self, f: F) -> Self
+    where
+        F: Fn(&UncasedStr) -> Option<Uncased<'_>> + Clone + 'static,
+    {
+        Self {
+            inner: self.inner.filter_map(f),
+        }
+    }
+
+    /// Whether to lowercase keys before emitting them.
+    #[must_use]
+    pub fn lowercase(self, lowercase: bool) -> Self {
+        Self {
+            inner: self.inner.lowercase(lowercase),
+        }
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (Uncased<'static>, String)> + '_ {
+        self.inner.iter()
+    }
+}
+
+impl Provider for CsvEnv {
+    fn metadata(&self) -> figment::Metadata {
+        self.inner.metadata()
+    }
+
+    fn profile(&self) -> Option<Profile> {
+        Some(self.inner.profile.clone())
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, Error> {
+        let mut dict = Dict::new();
+        for (k, v) in self.iter() {
+            let trimmed = v.trim();
+            let value = if trimmed.contains(',')
+                && !trimmed.starts_with('[')
+                && !trimmed.starts_with('{')
+                && !trimmed.starts_with('"')
+                && !trimmed.starts_with('\'')
+            {
+                let arr = trimmed
+                    .split(',')
+                    .map(|s| Value::from(s.trim().to_string()))
+                    .collect::<Vec<_>>();
+                Value::from(arr)
+            } else {
+                v.parse().expect("infallible")
+            };
+            let nested = nest(k.as_str(), value)
+                .into_dict()
+                .expect("key is non-empty: must have dict");
+            dict.extend(nested);
+        }
+        Ok(self.inner.profile.collect(dict))
+    }
+}

--- a/ortho_config/src/csv_env.rs
+++ b/ortho_config/src/csv_env.rs
@@ -17,8 +17,12 @@ use std::ops::Deref;
 use uncased::{Uncased, UncasedStr};
 
 /// Environment provider with CSV list support.
+///
+/// Wraps the standard [`Env`] provider to interpret comma-separated
+/// values as arrays, whilst leaving JSON strings untouched.
 #[derive(Clone)]
 pub struct CsvEnv {
+    /// Inner environment provider that performs the actual variable access.
     inner: Env,
 }
 

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub use ortho_config_macros::OrthoConfig;
 
+mod csv_env;
 mod error;
 mod file;
 mod merge;
@@ -25,6 +26,7 @@ pub fn normalize_prefix(prefix: &str) -> String {
     prefix.trim_end_matches('_').to_ascii_lowercase()
 }
 
+pub use csv_env::CsvEnv;
 pub use error::OrthoError;
 pub use file::load_config_file;
 

--- a/ortho_config/tests/csv_env.rs
+++ b/ortho_config/tests/csv_env.rs
@@ -1,0 +1,24 @@
+//! Tests for the `CsvEnv` provider.
+
+use figment::Figment;
+use ortho_config::CsvEnv;
+use rstest::rstest;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, serde::Serialize)]
+struct Cfg {
+    values: Vec<String>,
+}
+
+#[rstest]
+#[case("A,B,C", vec!["A", "B", "C"])]
+#[case("[\"x\",\"y\"]", vec!["x", "y"])]
+fn parses_lists(#[case] raw: &str, #[case] expected: Vec<&str>) {
+    figment::Jail::expect_with(|j| {
+        j.set_env("VALUES", raw);
+        let cfg: Cfg = Figment::from(CsvEnv::raw()).extract().expect("extract");
+        let want: Vec<String> = expected.into_iter().map(str::to_string).collect();
+        assert_eq!(cfg.values, want);
+        Ok(())
+    });
+}

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -1,17 +1,30 @@
+//! Cucumber-based integration tests for `ortho_config`.
+//!
+//! Exercises end-to-end configuration loading using [`CsvEnv`] and the
+//! derive macro.
+
 use clap::Parser;
 use cucumber::World as _;
 use ortho_config::OrthoConfig;
 use serde::{Deserialize, Serialize};
 
+/// Test world state shared between Cucumber steps.
 #[derive(Debug, Default, cucumber::World)]
 pub struct World {
+    /// Environment variable value set during the scenario.
     env_value: Option<String>,
+    /// Result of attempting to load configuration.
     pub result: Option<Result<RulesConfig, ortho_config::OrthoError>>,
 }
 
+/// Configuration struct used in integration tests.
+///
+/// The `DDLINT_` prefix is applied to environment variables and rule lists may
+/// be specified as comma-separated strings via [`CsvEnv`].
 #[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig, Default)]
 #[ortho_config(prefix = "DDLINT_")]
 pub struct RulesConfig {
+    /// List of lint rules parsed from CLI or environment.
     #[arg(long)]
     rules: Vec<String>,
 }

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+use cucumber::World as _;
+use ortho_config::OrthoConfig;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, cucumber::World)]
+pub struct World {
+    env_value: Option<String>,
+    pub result: Option<Result<RulesConfig, ortho_config::OrthoError>>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig, Default)]
+#[ortho_config(prefix = "DDLINT_")]
+pub struct RulesConfig {
+    #[arg(long)]
+    rules: Vec<String>,
+}
+
+mod steps;
+
+#[tokio::main]
+async fn main() {
+    World::run("tests/features").await;
+}

--- a/ortho_config/tests/features/csv_env.feature
+++ b/ortho_config/tests/features/csv_env.feature
@@ -1,0 +1,5 @@
+Feature: Comma-separated environment lists
+  Scenario: parse environment variable into list
+    Given the environment variable DDLINT_RULES is "A,B,C"
+    When the configuration is loaded
+    Then the rules are "A,B,C"

--- a/ortho_config/tests/steps/env_steps.rs
+++ b/ortho_config/tests/steps/env_steps.rs
@@ -1,0 +1,29 @@
+use crate::{RulesConfig, World};
+use clap::Parser;
+use cucumber::{given, then, when};
+
+#[given(expr = "the environment variable DDLINT_RULES is {string}")]
+fn set_env(world: &mut World, val: String) {
+    world.env_value = Some(val);
+}
+
+#[when("the configuration is loaded")]
+fn load_config(world: &mut World) {
+    let val = world.env_value.clone().expect("env value");
+    let mut result = None;
+    figment::Jail::expect_with(|j| {
+        j.set_env("DDLINT_RULES", &val);
+        let cli = RulesConfig::parse_from(["prog"]);
+        result = Some(cli.load_and_merge());
+        Ok(())
+    });
+    world.result = result;
+}
+
+#[then(expr = "the rules are {string}")]
+#[allow(clippy::needless_pass_by_value)]
+fn check_rules(world: &mut World, expected: String) {
+    let cfg = world.result.take().expect("result").expect("ok");
+    let want: Vec<String> = expected.split(',').map(str::to_string).collect();
+    assert_eq!(cfg.rules, want);
+}

--- a/ortho_config/tests/steps/env_steps.rs
+++ b/ortho_config/tests/steps/env_steps.rs
@@ -1,7 +1,13 @@
+//! Cucumber step definitions for environment variable testing.
+//!
+//! Provides BDD steps for setting environment variables, loading configuration
+//! using [`CsvEnv`], and verifying parsed results.
+
 use crate::{RulesConfig, World};
 use clap::Parser;
 use cucumber::{given, then, when};
 
+/// Sets `DDLINT_RULES` in the test environment.
 #[given(expr = "the environment variable DDLINT_RULES is {string}")]
 fn set_env(world: &mut World, val: String) {
     world.env_value = Some(val);
@@ -21,7 +27,11 @@ fn load_config(world: &mut World) {
 }
 
 #[then(expr = "the rules are {string}")]
-#[allow(clippy::needless_pass_by_value)]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step signature requires owned String"
+)]
+/// Verifies that the parsed rule list matches the expected string.
 fn check_rules(world: &mut World, expected: String) {
     let cfg = world.result.take().expect("result").expect("ok");
     let want: Vec<String> = expected.split(',').map(str::to_string).collect();

--- a/ortho_config/tests/steps/mod.rs
+++ b/ortho_config/tests/steps/mod.rs
@@ -1,0 +1,1 @@
+pub mod env_steps;

--- a/ortho_config_macros/src/derive/build.rs
+++ b/ortho_config_macros/src/derive/build.rs
@@ -60,9 +60,9 @@ pub(crate) fn build_default_struct_init(
 
 pub(crate) fn build_env_provider(struct_attrs: &StructAttrs) -> proc_macro2::TokenStream {
     if let Some(prefix) = &struct_attrs.prefix {
-        quote! { Env::prefixed(#prefix) }
+        quote! { ortho_config::CsvEnv::prefixed(#prefix) }
     } else {
-        quote! { Env::raw() }
+        quote! { ortho_config::CsvEnv::raw() }
     }
 }
 
@@ -220,7 +220,10 @@ mod tests {
     fn env_provider_tokens() {
         let (_, _, struct_attrs) = demo_input();
         let ts = build_env_provider(&struct_attrs);
-        assert_eq!(ts.to_string(), "Env :: prefixed (\"CFG_\")");
+        assert_eq!(
+            ts.to_string(),
+            "ortho_config :: CsvEnv :: prefixed (\"CFG_\")"
+        );
     }
 
     #[test]

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -151,7 +151,8 @@ pub(crate) fn build_load_impl(args: &LoadImplArgs<'_>) -> proc_macro2::TokenStre
             where
                 Self: serde::Serialize,
             {
-                use figment::{Figment, providers::{Toml, Env, Serialized}, Profile};
+                use figment::{Figment, providers::{Toml, Serialized}, Profile};
+                use ortho_config::CsvEnv as Env;
                 #[cfg(feature = "json5")] use figment_json5::Json5;
                 #[cfg(feature = "yaml")] use figment::providers::Yaml;
                 use uncased::Uncased;

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -152,7 +152,7 @@ pub(crate) fn build_load_impl(args: &LoadImplArgs<'_>) -> proc_macro2::TokenStre
                 Self: serde::Serialize,
             {
                 use figment::{Figment, providers::{Toml, Serialized}, Profile};
-                use ortho_config::CsvEnv as Env;
+                use ortho_config::CsvEnv;
                 #[cfg(feature = "json5")] use figment_json5::Json5;
                 #[cfg(feature = "yaml")] use figment::providers::Yaml;
                 use uncased::Uncased;


### PR DESCRIPTION
## Summary
- add `CsvEnv` provider to parse comma-separated lists
- use new provider in macro-generated loaders
- document environment list handling
- update roadmap entry
- add unit and behavioural tests for CSV env parsing

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(failed: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_688701b6931c832290461ab0984b2d27

## Summary by Sourcery

Implement CSV environment variable list support by adding a CsvEnv provider, integrating it into the derive macro, updating documentation, and adding unit and BDD tests.

New Features:
- Introduce CsvEnv provider to parse comma-separated environment variables into arrays and replace the default Env provider in macro-generated loaders.

Documentation:
- Document comma-separated environment list handling in the design specification, user guide, and update the roadmap entry.

Tests:
- Add unit tests for CsvEnv and Cucumber BDD tests for end-to-end CSV env var parsing, including new test dependencies (cucumber, rstest, tokio) in Cargo.toml.