### PR TITLE
Document usage examples for configuration helpers

### DIFF
--- a/ortho_config/src/csv_env.rs
+++ b/ortho_config/src/csv_env.rs
@@ -28,12 +28,28 @@ pub struct CsvEnv {
 
 impl CsvEnv {
     /// Create an unprefixed provider.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use ortho_config::CsvEnv;
+    /// let env = CsvEnv::raw();
+    /// let _ = env;
+    /// ```
     #[must_use]
     pub fn raw() -> Self {
         Self { inner: Env::raw() }
     }
 
     /// Create a provider using `prefix`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use ortho_config::CsvEnv;
+    /// let env = CsvEnv::prefixed("APP_");
+    /// let _ = env;
+    /// ```
     #[must_use]
     pub fn prefixed(prefix: &str) -> Self {
         Self {
@@ -42,6 +58,14 @@ impl CsvEnv {
     }
 
     /// Split keys at `pattern`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use ortho_config::CsvEnv;
+    /// let env = CsvEnv::raw().split("__");
+    /// let _ = env;
+    /// ```
     #[must_use]
     pub fn split(self, pattern: &str) -> Self {
         Self {
@@ -50,6 +74,15 @@ impl CsvEnv {
     }
 
     /// Map keys using `mapper`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use ortho_config::CsvEnv;
+    /// use uncased::Uncased;
+    /// let env = CsvEnv::raw().map(|k| Uncased::from(format!("APP_{k}")));
+    /// let _ = env;
+    /// ```
     #[must_use]
     pub fn map<F>(self, mapper: F) -> Self
     where
@@ -61,6 +94,15 @@ impl CsvEnv {
     }
 
     /// Filter and map keys using `f`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use ortho_config::CsvEnv;
+    /// use uncased::Uncased;
+    /// let env = CsvEnv::raw().filter_map(|k| k.strip_prefix("APP_").map(Uncased::from));
+    /// let _ = env;
+    /// ```
     #[must_use]
     pub fn filter_map<F>(self, f: F) -> Self
     where
@@ -72,6 +114,14 @@ impl CsvEnv {
     }
 
     /// Whether to lowercase keys before emitting them.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use ortho_config::CsvEnv;
+    /// let env = CsvEnv::raw().lowercase(true);
+    /// let _ = env;
+    /// ```
     #[must_use]
     pub fn lowercase(self, lowercase: bool) -> Self {
         Self {

--- a/ortho_config/src/file.rs
+++ b/ortho_config/src/file.rs
@@ -141,11 +141,20 @@ fn process_extends(
 ///
 /// ```rust,no_run
 /// use ortho_config::load_config_file;
+/// use serde::Deserialize;
 /// use std::path::Path;
+///
+/// #[derive(Deserialize)]
+/// struct Config {
+///     host: String,
+/// }
 ///
 /// # fn run() -> Result<(), ortho_config::OrthoError> {
 /// if let Some(figment) = load_config_file(Path::new("config.toml"))? {
-///     let _ = figment;
+///     let config: Config = figment
+///         .extract()
+///         .expect("invalid configuration file");
+///     assert_eq!(config.host, "localhost");
 /// }
 /// # Ok(())
 /// # }

--- a/ortho_config/src/file.rs
+++ b/ortho_config/src/file.rs
@@ -137,6 +137,20 @@ fn process_extends(
 ///
 /// Returns `Ok(None)` if the file does not exist.
 ///
+/// # Examples
+///
+/// ```rust,no_run
+/// use ortho_config::load_config_file;
+/// use std::path::Path;
+///
+/// # fn run() -> Result<(), ortho_config::OrthoError> {
+/// if let Some(figment) = load_config_file(Path::new("config.toml"))? {
+///     let _ = figment;
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
 /// # Errors
 ///
 /// Returns an [`OrthoError`] if reading or parsing the file fails.

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -9,6 +9,23 @@ use serde::{Serialize, de::DeserializeOwned};
 /// value from `defaults` intact. This function is intended for simple
 /// "CLI over defaults" merging in example code and small projects.
 ///
+/// # Examples
+///
+/// ```rust,no_run
+/// use ortho_config::merge_cli_over_defaults;
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Default, Serialize, Deserialize)]
+/// struct Config {
+///     count: Option<u32>,
+/// }
+///
+/// let defaults = Config { count: Some(1) };
+/// let cli = Config { count: Some(2) };
+/// let merged = merge_cli_over_defaults(&defaults, &cli).unwrap();
+/// assert_eq!(merged.count, Some(2));
+/// ```
+///
 /// # Errors
 ///
 /// Returns any [`figment::Error`] produced while extracting the merged

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -22,7 +22,8 @@ use serde::{Serialize, de::DeserializeOwned};
 ///
 /// let defaults = Config { count: Some(1) };
 /// let cli = Config { count: Some(2) };
-/// let merged = merge_cli_over_defaults(&defaults, &cli).unwrap();
+/// let merged = merge_cli_over_defaults(&defaults, &cli)
+///     .expect("failed to merge configuration");
 /// assert_eq!(merged.count, Some(2));
 /// ```
 ///


### PR DESCRIPTION
## Summary
- add examples to CsvEnv convenience methods
- show how to load a config file
- demonstrate merging CLI settings over defaults

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_688dcf55dc04832282401af4bfd93330

## Summary by Sourcery

Add usage examples to configuration helper functions to improve documentation and demonstrate common use cases.

Documentation:
- Add examples to CsvEnv convenience methods
- Add example to merge_cli_over_defaults for merging CLI settings over defaults
- Add example to load_config_file demonstrating config file loading