### PR TITLE
Implement configuration inheritance

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -229,6 +229,25 @@ containing literal commas must be wrapped in quotes or brackets to avoid being
 split. The derive macro now uses `CsvEnv` instead of `Env` so list handling is
 consistent across files, environment, and CLI inputs.
 
+### 4.8. Configuration Inheritance
+
+Some projects require a base configuration that can be extended by other files.
+A configuration file may specify an `extends` key whose value is a relative or
+absolute path to another file. When present, the loader first loads the
+referenced file and then merges the current file over it. The path is resolved
+relative to the file containing the `extends` key. The loader detects cycles
+and reports a `CyclicExtends` error listing the chain of files.
+
+Precedence across all sources becomes:
+
+1. Base file specified via `extends`
+2. The extending file itself
+3. Environment variables
+4. Command‑line arguments
+
+Prefixes and subcommand namespaces are applied at each layer just as they would
+be without inheritance.
+
 ## 5. Dependency Strategy
 
 - **`ortho_config_macros`:**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,14 +32,14 @@ references the relevant design guidance.
 
 - **Add configuration inheritance (extends)**
 
-  - [ ] Design and implement an `extends` key for configuration files, so a
+  - [x] Design and implement an `extends` key for configuration files, so a
     config can inherit from a base file, with current settings overriding those
     from the base. [[DDLint Gap Analysis](ddlint-gap-analysis.md)]
 
-  - [ ] Define the layering semantics (base file → extended file → env → CLI)
+  - [x] Define the layering semantics (base file → extended file → env → CLI)
     and update the loader accordingly.
 
-  - [ ] Document how inheritance interacts with prefixes and subcommand
+  - [x] Document how inheritance interacts with prefixes and subcommand
     namespaces.
 
 - **Support custom option names for the configuration path**

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -259,6 +259,16 @@ behave the same across environment variables, CLI arguments and configuration
 files. Values containing literal commas must be wrapped in quotes or brackets
 to disable list parsing.
 
+## Configuration inheritance
+
+A configuration file may specify an `extends` key pointing to another file. The
+referenced file is loaded first and the current file's values override it. The
+path is resolved relative to the file containing the `extends` directive.
+Precedence across all sources becomes base file → extending file → environment
+variables → CLI flags. Cycles are detected and reported via a `CyclicExtends`
+error. Prefix handling and subcommand namespaces work as normal when
+inheritance is in use.
+
 ## Subcommand configuration
 
 Many CLI applications use `clap` subcommands to perform different operations.

--- a/ortho_config/src/error.rs
+++ b/ortho_config/src/error.rs
@@ -18,6 +18,10 @@ pub enum OrthoError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    /// Cycle detected while resolving `extends`.
+    #[error("cyclic extends detected: {cycle}")]
+    CyclicExtends { cycle: String },
+
     /// Error while gathering configuration from providers.
     #[error("Failed to gather configuration: {0}")]
     Gathering(#[from] figment::Error),

--- a/ortho_config/src/file.rs
+++ b/ortho_config/src/file.rs
@@ -10,24 +10,23 @@ use figment::{
 #[cfg(feature = "json5")]
 use figment_json5::Json5;
 
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
-/// Load configuration from a file, selecting the parser based on extension.
+/// Parse configuration data according to the file extension.
 ///
-/// Returns `Ok(None)` if the file does not exist.
+/// Supported formats are JSON5, YAML and TOML. The `json5` and `yaml`
+/// features must be enabled for those formats to be parsed.
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if reading or parsing the file fails.
-#[allow(clippy::result_large_err)]
-pub fn load_config_file(path: &Path) -> Result<Option<Figment>, OrthoError> {
-    if !path.is_file() {
-        return Ok(None);
-    }
-    let data = std::fs::read_to_string(path).map_err(|e| OrthoError::File {
-        path: path.to_path_buf(),
-        source: Box::new(e),
-    })?;
+/// Returns an [`OrthoError`] if the file contents fail to parse or if the
+/// required feature is disabled.
+#[expect(
+    clippy::result_large_err,
+    reason = "Error type is library specific and intentionally large"
+)]
+fn parse_config_by_format(path: &Path, data: &str) -> Result<Figment, OrthoError> {
     let ext = path
         .extension()
         .and_then(|e| e.to_str())
@@ -36,7 +35,7 @@ pub fn load_config_file(path: &Path) -> Result<Option<Figment>, OrthoError> {
         Some("json" | "json5") => {
             #[cfg(feature = "json5")]
             {
-                Figment::from(Json5::string(&data))
+                Figment::from(Json5::string(data))
             }
             #[cfg(not(feature = "json5"))]
             {
@@ -50,11 +49,11 @@ pub fn load_config_file(path: &Path) -> Result<Option<Figment>, OrthoError> {
         Some("yaml") | Some("yml") => {
             #[cfg(feature = "yaml")]
             {
-                serde_yaml::from_str::<serde_yaml::Value>(&data).map_err(|e| OrthoError::File {
+                serde_yaml::from_str::<serde_yaml::Value>(data).map_err(|e| OrthoError::File {
                     path: path.to_path_buf(),
                     source: Box::new(e),
                 })?;
-                Figment::from(Yaml::string(&data))
+                Figment::from(Yaml::string(data))
             }
             #[cfg(not(feature = "yaml"))]
             {
@@ -65,12 +64,122 @@ pub fn load_config_file(path: &Path) -> Result<Option<Figment>, OrthoError> {
             }
         }
         _ => {
-            toml::from_str::<toml::Value>(&data).map_err(|e| OrthoError::File {
+            toml::from_str::<toml::Value>(data).map_err(|e| OrthoError::File {
                 path: path.to_path_buf(),
                 source: Box::new(e),
             })?;
-            Figment::from(Toml::string(&data))
+            Figment::from(Toml::string(data))
         }
     };
-    Ok(Some(figment))
+
+    Ok(figment)
+}
+
+/// Apply inheritance using the `extends` key.
+///
+/// The referenced file is loaded first and the current [`Figment`] is merged
+/// over it. Cycles are detected using `visited`.
+///
+/// # Errors
+///
+/// Returns an [`OrthoError`] if the extended file fails to load or the `extends`
+/// key is malformed.
+#[expect(clippy::result_large_err, reason = "propagating file loading errors")]
+fn process_extends(
+    mut figment: Figment,
+    current_path: &Path,
+    visited: &mut HashSet<PathBuf>,
+    stack: &mut Vec<PathBuf>,
+) -> Result<Figment, OrthoError> {
+    match figment.find_value("extends") {
+        Ok(val) => {
+            let base = val.as_str().ok_or_else(|| OrthoError::File {
+                path: current_path.to_path_buf(),
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "'extends' key must be a string",
+                )),
+            })?;
+
+            let parent = current_path.parent().ok_or_else(|| OrthoError::File {
+                path: current_path.to_path_buf(),
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "Cannot determine parent directory for config file when resolving 'extends'",
+                )),
+            })?;
+
+            let base_path = if Path::new(base).is_absolute() {
+                PathBuf::from(base)
+            } else {
+                parent.join(base)
+            };
+
+            let canonical = std::fs::canonicalize(&base_path).map_err(|e| OrthoError::File {
+                path: base_path.clone(),
+                source: Box::new(e),
+            })?;
+
+            if let Some(base_fig) = load_config_file_inner(&canonical, visited, stack)? {
+                figment = base_fig.merge(figment);
+            }
+            Ok(figment)
+        }
+        Err(e) if e.missing() => Ok(figment),
+        Err(e) => Err(OrthoError::File {
+            path: current_path.to_path_buf(),
+            source: Box::new(e),
+        }),
+    }
+}
+
+/// Load configuration from a file, selecting the parser based on extension.
+///
+/// Returns `Ok(None)` if the file does not exist.
+///
+/// # Errors
+///
+/// Returns an [`OrthoError`] if reading or parsing the file fails.
+#[expect(
+    clippy::result_large_err,
+    reason = "Error type is large but returned directly"
+)]
+pub fn load_config_file(path: &Path) -> Result<Option<Figment>, OrthoError> {
+    let mut visited = HashSet::new();
+    let mut stack = Vec::new();
+    load_config_file_inner(path, &mut visited, &mut stack)
+}
+
+#[expect(clippy::result_large_err, reason = "propagating parsing and IO errors")]
+fn load_config_file_inner(
+    path: &Path,
+    visited: &mut HashSet<PathBuf>,
+    stack: &mut Vec<PathBuf>,
+) -> Result<Option<Figment>, OrthoError> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let canonical = std::fs::canonicalize(path).map_err(|e| OrthoError::File {
+        path: path.to_path_buf(),
+        source: Box::new(e),
+    })?;
+    if !visited.insert(canonical.clone()) {
+        let mut cycle: Vec<String> = stack.iter().map(|p| p.display().to_string()).collect();
+        cycle.push(canonical.display().to_string());
+        return Err(OrthoError::CyclicExtends {
+            cycle: cycle.join(" -> "),
+        });
+    }
+    stack.push(canonical.clone());
+    let result = (|| {
+        let data = std::fs::read_to_string(&canonical).map_err(|e| OrthoError::File {
+            path: canonical.clone(),
+            source: Box::new(e),
+        })?;
+        let figment = parse_config_by_format(&canonical, &data)?;
+        process_extends(figment, &canonical, visited, stack)
+    })();
+    visited.remove(&canonical);
+    stack.pop();
+    result.map(Some)
 }

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -13,6 +13,12 @@ use serde::{Deserialize, Serialize};
 pub struct World {
     /// Environment variable value set during the scenario.
     env_value: Option<String>,
+    /// Whether the scenario requires an extended configuration file.
+    extends: bool,
+    /// Whether to create a cyclic inheritance scenario.
+    cyclic: bool,
+    /// Whether the base file is missing.
+    missing_base: bool,
     /// Result of attempting to load configuration.
     pub result: Option<Result<RulesConfig, ortho_config::OrthoError>>,
 }

--- a/ortho_config/tests/extends.rs
+++ b/ortho_config/tests/extends.rs
@@ -1,0 +1,62 @@
+//! Tests for configuration inheritance using the `extends` key.
+
+use clap::Parser;
+use ortho_config::{OrthoConfig, OrthoError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+struct ExtendsCfg {
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    foo: Option<String>,
+}
+
+#[test]
+fn extended_file_overrides_base() {
+    figment::Jail::expect_with(|j| {
+        j.create_file("base.toml", "foo = \"base\"")?;
+        j.create_file(".config.toml", "extends = \"base.toml\"\nfoo = \"child\"")?;
+        let cli = ExtendsCfg::parse_from(["prog"]);
+        let cfg = cli.load_and_merge().expect("load");
+        assert_eq!(cfg.foo.as_deref(), Some("child"));
+        Ok(())
+    });
+}
+
+#[test]
+fn env_and_cli_override_extended_file() {
+    figment::Jail::expect_with(|j| {
+        j.create_file("base.toml", "foo = \"base\"")?;
+        j.create_file(".config.toml", "extends = \"base.toml\"\nfoo = \"file\"")?;
+        j.set_env("FOO", "env");
+        let cli = ExtendsCfg::parse_from(["prog", "--foo", "cli"]);
+        let cfg = cli.load_and_merge().expect("load");
+        assert_eq!(cfg.foo.as_deref(), Some("cli"));
+        Ok(())
+    });
+}
+
+#[test]
+fn cyclic_inheritance_is_detected() {
+    figment::Jail::expect_with(|j| {
+        j.create_file("a.toml", "extends = \"b.toml\"\nfoo = \"a\"")?;
+        j.create_file("b.toml", "extends = \"a.toml\"\nfoo = \"b\"")?;
+        j.create_file(".config.toml", "extends = \"a.toml\"")?;
+        let cli = ExtendsCfg::parse_from(["prog"]);
+        let err = cli.load_and_merge().unwrap_err();
+        assert!(matches!(err, OrthoError::CyclicExtends { .. }));
+        Ok(())
+    });
+}
+
+#[test]
+fn missing_base_file_errors() {
+    figment::Jail::expect_with(|j| {
+        j.create_file(".config.toml", "extends = \"missing.toml\"")?;
+        let cli = ExtendsCfg::parse_from(["prog"]);
+        let err = cli.load_and_merge().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("missing.toml"));
+        Ok(())
+    });
+}

--- a/ortho_config/tests/features/extends.feature
+++ b/ortho_config/tests/features/extends.feature
@@ -1,0 +1,15 @@
+Feature: Configuration inheritance
+  Scenario: load config from base file
+    Given a configuration file extending a base file
+    When the extended configuration is loaded
+    Then the rules are "child"
+
+  Scenario: cyclic inheritance error
+    Given a configuration file with cyclic inheritance
+    When the cyclic configuration is loaded
+    Then an error occurs
+
+  Scenario: missing base file error
+    Given a configuration file extending a missing base file
+    When the configuration with missing base is loaded
+    Then an error occurs

--- a/ortho_config/tests/steps/extends_steps.rs
+++ b/ortho_config/tests/steps/extends_steps.rs
@@ -1,0 +1,75 @@
+//! Steps for testing configuration inheritance.
+
+use crate::{RulesConfig, World};
+use clap::Parser;
+use cucumber::{given, then, when};
+
+#[given("a configuration file extending a base file")]
+fn create_files(world: &mut World) {
+    world.extends = true;
+}
+
+#[given("a configuration file with cyclic inheritance")]
+fn create_cyclic(world: &mut World) {
+    world.cyclic = true;
+}
+
+#[given("a configuration file extending a missing base file")]
+fn create_missing_base(world: &mut World) {
+    world.missing_base = true;
+}
+
+#[when("the extended configuration is loaded")]
+fn load_extended(world: &mut World) {
+    let mut result = None;
+    figment::Jail::expect_with(|j| {
+        if world.extends {
+            j.create_file("base.toml", "rules = [\"base\"]")?;
+            j.create_file(
+                ".ddlint.toml",
+                "extends = \"base.toml\"\nrules = [\"child\"]",
+            )?;
+        }
+        let cli = RulesConfig::parse_from(["prog"]);
+        result = Some(cli.load_and_merge());
+        Ok(())
+    });
+    world.result = result;
+    world.extends = false;
+}
+
+#[when("the cyclic configuration is loaded")]
+fn load_cyclic(world: &mut World) {
+    let mut result = None;
+    figment::Jail::expect_with(|j| {
+        j.create_file("a.toml", "extends = \"b.toml\"\nrules = [\"a\"]")?;
+        j.create_file("b.toml", "extends = \"a.toml\"\nrules = [\"b\"]")?;
+        j.create_file(".ddlint.toml", "extends = \"a.toml\"")?;
+        let cli = RulesConfig::parse_from(["prog"]);
+        result = Some(cli.load_and_merge());
+        Ok(())
+    });
+    world.result = result;
+    world.cyclic = false;
+}
+
+#[when("the configuration with missing base is loaded")]
+fn load_missing_base(world: &mut World) {
+    let mut result = None;
+    figment::Jail::expect_with(|j| {
+        j.create_file(
+            ".ddlint.toml",
+            "extends = \"missing.toml\"\nrules = [\"main\"]",
+        )?;
+        let cli = RulesConfig::parse_from(["prog"]);
+        result = Some(cli.load_and_merge());
+        Ok(())
+    });
+    world.result = result;
+    world.missing_base = false;
+}
+
+#[then("an error occurs")]
+fn error_occurs(world: &mut World) {
+    assert!(world.result.take().expect("result").is_err());
+}

--- a/ortho_config/tests/steps/mod.rs
+++ b/ortho_config/tests/steps/mod.rs
@@ -1,1 +1,2 @@
 pub mod env_steps;
+pub mod extends_steps;


### PR DESCRIPTION
## Summary
- implement `extends` configuration inheritance
- detect cycles via `CyclicExtends` error
- document inheritance semantics and update roadmap
- update cucumber world state and add BDD steps
- add unit tests for `extends` behaviour

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688b2fcf6a488322b9edaf3f3867bd6b

## Summary by Sourcery

Implement configuration inheritance by introducing an `extends` directive for merging configs, refactor parsing logic, add cycle detection, update documentation, and cover the new behavior with tests

New Features:
- Add configuration inheritance via an `extends` key with hierarchical merging of config files
- Introduce cycle detection for inheritance chains, reporting a `CyclicExtends` error

Enhancements:
- Refactor config loading into separate parsing and inheritance processing functions
- Extract file format parsing into `parse_config_by_format` and centralize loading logic with `load_config_file_inner`

Documentation:
- Document inheritance semantics and update user guide, design doc, and roadmap to reflect completed implementation

Tests:
- Add unit tests and BDD scenarios covering extends behavior, missing base files, and cyclic inheritance detection