### PR TITLE
Implement hidden clap parser for config derivation

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -122,14 +122,19 @@ This is the most complex component. It needs to perform the following using
 2. **Generate a `clap`-aware Struct:** In the generated code, create a hidden
    struct derived from `clap::Parser`. Its fields should correspond to the main
    struct's fields but be wrapped in `Option<T>` to capture only user-provided
-   values. The macro will translate `#[ortho_config(cli_long="…")]` into
-   `#[clap(long="…")]`.
+   values. The macro translates `#[ortho_config(cli_long="…")]` and
+   `#[ortho_config(cli_short='x')]` attributes into `#[arg(long=…, short=…)]`
+   on this struct. When these attributes are absent, long names are derived
+   automatically from the field name using `kebab-case` and short names default
+   to the field's first character.
 3. **Generate `impl OrthoConfig for UserStruct`:**
-   - This block will contain the `load()` method.
-   - The generated `load()` will perform the architectural flow described in
-     section 3.
-   - It will need to dynamically generate the `figment` profile based on the
-     parsed attributes. For example, it will use the `prefix` attribute for
+   - This block contains the `load_from_iter` method used by the `load`
+     convenience function.
+   - The generated loader performs the architectural flow described in section
+     3, parsing the CLI into the hidden struct before layering file and
+     environment sources.
+   - It dynamically generates the `figment` profile based on parsed attributes.
+     For example, it uses the `prefix` attribute for
      `figment::providers::Env::prefixed(…)`.
 
 ### 4.3. Orthographic Name Mapping

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -59,14 +59,14 @@ references the relevant design guidance.
 
 - **Finish `clap` integration in the derive macro**
 
-  - [ ] Generate a hidden `clap::Parser` struct that automatically derives long
+  - [x] Generate a hidden `clap::Parser` struct that automatically derives long
     and short option names from field names (snake_case → kebab‑case) unless
     overridden via `#[ortho_config(cli_long = "…")]`. [[Design](design.md)]
 
-  - [ ] Ensure the macro sets appropriate `#[clap(long, short)]` attributes and
+  - [x] Ensure the macro sets appropriate `#[clap(long, short)]` attributes and
     respects default values specified in struct attributes.
 
-  - [ ] Confirm that CLI arguments override environment variables and file
+  - [x] Confirm that CLI arguments override environment variables and file
     values in the correct order. [[Design](design.md)]
 
 - **Improve merging and error reporting when combining CLI and configuration

--- a/ortho_config/tests/attribute_handling.rs
+++ b/ortho_config/tests/attribute_handling.rs
@@ -2,27 +2,25 @@
 
 #![allow(non_snake_case)]
 
-use clap::Parser;
 use ortho_config::OrthoConfig;
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 #[allow(dead_code)]
 struct CustomCli {
     #[ortho_config(cli_long = "my-val")]
-    #[arg(long = "my-val")]
     value: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 #[allow(dead_code)]
 #[ortho_config(prefix = "CFG_")]
 struct Prefixed {
-    #[arg(long)]
     value: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 #[allow(dead_code)]
 struct Defaulted {
     #[ortho_config(default = 5)]
@@ -30,27 +28,25 @@ struct Defaulted {
     num: Option<u32>,
 }
 
-#[test]
+#[rstest]
 fn uses_custom_cli_long() {
-    let cli = CustomCli::parse_from(["prog", "--my-val", "42"]);
-    assert_eq!(cli.value.as_deref(), Some("42"));
+    let cfg = CustomCli::load_from_iter(["prog", "--my-val", "42"]).expect("load");
+    assert_eq!(cfg.value.as_deref(), Some("42"));
 }
 
-#[test]
+#[rstest]
 fn env_prefix_is_used() {
     figment::Jail::expect_with(|j| {
         j.set_env("CFG_VALUE", "env");
-        let cli = Prefixed::parse_from(["prog", "--value", "cli"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = Prefixed::load_from_iter(["prog", "--value", "cli"]).expect("load");
         assert_eq!(cfg.value.as_deref(), Some("cli"));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn default_value_applied() {
-    let cli = Defaulted::parse_from(["prog"]);
-    let cfg = cli.load_and_merge().expect("load");
+    let cfg = Defaulted::load_from_iter(["prog"]).expect("load");
     assert_eq!(cfg.num, Some(5));
 }
 

--- a/ortho_config/tests/clap_integration.rs
+++ b/ortho_config/tests/clap_integration.rs
@@ -2,61 +2,66 @@
 
 #![allow(non_snake_case)]
 
-use clap::Parser;
 use ortho_config::{OrthoConfig, OrthoError};
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 struct TestConfig {
-    #[arg(long = "sample-value")]
     #[serde(skip_serializing_if = "Option::is_none")]
     sample_value: Option<String>,
-    #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     other: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 struct OptionConfig {
-    #[arg(long)]
     maybe: Option<u32>,
 }
 
-#[test]
+#[rstest]
 fn parses_kebab_case_flags() {
-    let cli = TestConfig::parse_from(["prog", "--sample-value", "hello", "--other", "val"]);
-    assert_eq!(cli.sample_value.as_deref(), Some("hello"));
-    assert_eq!(cli.other.as_deref(), Some("val"));
+    let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "hello", "--other", "val"])
+        .expect("load");
+    assert_eq!(cfg.sample_value.as_deref(), Some("hello"));
+    assert_eq!(cfg.other.as_deref(), Some("val"));
 }
 
-#[test]
+#[rstest]
+fn short_flags_work() {
+    let cfg = TestConfig::load_from_iter(["prog", "-s", "hi", "-o", "val"]).expect("load");
+    assert_eq!(cfg.sample_value.as_deref(), Some("hi"));
+    assert_eq!(cfg.other.as_deref(), Some("val"));
+}
+
+#[rstest]
 fn cli_only_source() {
-    let cli = TestConfig::parse_from(["prog", "--sample-value", "only", "--other", "x"]);
-    let cfg = cli.load_and_merge().expect("load");
+    let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "only", "--other", "x"])
+        .expect("load");
     assert_eq!(cfg.sample_value.as_deref(), Some("only"));
     assert_eq!(cfg.other.as_deref(), Some("x"));
 }
 
-#[test]
+#[rstest]
 fn cli_overrides_other_sources() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "sample_value = \"file\"\nother = \"f\"")?;
         j.set_env("SAMPLE_VALUE", "env");
         j.set_env("OTHER", "e");
-        let cli = TestConfig::parse_from(["prog", "--sample-value", "cli", "--other", "cli2"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "cli", "--other", "cli2"])
+            .expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("cli"));
         assert_eq!(cfg.other.as_deref(), Some("cli2"));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn cli_combines_with_file() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "other = \"file\"")?;
-        let cli = TestConfig::parse_from(["prog", "--sample-value", "cli", "--other", "cli2"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "cli", "--other", "cli2"])
+            .expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("cli"));
         // CLI argument should override file value
         assert_eq!(cfg.other.as_deref(), Some("cli2"));
@@ -64,19 +69,20 @@ fn cli_combines_with_file() {
     });
 }
 
-#[test]
+#[rstest]
 fn invalid_cli_input_maps_error() {
-    let err = TestConfig::try_parse_from(["prog", "--bogus"])
-        .map_err(OrthoError::CliParsing)
-        .unwrap_err();
+    let err = TestConfig::load_from_iter(["prog", "--bogus"]).unwrap_err();
     matches!(err, OrthoError::CliParsing(_));
 }
 
-#[test]
+#[rstest]
 fn merges_cli_into_figment() {
     use figment::{Figment, Profile, providers::Serialized};
 
-    let cli = TestConfig::parse_from(["prog", "--sample-value", "hi", "--other", "there"]);
+    let cli = TestConfig {
+        sample_value: Some("hi".into()),
+        other: Some("there".into()),
+    };
 
     let cfg: TestConfig = Figment::new()
         .merge(Serialized::from(cli, Profile::Default))
@@ -87,41 +93,38 @@ fn merges_cli_into_figment() {
     assert_eq!(cfg.other.as_deref(), Some("there"));
 }
 
-#[test]
+#[rstest]
 fn option_field_cli_present() {
-    let cli = OptionConfig::parse_from(["prog", "--maybe", "5"]);
-    let cfg = cli.load_and_merge().expect("load");
+    let cfg = OptionConfig::load_from_iter(["prog", "--maybe", "5"]).expect("load");
     assert_eq!(cfg.maybe, Some(5));
 }
 
-#[test]
+#[rstest]
 fn option_field_cli_absent() {
-    let cli = OptionConfig::parse_from(["prog"]);
-    let cfg = cli.load_and_merge().expect("load");
+    let cfg = OptionConfig::load_from_iter(["prog"]).expect("load");
     assert_eq!(cfg.maybe, None);
 }
 
-#[test]
+#[rstest]
 fn config_path_env_var() {
     figment::Jail::expect_with(|j| {
         j.create_file("alt.toml", "sample_value = \"from_env\"\nother = \"val\"")?;
         j.set_env("CONFIG_PATH", "alt.toml");
 
-        let cli = TestConfig::parse_from(["prog"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog"]).expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("from_env"));
         assert_eq!(cfg.other.as_deref(), Some("val"));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn missing_config_file_is_ignored() {
     figment::Jail::expect_with(|j| {
         j.set_env("CONFIG_PATH", "nope.toml");
 
-        let cli = TestConfig::parse_from(["prog", "--sample-value", "cli", "--other", "val"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "cli", "--other", "val"])
+            .expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("cli"));
         assert_eq!(cfg.other.as_deref(), Some("val"));
         Ok(())
@@ -141,8 +144,7 @@ fn loads_from_xdg_config() {
         )?;
         j.set_env("XDG_CONFIG_HOME", abs.to_str().unwrap());
 
-        let cli = TestConfig::parse_from(["prog"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog"]).expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("xdg"));
         assert_eq!(cfg.other.as_deref(), Some("val"));
         Ok(())
@@ -160,8 +162,7 @@ fn loads_from_xdg_yaml_config() {
         j.create_file(dir.join("config.yaml"), "sample_value: xdg\nother: val")?;
         j.set_env("XDG_CONFIG_HOME", abs.to_str().unwrap());
 
-        let cli = TestConfig::parse_from(["prog"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog"]).expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("xdg"));
         assert_eq!(cfg.other.as_deref(), Some("val"));
         Ok(())

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use ortho_config::OrthoConfig;
+use ortho_config::{OrthoConfig, subcommand::load_and_merge_subcommand_for};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Parser)]
@@ -27,8 +27,7 @@ fn merge_works_for_subcommand() {
         j.create_file(".config.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run", "--option", "cli"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = args
-            .load_and_merge()
+        let cfg = load_and_merge_subcommand_for(&args)
             .map_err(|e| figment::error::Error::from(e.to_string()))?;
         assert_eq!(cfg.option.as_deref(), Some("cli"));
         Ok(())

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 pub struct World {
     /// Environment variable value set during the scenario.
     env_value: Option<String>,
+    /// Configuration file value set during the scenario.
+    file_value: Option<String>,
     /// Whether the scenario requires an extended configuration file.
     extends: bool,
     /// Whether to create a cyclic inheritance scenario.
@@ -45,11 +47,10 @@ pub struct PrArgs {
 ///
 /// The `DDLINT_` prefix is applied to environment variables and rule lists may
 /// be specified as comma-separated strings via [`CsvEnv`].
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig, Default)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig, Default)]
 #[ortho_config(prefix = "DDLINT_")]
 pub struct RulesConfig {
     /// List of lint rules parsed from CLI or environment.
-    #[arg(long)]
     rules: Vec<String>,
 }
 

--- a/ortho_config/tests/extends.rs
+++ b/ortho_config/tests/extends.rs
@@ -1,60 +1,55 @@
 //! Tests for configuration inheritance using the `extends` key.
 
-use clap::Parser;
 use ortho_config::{OrthoConfig, OrthoError};
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 struct ExtendsCfg {
-    #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     foo: Option<String>,
 }
 
-#[test]
+#[rstest]
 fn extended_file_overrides_base() {
     figment::Jail::expect_with(|j| {
         j.create_file("base.toml", "foo = \"base\"")?;
         j.create_file(".config.toml", "extends = \"base.toml\"\nfoo = \"child\"")?;
-        let cli = ExtendsCfg::parse_from(["prog"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = ExtendsCfg::load_from_iter(["prog"]).expect("load");
         assert_eq!(cfg.foo.as_deref(), Some("child"));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn env_and_cli_override_extended_file() {
     figment::Jail::expect_with(|j| {
         j.create_file("base.toml", "foo = \"base\"")?;
         j.create_file(".config.toml", "extends = \"base.toml\"\nfoo = \"file\"")?;
         j.set_env("FOO", "env");
-        let cli = ExtendsCfg::parse_from(["prog", "--foo", "cli"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = ExtendsCfg::load_from_iter(["prog", "--foo", "cli"]).expect("load");
         assert_eq!(cfg.foo.as_deref(), Some("cli"));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn cyclic_inheritance_is_detected() {
     figment::Jail::expect_with(|j| {
         j.create_file("a.toml", "extends = \"b.toml\"\nfoo = \"a\"")?;
         j.create_file("b.toml", "extends = \"a.toml\"\nfoo = \"b\"")?;
         j.create_file(".config.toml", "extends = \"a.toml\"")?;
-        let cli = ExtendsCfg::parse_from(["prog"]);
-        let err = cli.load_and_merge().unwrap_err();
+        let err = ExtendsCfg::load_from_iter(["prog"]).unwrap_err();
         assert!(matches!(err, OrthoError::CyclicExtends { .. }));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn missing_base_file_errors() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "extends = \"missing.toml\"")?;
-        let cli = ExtendsCfg::parse_from(["prog"]);
-        let err = cli.load_and_merge().unwrap_err();
+        let err = ExtendsCfg::load_from_iter(["prog"]).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("missing.toml"));
         Ok(())

--- a/ortho_config/tests/features/cli_precedence.feature
+++ b/ortho_config/tests/features/cli_precedence.feature
@@ -1,0 +1,6 @@
+Feature: CLI precedence
+  Scenario: CLI overrides environment and file values
+    Given the configuration file has rules "file"
+    And the environment variable DDLINT_RULES is "env"
+    When the config is loaded with CLI rules "cli"
+    Then the loaded rules are "cli"

--- a/ortho_config/tests/merge_strategy.rs
+++ b/ortho_config/tests/merge_strategy.rs
@@ -1,43 +1,40 @@
 //! Tests for the append merge strategy on vectors.
 
 #![allow(non_snake_case)]
-use clap::Parser;
 use ortho_config::OrthoConfig;
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 struct VecConfig {
     #[ortho_config(merge_strategy = "append")]
-    #[arg(long)]
     values: Vec<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 struct DefaultVec {
     #[ortho_config(default = vec!["def".to_string()], merge_strategy = "append")]
-    #[arg(long)]
     values: Vec<String>,
 }
 
-#[test]
+#[rstest]
 fn append_merges_all_sources() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "values = [\"file\"]")?;
         j.set_env("VALUES", "[\"env\"]");
-        let cli = VecConfig::parse_from(["prog", "--values", "cli1", "--values", "cli2"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = VecConfig::load_from_iter(["prog", "--values", "cli1", "--values", "cli2"])
+            .expect("load");
         assert_eq!(cfg.values, vec!["file", "env", "cli1", "cli2"]);
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn append_includes_defaults() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "values = [\"file\"]")?;
         j.set_env("VALUES", "[\"env\"]");
-        let cli = DefaultVec::parse_from(["prog", "--values", "cli"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = DefaultVec::load_from_iter(["prog", "--values", "cli"]).expect("load");
         assert_eq!(cfg.values, vec!["def", "file", "env", "cli"]);
         Ok(())
     });

--- a/ortho_config/tests/steps/cli_steps.rs
+++ b/ortho_config/tests/steps/cli_steps.rs
@@ -1,0 +1,42 @@
+//! Steps verifying CLI precedence over environment variables and files.
+
+use crate::{RulesConfig, World};
+use cucumber::{given, then, when};
+use ortho_config::OrthoConfig;
+
+#[given(expr = "the configuration file has rules {string}")]
+fn file_rules(world: &mut World, val: String) {
+    world.file_value = Some(val);
+}
+
+#[when(expr = "the config is loaded with CLI rules {string}")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step signature requires owned String"
+)]
+fn load_with_cli(world: &mut World, cli: String) {
+    let file_val = world.file_value.clone();
+    let env_val = world.env_value.clone();
+    let mut result = None;
+    figment::Jail::expect_with(|j| {
+        if let Some(f) = file_val {
+            j.create_file(".ddlint.toml", &format!("rules = [\"{f}\"]"))?;
+        }
+        if let Some(e) = env_val {
+            j.set_env("DDLINT_RULES", &e);
+        }
+        result = Some(RulesConfig::load_from_iter(["prog", "--rules", &cli]));
+        Ok(())
+    });
+    world.result = result;
+}
+
+#[then(expr = "the loaded rules are {string}")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step signature requires owned String"
+)]
+fn loaded_rules(world: &mut World, expected: String) {
+    let cfg = world.result.take().expect("result").expect("ok");
+    assert_eq!(cfg.rules.last().expect("rule"), &expected);
+}

--- a/ortho_config/tests/steps/env_steps.rs
+++ b/ortho_config/tests/steps/env_steps.rs
@@ -4,8 +4,8 @@
 //! using [`CsvEnv`], and verifying parsed results.
 
 use crate::{RulesConfig, World};
-use clap::Parser;
 use cucumber::{given, then, when};
+use ortho_config::OrthoConfig;
 
 /// Sets `DDLINT_RULES` in the test environment.
 #[given(expr = "the environment variable DDLINT_RULES is {string}")]
@@ -19,8 +19,7 @@ fn load_config(world: &mut World) {
     let mut result = None;
     figment::Jail::expect_with(|j| {
         j.set_env("DDLINT_RULES", &val);
-        let cli = RulesConfig::parse_from(["prog"]);
-        result = Some(cli.load_and_merge());
+        result = Some(RulesConfig::load_from_iter(["prog"]));
         Ok(())
     });
     world.result = result;

--- a/ortho_config/tests/steps/extends_steps.rs
+++ b/ortho_config/tests/steps/extends_steps.rs
@@ -1,8 +1,8 @@
 //! Steps for testing configuration inheritance.
 
 use crate::{RulesConfig, World};
-use clap::Parser;
 use cucumber::{given, then, when};
+use ortho_config::OrthoConfig;
 
 #[given("a configuration file extending a base file")]
 fn create_files(world: &mut World) {
@@ -30,8 +30,7 @@ fn load_extended(world: &mut World) {
                 "extends = \"base.toml\"\nrules = [\"child\"]",
             )?;
         }
-        let cli = RulesConfig::parse_from(["prog"]);
-        result = Some(cli.load_and_merge());
+        result = Some(RulesConfig::load_from_iter(["prog"]));
         Ok(())
     });
     world.result = result;
@@ -45,8 +44,7 @@ fn load_cyclic(world: &mut World) {
         j.create_file("a.toml", "extends = \"b.toml\"\nrules = [\"a\"]")?;
         j.create_file("b.toml", "extends = \"a.toml\"\nrules = [\"b\"]")?;
         j.create_file(".ddlint.toml", "extends = \"a.toml\"")?;
-        let cli = RulesConfig::parse_from(["prog"]);
-        result = Some(cli.load_and_merge());
+        result = Some(RulesConfig::load_from_iter(["prog"]));
         Ok(())
     });
     world.result = result;
@@ -61,8 +59,7 @@ fn load_missing_base(world: &mut World) {
             ".ddlint.toml",
             "extends = \"missing.toml\"\nrules = [\"main\"]",
         )?;
-        let cli = RulesConfig::parse_from(["prog"]);
-        result = Some(cli.load_and_merge());
+        result = Some(RulesConfig::load_from_iter(["prog"]));
         Ok(())
     });
     world.result = result;

--- a/ortho_config/tests/steps/mod.rs
+++ b/ortho_config/tests/steps/mod.rs
@@ -1,3 +1,4 @@
+pub mod cli_steps;
 pub mod env_steps;
 pub mod extends_steps;
 pub mod subcommand_steps;

--- a/ortho_config_macros/src/derive/build.rs
+++ b/ortho_config_macros/src/derive/build.rs
@@ -17,15 +17,8 @@ fn option_type_tokens(ty: &Type) -> proc_macro2::TokenStream {
     }
 }
 
-/// Generates the fields for the hidden `clap::Parser` struct.
-///
-/// Each user field becomes `Option<T>` to record whether the CLI provided
-/// a value. This lets the configuration merge logic keep track of which
-/// layer supplied each setting. A dedicated `config_path` field is
-/// inserted to allow overriding the path to the configuration file.
-///
-/// This function is used internally by the derive macro to transform
-/// user-defined struct fields into CLI-compatible equivalents.
+/// Generates fields for the defaults struct used to hold attribute-specified
+/// default values.
 pub(crate) fn build_default_struct_fields(fields: &[syn::Field]) -> Vec<proc_macro2::TokenStream> {
     fields
         .iter()
@@ -33,6 +26,40 @@ pub(crate) fn build_default_struct_fields(fields: &[syn::Field]) -> Vec<proc_mac
             let name = f.ident.as_ref().expect("named field");
             let ty = option_type_tokens(&f.ty);
             quote! {
+                #[serde(skip_serializing_if = "Option::is_none")]
+                pub #name: #ty
+            }
+        })
+        .collect()
+}
+
+/// Generates the fields for the hidden `clap::Parser` struct.
+///
+/// Each user field becomes `Option<T>` to record whether the CLI provided a
+/// value. Long names default to the field name converted to kebab-case and
+/// short names default to the first character of the field. These may be
+/// overridden via `cli_long` and `cli_short` attributes.
+pub(crate) fn build_cli_struct_fields(
+    fields: &[syn::Field],
+    field_attrs: &[FieldAttrs],
+) -> Vec<proc_macro2::TokenStream> {
+    fields
+        .iter()
+        .zip(field_attrs.iter())
+        .map(|(f, attrs)| {
+            let name = f.ident.as_ref().expect("named field");
+            let ty = option_type_tokens(&f.ty);
+            let long = attrs
+                .cli_long
+                .clone()
+                .unwrap_or_else(|| name.to_string().replace('_', "-"));
+            let short_ch = attrs
+                .cli_short
+                .unwrap_or_else(|| name.to_string().chars().next().unwrap());
+            let long_lit = syn::LitStr::new(&long, proc_macro2::Span::call_site());
+            let short_lit = syn::LitChar::new(short_ch, proc_macro2::Span::call_site());
+            quote! {
+                #[arg(long = #long_lit, short = #short_lit)]
                 #[serde(skip_serializing_if = "Option::is_none")]
                 pub #name: #ty
             }
@@ -191,7 +218,7 @@ pub(crate) fn build_append_logic(fields: &[(Ident, &Type)]) -> proc_macro2::Toke
     });
     quote! {
         let env_figment = Figment::from(env_provider.clone());
-        let cli_figment = Figment::from(Serialized::defaults(self));
+        let cli_figment = Figment::from(Serialized::defaults(&cli));
         #( #logic )*
     }
 }


### PR DESCRIPTION
## Summary
- generate an internal clap `Parser` struct and expose a `load_from_iter` API
- document the automatic CLI flag generation and updated loading flow
- cover CLI precedence with unit and cucumber tests

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: error: too many arguments. Expected 0 arguments but got 1.)*

------
https://chatgpt.com/codex/tasks/task_e_689299f2537483228323afb8ddc1cbd5