### PR TITLE
Refine subcommand merging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ markdownlint: ## Lint Markdown files
 	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT)
 
 nixie: ## Validate Mermaid diagrams
-	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(NIXIE)
+	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -n1 $(NIXIE)
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/docs/behavioural-tests.md
+++ b/docs/behavioural-tests.md
@@ -89,6 +89,11 @@ into a `BTreeMap<String, RuleCfg>` **Then** unknown keys are preserved
 **Given** `DDLINT_IGNORE_PATTERNS=.git/,build/` in the environment **When**
 loading `ignore_patterns` as a vector **Then** it becomes `[".git/", "build/"]`
 
+### 3.12 CLI-only Required Values
+
+**Given** a CLI reference is provided and no defaults exist **When** loading
+the subcommand configuration **Then** the CLI value is used without error
+
 ## 4. Future Scenarios
 
 The design document lists potential future work such as async loading and

--- a/docs/design.md
+++ b/docs/design.md
@@ -248,6 +248,17 @@ Precedence across all sources becomes:
 Prefixes and subcommand namespaces are applied at each layer just as they would
 be without inheritance.
 
+### 4.9. Improved Subcommand Merging
+
+Earlier versions extracted subcommand defaults before applying CLI overrides.
+Missing required fields in `[cmds.<name>]` caused deserialization failures even
+when the CLI supplied those values. The revised implementation builds the
+`Figment` from file and environment sources first, then merges the already
+parsed CLI struct before extraction. This ensures that required CLI arguments
+fulfil missing defaults and eliminates workarounds like
+`load_with_reference_fallback`. The legacy `load_subcommand_config` helpers are
+retained but deprecated.
+
 ## 5. Dependency Strategy
 
 - **`ortho_config_macros`:**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,17 +44,17 @@ references the relevant design guidance.
 
 - **Refine subcommand merging behaviour**
 
-  - [ ] Simplify `load_and_merge` for subcommands to merge CLI‑provided values
+  - [x] Simplify `load_and_merge` for subcommands to merge CLI‑provided values
     over file/env defaults without requiring all fields to exist in the
     lower‑precedence layers.
     [[Subcommand Refinements](subcommand-refinements.md)]
 
-  - [ ] Remove the need for workarounds such as `load_with_reference_fallback`
+  - [x] Remove the need for workarounds such as `load_with_reference_fallback`
     in client applications by ensuring missing required values can be satisfied
     by the already‑parsed CLI struct.
     [[Subcommand Refinements](subcommand-refinements.md)]
 
-  - [ ] Deprecate and eventually remove `load_subcommand_config` and its `_for`
+  - [x] Deprecate and eventually remove `load_subcommand_config` and its `_for`
     variant in favour of a unified `load_and_merge` API.
 
 - **Finish `clap` integration in the derive macro**

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -21,6 +21,19 @@ pub struct World {
     missing_base: bool,
     /// Result of attempting to load configuration.
     pub result: Option<Result<RulesConfig, ortho_config::OrthoError>>,
+    /// CLI reference value for subcommand scenarios.
+    sub_ref: Option<String>,
+    /// Result of subcommand configuration loading.
+    pub sub_result: Option<Result<PrArgs, ortho_config::OrthoError>>,
+}
+
+/// CLI struct used for subcommand behavioural tests.
+#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig, Default, Clone)]
+#[command(name = "test")]
+#[ortho_config(prefix = "APP_")]
+pub struct PrArgs {
+    #[arg(long, required = true)]
+    reference: Option<String>,
 }
 
 /// Configuration struct used in integration tests.

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -23,6 +23,10 @@ pub struct World {
     pub result: Option<Result<RulesConfig, ortho_config::OrthoError>>,
     /// CLI reference value for subcommand scenarios.
     sub_ref: Option<String>,
+    /// Configuration file reference for subcommand scenarios.
+    sub_file: Option<String>,
+    /// Environment variable reference for subcommand scenarios.
+    sub_env: Option<String>,
     /// Result of subcommand configuration loading.
     pub sub_result: Option<Result<PrArgs, ortho_config::OrthoError>>,
 }
@@ -33,6 +37,7 @@ pub struct World {
 #[ortho_config(prefix = "APP_")]
 pub struct PrArgs {
     #[arg(long, required = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     reference: Option<String>,
 }
 

--- a/ortho_config/tests/features/subcommand.feature
+++ b/ortho_config/tests/features/subcommand.feature
@@ -3,3 +3,20 @@ Feature: Subcommand defaults
     Given a CLI reference "https://example.com/pr/1"
     When the subcommand configuration is loaded without defaults
     Then the merged reference is "https://example.com/pr/1"
+
+  Scenario: missing CLI value errors
+    Given no CLI reference
+    When the subcommand configuration is loaded without defaults
+    Then the subcommand load fails
+
+  Scenario: environment provides reference
+    Given no CLI reference
+    And an environment reference "https://example.com/env"
+    When the subcommand configuration is loaded without defaults
+    Then the merged reference is "https://example.com/env"
+
+  Scenario: CLI overrides configuration file
+    Given a CLI reference "https://example.com/cli"
+    And a configuration reference "https://example.com/file"
+    When the subcommand configuration is loaded without defaults
+    Then the merged reference is "https://example.com/cli"

--- a/ortho_config/tests/features/subcommand.feature
+++ b/ortho_config/tests/features/subcommand.feature
@@ -1,0 +1,5 @@
+Feature: Subcommand defaults
+  Scenario: CLI fills missing required field
+    Given a CLI reference "https://example.com/pr/1"
+    When the subcommand configuration is loaded without defaults
+    Then the merged reference is "https://example.com/pr/1"

--- a/ortho_config/tests/steps/mod.rs
+++ b/ortho_config/tests/steps/mod.rs
@@ -1,2 +1,3 @@
 pub mod env_steps;
 pub mod extends_steps;
+pub mod subcommand_steps;

--- a/ortho_config/tests/steps/subcommand_steps.rs
+++ b/ortho_config/tests/steps/subcommand_steps.rs
@@ -1,0 +1,32 @@
+use crate::{PrArgs, World};
+use cucumber::{given, then, when};
+use ortho_config::subcommand::load_and_merge_subcommand_for;
+
+#[given(expr = "a CLI reference {string}")]
+fn set_cli_ref(world: &mut World, val: String) {
+    world.sub_ref = Some(val);
+}
+
+#[when("the subcommand configuration is loaded without defaults")]
+fn load_sub(world: &mut World) {
+    let val = world.sub_ref.clone().expect("ref");
+    let cli = PrArgs {
+        reference: Some(val),
+    };
+    let mut result = None;
+    figment::Jail::expect_with(|_| {
+        result = Some(load_and_merge_subcommand_for::<PrArgs>(&cli));
+        Ok(())
+    });
+    world.sub_result = result;
+}
+
+#[then(expr = "the merged reference is {string}")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step requires owned String"
+)]
+fn check_ref(world: &mut World, expected: String) {
+    let cfg = world.sub_result.take().expect("result").expect("ok");
+    assert_eq!(cfg.reference.as_deref(), Some(expected.as_str()));
+}

--- a/ortho_config/tests/steps/subcommand_steps.rs
+++ b/ortho_config/tests/steps/subcommand_steps.rs
@@ -3,6 +3,11 @@ use clap::Parser;
 use cucumber::{given, then, when};
 use ortho_config::subcommand::load_and_merge_subcommand_for;
 
+/// Check if all configuration sources are absent.
+fn has_no_config_sources(world: &World) -> bool {
+    world.sub_ref.is_none() && world.sub_file.is_none() && world.sub_env.is_none()
+}
+
 #[given(expr = "a CLI reference {string}")]
 fn set_cli_ref(world: &mut World, val: String) {
     world.sub_ref = Some(val);
@@ -26,7 +31,7 @@ fn env_ref(world: &mut World, val: String) {
 #[when("the subcommand configuration is loaded without defaults")]
 fn load_sub(world: &mut World) {
     let mut result = None;
-    if world.sub_ref.is_none() && world.sub_file.is_none() && world.sub_env.is_none() {
+    if has_no_config_sources(world) {
         result = Some(PrArgs::try_parse_from(["test"]).map_err(Into::into));
     } else {
         let cli = PrArgs {

--- a/ortho_config/tests/subcommand.rs
+++ b/ortho_config/tests/subcommand.rs
@@ -162,3 +162,20 @@ fn merge_wrapper_respects_prefix() {
     .expect("merge");
     assert_eq!(merged.foo.as_deref(), Some("file"));
 }
+
+#[derive(Debug, Deserialize, serde::Serialize, Parser, Default, PartialEq)]
+#[command(name = "test")]
+struct RequiredCli {
+    #[arg(long, required = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ref_id: Option<String>,
+}
+
+#[rstest::rstest]
+fn cli_only_values_are_accepted() {
+    let cli = RequiredCli {
+        ref_id: Some("cli".into()),
+    };
+    let merged: RequiredCli = with_merged_subcommand_cli(|_j| Ok(()), &cli).expect("merge");
+    assert_eq!(merged.ref_id.as_deref(), Some("cli"));
+}


### PR DESCRIPTION
## Summary
- allow CLI-only values in `load_and_merge_subcommand`
- deprecate `load_subcommand_config*` helpers
- record design of new merging behaviour
- add behavioural and unit tests for missing subcommand defaults
- document the new scenario and mark roadmap item done

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_688bf05352348322b305a9fb51c2ccc6

## Summary by Sourcery

Refine subcommand merging to first load file and environment sources, then merge the CLI struct to support CLI-only required values, deprecate legacy helpers, and update tests and documentation accordingly

Enhancements:
- Merge CLI-provided struct into subcommand configuration earlier to allow CLI-only values to satisfy missing defaults
- Deprecate legacy load_subcommand_config and load_subcommand_config_for helpers in favor of load_and_merge_subcommand_for
- Integrate environment variable provider merging into load_and_merge_subcommand

Documentation:
- Document the improved subcommand merging behavior and deprecations in design.md
- Update roadmap.md to mark subcommand merging refinements as completed
- Add CLI-only required values scenario in behavioural-tests.md

Tests:
- Add unit test to verify CLI-only required values are accepted in subcommand merging
- Add cucumber behavioural tests and step definitions for CLI-only required subcommand defaults