### PR TITLE
Implement hidden clap parser for config derivation

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -128,7 +128,10 @@ This is the most complex component. It needs to perform the following using
    automatically from the field name using `kebab-case` and short names default
    to the field's first character. If the short letter is already used, the
    macro tries the upper-case variant. A further collision triggers a compile
-   error and requires the user to supply `cli_short`.
+   error and requires the user to supply `cli_short`. Short flags must be ASCII
+   alphanumeric and cannot reuse clap's `-h` or `-V`. Long flags must contain
+   only ASCII alphanumeric characters plus `-` or `_` and may not be `help` or
+   `version`.
 3. **Generate `impl OrthoConfig for UserStruct`:**
    - This block contains the `load_from_iter` method used by the `load`
      convenience function.

--- a/docs/design.md
+++ b/docs/design.md
@@ -122,14 +122,21 @@ This is the most complex component. It needs to perform the following using
 2. **Generate a `clap`-aware Struct:** In the generated code, create a hidden
    struct derived from `clap::Parser`. Its fields should correspond to the main
    struct's fields but be wrapped in `Option<T>` to capture only user-provided
-   values. The macro will translate `#[ortho_config(cli_long="…")]` into
-   `#[clap(long="…")]`.
+   values. The macro translates `#[ortho_config(cli_long="…")]` and
+   `#[ortho_config(cli_short='x')]` attributes into `#[arg(long=…, short=…)]`
+   on this struct. When these attributes are absent, long names are derived
+   automatically from the field name using `kebab-case` and short names default
+   to the field's first character. If the short letter is already used, the
+   macro tries the upper-case variant. A further collision triggers a compile
+   error and requires the user to supply `cli_short`.
 3. **Generate `impl OrthoConfig for UserStruct`:**
-   - This block will contain the `load()` method.
-   - The generated `load()` will perform the architectural flow described in
-     section 3.
-   - It will need to dynamically generate the `figment` profile based on the
-     parsed attributes. For example, it will use the `prefix` attribute for
+   - This block contains the `load_from_iter` method used by the `load`
+     convenience function.
+   - The generated loader performs the architectural flow described in section
+     3, parsing the CLI into the hidden struct before layering file and
+     environment sources.
+   - It dynamically generates the `figment` profile based on parsed attributes.
+     For example, it uses the `prefix` attribute for
      `figment::providers::Env::prefixed(…)`.
 
 ### 4.3. Orthographic Name Mapping

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -102,7 +102,7 @@ alt text describing the content. Add a brief description before each Mermaid
 diagram, so screen readers can understand it.
 
 ```mermaid
-flowchart TD
+graph TD
     A[Start] --> B[Draft]
     B --> C[Review]
     C --> D[Merge]

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,16 +57,16 @@ references the relevant design guidance.
   - [x] Deprecate and eventually remove `load_subcommand_config` and its `_for`
     variant in favour of a unified `load_and_merge` API.
 
-- **Finish `clap` integration in the derive macro**
+- [x] **Finish `clap` integration in the derive macro**
 
-  - [ ] Generate a hidden `clap::Parser` struct that automatically derives long
+  - [x] Generate a hidden `clap::Parser` struct that automatically derives long
     and short option names from field names (snake_case → kebab‑case) unless
     overridden via `#[ortho_config(cli_long = "…")]`. [[Design](design.md)]
 
-  - [ ] Ensure the macro sets appropriate `#[clap(long, short)]` attributes and
+  - [x] Ensure the macro sets appropriate `#[clap(long, short)]` attributes and
     respects default values specified in struct attributes.
 
-  - [ ] Confirm that CLI arguments override environment variables and file
+  - [x] Confirm that CLI arguments override environment variables and file
     values in the correct order. [[Design](design.md)]
 
 - **Improve merging and error reporting when combining CLI and configuration

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -32,9 +32,8 @@ values from multiple sources. The core features are:
   Rust structs using `serde`.
 
 - **Easy adoption** – A procedural macro `#[derive(OrthoConfig)]` adds the
-  necessary code. Developers only need to derive `serde` and `clap` traits on
-  their configuration struct and call a generated method to load the
-  configuration.
+  necessary code. Developers only need to derive `serde` traits on their
+  configuration struct and call a generated method to load the configuration.
 
 - **Customizable behaviour** – Attributes such as `default`, `cli_long`,
   `cli_short` and `merge_strategy` provide fine‑grained control over naming and
@@ -73,9 +72,8 @@ A configuration is represented by a plain Rust struct. To take advantage of
 - `serde::Deserialize` and `serde::Serialize` – required for deserialising
   values and merging overrides.
 
-- `clap::Parser` – required for generating CLI parsing code. Fields may be
-  annotated with standard `clap` attributes such as `#[arg(long)]` or
-  `#[arg(short)]`.
+- The derive macro generates a hidden `clap::Parser` implementation, so
+  no manual `clap` annotations are needed.
 
 - `OrthoConfig` – provided by the library. This derive macro generates the code
   to load and merge configuration from multiple sources.
@@ -102,21 +100,24 @@ Unrecognized keys are ignored by the derive macro for forwards compatibility.
 Unknown keys will therefore silently do nothing. Developers who require
 stricter validation may add manual `compile_error!` guards.
 
+By default, each field receives a long flag derived from its name in kebab-case
+and a short flag from its first letter. If that letter is already used, the
+macro assigns the upper-case variant to the next field. Further collisions
+require specifying `cli_short` explicitly.
+
 ### Example configuration struct
 
 The following example illustrates many of these features:
 
 ```rust
-use ortho_config::{OrthoConfig, OrthoError};
-use serde::{Deserialize, Serialize};
-use clap::Parser;
+  use ortho_config::{OrthoConfig, OrthoError};
+  use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize, OrthoConfig, Parser)]
-#[ortho_config(prefix = "APP")]                // environment variables start with APP_
-struct AppConfig {
-    /// Logging verbosity
-    #[arg(long)]
-    log_level: String,
+  #[derive(Debug, Clone, Deserialize, Serialize, OrthoConfig)]
+  #[ortho_config(prefix = "APP")]                // environment variables start with APP_
+  struct AppConfig {
+      /// Logging verbosity
+      log_level: String,
 
     /// Port to bind on – defaults to 8080 when unspecified
     #[arg(long)]
@@ -151,8 +152,7 @@ struct DatabaseConfig {
 
 fn main() -> Result<(), OrthoError> {
     // Parse CLI arguments and merge with defaults, file and environment
-    let cli_args = AppConfig::parse();
-    let config = cli_args.load_and_merge()?;
+    let config = AppConfig::load()?;
     println!("Final config: {:#?}", config);
     Ok(())
 }
@@ -165,12 +165,10 @@ will accumulate values from multiple sources rather than overwriting them.
 
 ## Loading configuration and precedence rules
 
-### The `load_and_merge()` method
+### How loading works
 
-The `OrthoConfig` derive macro generates a method
-`load_and_merge(&self) -> Result<Self, OrthoError>`. It takes the struct
-populated by `clap` parsing and returns a fully populated configuration
-instance. Internally, it performs the following steps:
+The `load_from_iter` method (used by the convenience `load`) performs the
+following steps:
 
 1. Builds a `figment` configuration profile. A defaults provider constructed
    from the `#[ortho_config(default = …)]` attributes is added first.
@@ -359,13 +357,13 @@ for a complete example.
 
 ## Error handling
 
-`load_and_merge` and `load_and_merge_subcommand_for` return a
-`Result<T, OrthoError>`. `OrthoError` wraps errors from `clap`, file I/O and
-`figment`. When configuration cannot be gathered or deserialized, the error
-propagates up to the caller. Consumers should handle these errors
-appropriately, for example by printing them to stderr and exiting. Future
-releases may include improved missing‑value error messages, but currently the
-crate simply returns the underlying error.
+`load` and `load_and_merge_subcommand_for` return a `Result<T, OrthoError>`.
+`OrthoError` wraps errors from `clap`, file I/O and `figment`. When
+configuration cannot be gathered or deserialized, the error propagates up to
+the caller. Consumers should handle these errors appropriately, for example by
+printing them to stderr and exiting. Future releases may include improved
+missing‑value error messages, but currently the crate simply returns the
+underlying error.
 
 ## Additional notes
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -103,7 +103,10 @@ stricter validation may add manual `compile_error!` guards.
 By default, each field receives a long flag derived from its name in kebab-case
 and a short flag from its first letter. If that letter is already used, the
 macro assigns the upper-case variant to the next field. Further collisions
-require specifying `cli_short` explicitly.
+require specifying `cli_short` explicitly. Short flags must be ASCII
+alphanumeric and may not use clap's global `-h` or `-V` options. Long flags
+must contain only ASCII alphanumeric characters, hyphens or underscores and
+cannot be named `help` or `version`.
 
 ### Example configuration struct
 

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -50,8 +50,7 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// }
     ///
     /// # fn main() -> Result<(), OrthoError> {
-    /// let cfg = AppConfig::load()?;
-    /// # let _ = cfg;
+    /// let _cfg = AppConfig::load()?;
     /// # Ok(())
     /// # }
     /// ```

--- a/ortho_config/tests/attribute_handling.rs
+++ b/ortho_config/tests/attribute_handling.rs
@@ -2,27 +2,25 @@
 
 #![allow(non_snake_case)]
 
-use clap::Parser;
 use ortho_config::OrthoConfig;
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 #[allow(dead_code)]
 struct CustomCli {
     #[ortho_config(cli_long = "my-val")]
-    #[arg(long = "my-val")]
     value: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 #[allow(dead_code)]
 #[ortho_config(prefix = "CFG_")]
 struct Prefixed {
-    #[arg(long)]
     value: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 #[allow(dead_code)]
 struct Defaulted {
     #[ortho_config(default = 5)]
@@ -30,27 +28,25 @@ struct Defaulted {
     num: Option<u32>,
 }
 
-#[test]
+#[rstest]
 fn uses_custom_cli_long() {
-    let cli = CustomCli::parse_from(["prog", "--my-val", "42"]);
-    assert_eq!(cli.value.as_deref(), Some("42"));
+    let cfg = CustomCli::load_from_iter(["prog", "--my-val", "42"]).expect("load");
+    assert_eq!(cfg.value.as_deref(), Some("42"));
 }
 
-#[test]
+#[rstest]
 fn env_prefix_is_used() {
     figment::Jail::expect_with(|j| {
         j.set_env("CFG_VALUE", "env");
-        let cli = Prefixed::parse_from(["prog", "--value", "cli"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = Prefixed::load_from_iter(["prog", "--value", "cli"]).expect("load");
         assert_eq!(cfg.value.as_deref(), Some("cli"));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn default_value_applied() {
-    let cli = Defaulted::parse_from(["prog"]);
-    let cfg = cli.load_and_merge().expect("load");
+    let cfg = Defaulted::load_from_iter(["prog"]).expect("load");
     assert_eq!(cfg.num, Some(5));
 }
 

--- a/ortho_config/tests/clap_integration.rs
+++ b/ortho_config/tests/clap_integration.rs
@@ -1,62 +1,76 @@
 //! Tests covering CLI integration and error handling.
 
-#![allow(non_snake_case)]
-
-use clap::Parser;
 use ortho_config::{OrthoConfig, OrthoError};
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 struct TestConfig {
-    #[arg(long = "sample-value")]
     #[serde(skip_serializing_if = "Option::is_none")]
     sample_value: Option<String>,
-    #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     other: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 struct OptionConfig {
-    #[arg(long)]
     maybe: Option<u32>,
 }
 
-#[test]
-fn parses_kebab_case_flags() {
-    let cli = TestConfig::parse_from(["prog", "--sample-value", "hello", "--other", "val"]);
-    assert_eq!(cli.sample_value.as_deref(), Some("hello"));
-    assert_eq!(cli.other.as_deref(), Some("val"));
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
+struct RequiredConfig {
+    sample_value: String,
 }
 
-#[test]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
+struct ConflictConfig {
+    second: Option<String>,
+    sample: Option<String>,
+}
+
+#[rstest]
+fn parses_kebab_case_flags() {
+    let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "hello", "--other", "val"])
+        .expect("load");
+    assert_eq!(cfg.sample_value.as_deref(), Some("hello"));
+    assert_eq!(cfg.other.as_deref(), Some("val"));
+}
+
+#[rstest]
+fn short_flags_work() {
+    let cfg = TestConfig::load_from_iter(["prog", "-s", "hi", "-o", "val"]).expect("load");
+    assert_eq!(cfg.sample_value.as_deref(), Some("hi"));
+    assert_eq!(cfg.other.as_deref(), Some("val"));
+}
+
+#[rstest]
 fn cli_only_source() {
-    let cli = TestConfig::parse_from(["prog", "--sample-value", "only", "--other", "x"]);
-    let cfg = cli.load_and_merge().expect("load");
+    let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "only", "--other", "x"])
+        .expect("load");
     assert_eq!(cfg.sample_value.as_deref(), Some("only"));
     assert_eq!(cfg.other.as_deref(), Some("x"));
 }
 
-#[test]
+#[rstest]
 fn cli_overrides_other_sources() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "sample_value = \"file\"\nother = \"f\"")?;
         j.set_env("SAMPLE_VALUE", "env");
         j.set_env("OTHER", "e");
-        let cli = TestConfig::parse_from(["prog", "--sample-value", "cli", "--other", "cli2"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "cli", "--other", "cli2"])
+            .expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("cli"));
         assert_eq!(cfg.other.as_deref(), Some("cli2"));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn cli_combines_with_file() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "other = \"file\"")?;
-        let cli = TestConfig::parse_from(["prog", "--sample-value", "cli", "--other", "cli2"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "cli", "--other", "cli2"])
+            .expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("cli"));
         // CLI argument should override file value
         assert_eq!(cfg.other.as_deref(), Some("cli2"));
@@ -64,19 +78,43 @@ fn cli_combines_with_file() {
     });
 }
 
-#[test]
+#[rstest]
 fn invalid_cli_input_maps_error() {
-    let err = TestConfig::try_parse_from(["prog", "--bogus"])
-        .map_err(OrthoError::CliParsing)
-        .unwrap_err();
+    let err = TestConfig::load_from_iter(["prog", "--bogus"]).unwrap_err();
     matches!(err, OrthoError::CliParsing(_));
 }
 
-#[test]
+#[rstest]
+fn invalid_cli_wrong_type_maps_error() {
+    let err = OptionConfig::load_from_iter(["prog", "--maybe", "notanumber"]).unwrap_err();
+    matches!(err, OrthoError::CliParsing(_));
+}
+
+#[rstest]
+fn invalid_cli_missing_required_maps_error() {
+    figment::Jail::expect_with(|_| {
+        let err = RequiredConfig::load_from_iter(["prog"]).unwrap_err();
+        matches!(err, OrthoError::CliParsing(_));
+        Ok(())
+    });
+}
+
+#[rstest]
+fn invalid_cli_duplicate_flag_maps_error() {
+    let err =
+        TestConfig::load_from_iter(["prog", "--sample-value", "foo", "--sample-value", "bar"])
+            .unwrap_err();
+    matches!(err, OrthoError::CliParsing(_));
+}
+
+#[rstest]
 fn merges_cli_into_figment() {
     use figment::{Figment, Profile, providers::Serialized};
 
-    let cli = TestConfig::parse_from(["prog", "--sample-value", "hi", "--other", "there"]);
+    let cli = TestConfig {
+        sample_value: Some("hi".into()),
+        other: Some("there".into()),
+    };
 
     let cfg: TestConfig = Figment::new()
         .merge(Serialized::from(cli, Profile::Default))
@@ -87,41 +125,45 @@ fn merges_cli_into_figment() {
     assert_eq!(cfg.other.as_deref(), Some("there"));
 }
 
-#[test]
+#[rstest]
 fn option_field_cli_present() {
-    let cli = OptionConfig::parse_from(["prog", "--maybe", "5"]);
-    let cfg = cli.load_and_merge().expect("load");
+    let cfg = OptionConfig::load_from_iter(["prog", "--maybe", "5"]).expect("load");
     assert_eq!(cfg.maybe, Some(5));
 }
 
-#[test]
+#[rstest]
 fn option_field_cli_absent() {
-    let cli = OptionConfig::parse_from(["prog"]);
-    let cfg = cli.load_and_merge().expect("load");
+    let cfg = OptionConfig::load_from_iter(["prog"]).expect("load");
     assert_eq!(cfg.maybe, None);
 }
 
-#[test]
+#[rstest]
+fn resolves_short_flag_conflict() {
+    let cfg = ConflictConfig::load_from_iter(["prog", "-s", "one", "-S", "two"]).expect("load");
+    assert_eq!(cfg.second.as_deref(), Some("one"));
+    assert_eq!(cfg.sample.as_deref(), Some("two"));
+}
+
+#[rstest]
 fn config_path_env_var() {
     figment::Jail::expect_with(|j| {
         j.create_file("alt.toml", "sample_value = \"from_env\"\nother = \"val\"")?;
         j.set_env("CONFIG_PATH", "alt.toml");
 
-        let cli = TestConfig::parse_from(["prog"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog"]).expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("from_env"));
         assert_eq!(cfg.other.as_deref(), Some("val"));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn missing_config_file_is_ignored() {
     figment::Jail::expect_with(|j| {
         j.set_env("CONFIG_PATH", "nope.toml");
 
-        let cli = TestConfig::parse_from(["prog", "--sample-value", "cli", "--other", "val"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog", "--sample-value", "cli", "--other", "val"])
+            .expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("cli"));
         assert_eq!(cfg.other.as_deref(), Some("val"));
         Ok(())
@@ -141,8 +183,7 @@ fn loads_from_xdg_config() {
         )?;
         j.set_env("XDG_CONFIG_HOME", abs.to_str().unwrap());
 
-        let cli = TestConfig::parse_from(["prog"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog"]).expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("xdg"));
         assert_eq!(cfg.other.as_deref(), Some("val"));
         Ok(())
@@ -160,8 +201,7 @@ fn loads_from_xdg_yaml_config() {
         j.create_file(dir.join("config.yaml"), "sample_value: xdg\nother: val")?;
         j.set_env("XDG_CONFIG_HOME", abs.to_str().unwrap());
 
-        let cli = TestConfig::parse_from(["prog"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = TestConfig::load_from_iter(["prog"]).expect("load");
         assert_eq!(cfg.sample_value.as_deref(), Some("xdg"));
         assert_eq!(cfg.other.as_deref(), Some("val"));
         Ok(())

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use ortho_config::OrthoConfig;
+use ortho_config::{OrthoConfig, subcommand::load_and_merge_subcommand_for};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Parser)]
@@ -27,8 +27,7 @@ fn merge_works_for_subcommand() {
         j.create_file(".config.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run", "--option", "cli"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = args
-            .load_and_merge()
+        let cfg = load_and_merge_subcommand_for(&args)
             .map_err(|e| figment::error::Error::from(e.to_string()))?;
         assert_eq!(cfg.option.as_deref(), Some("cli"));
         Ok(())

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 pub struct World {
     /// Environment variable value set during the scenario.
     env_value: Option<String>,
+    /// Configuration file value set during the scenario.
+    file_value: Option<String>,
     /// Whether the scenario requires an extended configuration file.
     extends: bool,
     /// Whether to create a cyclic inheritance scenario.
@@ -45,11 +47,10 @@ pub struct PrArgs {
 ///
 /// The `DDLINT_` prefix is applied to environment variables and rule lists may
 /// be specified as comma-separated strings via [`CsvEnv`].
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig, Default)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig, Default)]
 #[ortho_config(prefix = "DDLINT_")]
 pub struct RulesConfig {
     /// List of lint rules parsed from CLI or environment.
-    #[arg(long)]
     rules: Vec<String>,
 }
 

--- a/ortho_config/tests/extends.rs
+++ b/ortho_config/tests/extends.rs
@@ -1,60 +1,55 @@
 //! Tests for configuration inheritance using the `extends` key.
 
-use clap::Parser;
 use ortho_config::{OrthoConfig, OrthoError};
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 struct ExtendsCfg {
-    #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     foo: Option<String>,
 }
 
-#[test]
+#[rstest]
 fn extended_file_overrides_base() {
     figment::Jail::expect_with(|j| {
         j.create_file("base.toml", "foo = \"base\"")?;
         j.create_file(".config.toml", "extends = \"base.toml\"\nfoo = \"child\"")?;
-        let cli = ExtendsCfg::parse_from(["prog"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = ExtendsCfg::load_from_iter(["prog"]).expect("load");
         assert_eq!(cfg.foo.as_deref(), Some("child"));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn env_and_cli_override_extended_file() {
     figment::Jail::expect_with(|j| {
         j.create_file("base.toml", "foo = \"base\"")?;
         j.create_file(".config.toml", "extends = \"base.toml\"\nfoo = \"file\"")?;
         j.set_env("FOO", "env");
-        let cli = ExtendsCfg::parse_from(["prog", "--foo", "cli"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = ExtendsCfg::load_from_iter(["prog", "--foo", "cli"]).expect("load");
         assert_eq!(cfg.foo.as_deref(), Some("cli"));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn cyclic_inheritance_is_detected() {
     figment::Jail::expect_with(|j| {
         j.create_file("a.toml", "extends = \"b.toml\"\nfoo = \"a\"")?;
         j.create_file("b.toml", "extends = \"a.toml\"\nfoo = \"b\"")?;
         j.create_file(".config.toml", "extends = \"a.toml\"")?;
-        let cli = ExtendsCfg::parse_from(["prog"]);
-        let err = cli.load_and_merge().unwrap_err();
+        let err = ExtendsCfg::load_from_iter(["prog"]).unwrap_err();
         assert!(matches!(err, OrthoError::CyclicExtends { .. }));
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
 fn missing_base_file_errors() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "extends = \"missing.toml\"")?;
-        let cli = ExtendsCfg::parse_from(["prog"]);
-        let err = cli.load_and_merge().unwrap_err();
+        let err = ExtendsCfg::load_from_iter(["prog"]).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("missing.toml"));
         Ok(())

--- a/ortho_config/tests/features/cli_precedence.feature
+++ b/ortho_config/tests/features/cli_precedence.feature
@@ -1,0 +1,6 @@
+Feature: CLI precedence
+  Scenario: CLI overrides environment and file values
+    Given the configuration file has rules "file"
+    And the environment variable DDLINT_RULES is "env"
+    When the config is loaded with CLI rules "cli"
+    Then the loaded rules are "cli"

--- a/ortho_config/tests/merge_strategy.rs
+++ b/ortho_config/tests/merge_strategy.rs
@@ -1,43 +1,54 @@
 //! Tests for the append merge strategy on vectors.
 
-#![allow(non_snake_case)]
-use clap::Parser;
 use ortho_config::OrthoConfig;
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 struct VecConfig {
     #[ortho_config(merge_strategy = "append")]
-    #[arg(long)]
     values: Vec<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 struct DefaultVec {
     #[ortho_config(default = vec!["def".to_string()], merge_strategy = "append")]
-    #[arg(long)]
     values: Vec<String>,
 }
 
-#[test]
+#[derive(Debug, Deserialize, Serialize, OrthoConfig)]
+struct EmptyVec {
+    #[ortho_config(default = vec![], merge_strategy = "append")]
+    values: Vec<String>,
+}
+
+#[rstest]
 fn append_merges_all_sources() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "values = [\"file\"]")?;
         j.set_env("VALUES", "[\"env\"]");
-        let cli = VecConfig::parse_from(["prog", "--values", "cli1", "--values", "cli2"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = VecConfig::load_from_iter(["prog", "--values", "cli1", "--values", "cli2"])
+            .expect("load");
         assert_eq!(cfg.values, vec!["file", "env", "cli1", "cli2"]);
         Ok(())
     });
 }
 
-#[test]
+#[rstest]
+fn append_empty_sources_yields_empty() {
+    figment::Jail::expect_with(|_| {
+        let cfg = EmptyVec::load_from_iter(["prog"]).expect("load");
+        assert!(cfg.values.is_empty());
+        Ok(())
+    });
+}
+
+#[rstest]
 fn append_includes_defaults() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "values = [\"file\"]")?;
         j.set_env("VALUES", "[\"env\"]");
-        let cli = DefaultVec::parse_from(["prog", "--values", "cli"]);
-        let cfg = cli.load_and_merge().expect("load");
+        let cfg = DefaultVec::load_from_iter(["prog", "--values", "cli"]).expect("load");
         assert_eq!(cfg.values, vec!["def", "file", "env", "cli"]);
         Ok(())
     });

--- a/ortho_config/tests/steps/cli_steps.rs
+++ b/ortho_config/tests/steps/cli_steps.rs
@@ -1,0 +1,42 @@
+//! Steps verifying CLI precedence over environment variables and files.
+
+use crate::{RulesConfig, World};
+use cucumber::{given, then, when};
+use ortho_config::OrthoConfig;
+
+#[given(expr = "the configuration file has rules {string}")]
+fn file_rules(world: &mut World, val: String) {
+    world.file_value = Some(val);
+}
+
+#[when(expr = "the config is loaded with CLI rules {string}")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step signature requires owned String"
+)]
+fn load_with_cli(world: &mut World, cli: String) {
+    let file_val = world.file_value.clone();
+    let env_val = world.env_value.clone();
+    let mut result = None;
+    figment::Jail::expect_with(|j| {
+        if let Some(f) = file_val {
+            j.create_file(".ddlint.toml", &format!("rules = [\"{f}\"]"))?;
+        }
+        if let Some(e) = env_val {
+            j.set_env("DDLINT_RULES", &e);
+        }
+        result = Some(RulesConfig::load_from_iter(["prog", "--rules", &cli]));
+        Ok(())
+    });
+    world.result = result;
+}
+
+#[then(expr = "the loaded rules are {string}")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step signature requires owned String"
+)]
+fn loaded_rules(world: &mut World, expected: String) {
+    let cfg = world.result.take().expect("result").expect("ok");
+    assert_eq!(cfg.rules.last().expect("rule"), &expected);
+}

--- a/ortho_config/tests/steps/env_steps.rs
+++ b/ortho_config/tests/steps/env_steps.rs
@@ -4,8 +4,8 @@
 //! using [`CsvEnv`], and verifying parsed results.
 
 use crate::{RulesConfig, World};
-use clap::Parser;
 use cucumber::{given, then, when};
+use ortho_config::OrthoConfig;
 
 /// Sets `DDLINT_RULES` in the test environment.
 #[given(expr = "the environment variable DDLINT_RULES is {string}")]
@@ -19,8 +19,7 @@ fn load_config(world: &mut World) {
     let mut result = None;
     figment::Jail::expect_with(|j| {
         j.set_env("DDLINT_RULES", &val);
-        let cli = RulesConfig::parse_from(["prog"]);
-        result = Some(cli.load_and_merge());
+        result = Some(RulesConfig::load_from_iter(["prog"]));
         Ok(())
     });
     world.result = result;

--- a/ortho_config/tests/steps/extends_steps.rs
+++ b/ortho_config/tests/steps/extends_steps.rs
@@ -1,8 +1,8 @@
 //! Steps for testing configuration inheritance.
 
 use crate::{RulesConfig, World};
-use clap::Parser;
 use cucumber::{given, then, when};
+use ortho_config::OrthoConfig;
 
 #[given("a configuration file extending a base file")]
 fn create_files(world: &mut World) {
@@ -30,8 +30,7 @@ fn load_extended(world: &mut World) {
                 "extends = \"base.toml\"\nrules = [\"child\"]",
             )?;
         }
-        let cli = RulesConfig::parse_from(["prog"]);
-        result = Some(cli.load_and_merge());
+        result = Some(RulesConfig::load_from_iter(["prog"]));
         Ok(())
     });
     world.result = result;
@@ -45,8 +44,7 @@ fn load_cyclic(world: &mut World) {
         j.create_file("a.toml", "extends = \"b.toml\"\nrules = [\"a\"]")?;
         j.create_file("b.toml", "extends = \"a.toml\"\nrules = [\"b\"]")?;
         j.create_file(".ddlint.toml", "extends = \"a.toml\"")?;
-        let cli = RulesConfig::parse_from(["prog"]);
-        result = Some(cli.load_and_merge());
+        result = Some(RulesConfig::load_from_iter(["prog"]));
         Ok(())
     });
     world.result = result;
@@ -61,8 +59,7 @@ fn load_missing_base(world: &mut World) {
             ".ddlint.toml",
             "extends = \"missing.toml\"\nrules = [\"main\"]",
         )?;
-        let cli = RulesConfig::parse_from(["prog"]);
-        result = Some(cli.load_and_merge());
+        result = Some(RulesConfig::load_from_iter(["prog"]));
         Ok(())
     });
     world.result = result;

--- a/ortho_config/tests/steps/mod.rs
+++ b/ortho_config/tests/steps/mod.rs
@@ -1,3 +1,4 @@
+pub mod cli_steps;
 pub mod env_steps;
 pub mod extends_steps;
 pub mod subcommand_steps;

--- a/ortho_config/tests/ui/invalid_cli_short.rs
+++ b/ortho_config/tests/ui/invalid_cli_short.rs
@@ -1,0 +1,7 @@
+use ortho_config::OrthoConfig;
+
+#[derive(OrthoConfig)]
+struct Bad {
+    #[ortho_config(cli_short = '?')]
+    field: String,
+}

--- a/ortho_config/tests/ui/invalid_cli_short.stderr
+++ b/ortho_config/tests/ui/invalid_cli_short.stderr
@@ -1,0 +1,11 @@
+error: invalid `cli_short` value '?': must be an ASCII alphanumeric character
+ --> tests/ui/invalid_cli_short.rs:6:5
+  |
+6 |     field: String,
+  |     ^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/invalid_cli_short.rs:7:2
+  |
+7 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/ui/invalid_cli_short.rs`

--- a/ortho_config/tests/ui/reserved_cli_long.rs
+++ b/ortho_config/tests/ui/reserved_cli_long.rs
@@ -1,0 +1,7 @@
+use ortho_config::OrthoConfig;
+
+#[derive(OrthoConfig)]
+struct Bad {
+    #[ortho_config(cli_long = "help")]
+    field: String,
+}

--- a/ortho_config/tests/ui/reserved_cli_long.stderr
+++ b/ortho_config/tests/ui/reserved_cli_long.stderr
@@ -1,0 +1,11 @@
+error: reserved `cli_long` value 'help': conflicts with global clap flags
+ --> tests/ui/reserved_cli_long.rs:6:5
+  |
+6 |     field: String,
+  |     ^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/reserved_cli_long.rs:7:2
+  |
+7 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/ui/reserved_cli_long.rs`

--- a/ortho_config/tests/ui/short_flag_collision.rs
+++ b/ortho_config/tests/ui/short_flag_collision.rs
@@ -1,0 +1,9 @@
+use ortho_config::OrthoConfig;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, OrthoConfig)]
+struct Collide {
+    second: Option<String>,
+    sample: Option<String>,
+    spare: Option<String>,
+}

--- a/ortho_config/tests/ui/short_flag_collision.stderr
+++ b/ortho_config/tests/ui/short_flag_collision.stderr
@@ -1,0 +1,11 @@
+error: short flag collision; supply `cli_short`
+ --> tests/ui/short_flag_collision.rs:8:5
+  |
+8 |     spare: Option<String>,
+  |     ^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/short_flag_collision.rs:9:2
+  |
+9 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/ui/short_flag_collision.rs`

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -9,8 +9,13 @@ use quote::quote;
 use syn::Ident;
 
 /// Identifiers used when generating the load implementation.
+#[expect(
+    clippy::struct_field_names,
+    reason = "Field names mirror their purpose for clarity"
+)]
 pub(crate) struct LoadImplIdents<'a> {
-    pub ident: &'a Ident,
+    pub cli_ident: &'a Ident,
+    pub config_ident: &'a Ident,
     pub defaults_ident: &'a Ident,
 }
 
@@ -50,7 +55,7 @@ pub(crate) fn build_file_discovery(
         ..
     } = tokens;
     let config_path_chain = if has_config_path {
-        quote! { .chain(self.config_path.clone()) }
+        quote! { .chain(cli.config_path.clone()) }
     } else {
         quote! {}
     };
@@ -101,7 +106,11 @@ pub(crate) fn build_merge_section(
     idents: &LoadImplIdents<'_>,
     tokens: &LoadImplTokens<'_>,
 ) -> proc_macro2::TokenStream {
-    let LoadImplIdents { defaults_ident, .. } = *idents;
+    let LoadImplIdents {
+        defaults_ident,
+        config_ident,
+        ..
+    } = *idents;
     let LoadImplTokens {
         default_struct_init,
         override_init_ts,
@@ -122,13 +131,13 @@ pub(crate) fn build_merge_section(
 
         fig = fig
             .merge(env_provider.clone())
-            .merge(Serialized::defaults(self));
+            .merge(Serialized::defaults(&cli));
 
         #append_logic
 
         fig = fig.merge(Serialized::defaults(overrides));
 
-        fig.extract().map_err(ortho_config::OrthoError::Gathering)
+        fig.extract::<#config_ident>().map_err(ortho_config::OrthoError::Gathering)
     }
 }
 
@@ -139,18 +148,24 @@ pub(crate) fn build_load_impl(args: &LoadImplArgs<'_>) -> proc_macro2::TokenStre
         tokens,
         has_config_path,
     } = args;
-    let LoadImplIdents { ident, .. } = idents;
+    let LoadImplIdents {
+        cli_ident,
+        config_ident,
+        ..
+    } = idents;
     let file_discovery = build_file_discovery(tokens, *has_config_path);
     let env_section = build_env_section(tokens);
     let merge_section = build_merge_section(idents, tokens);
 
     quote! {
-        impl #ident {
+        impl #cli_ident {
             #[expect(dead_code, reason = "Generated method may not be used in all builds")]
-            pub fn load_and_merge(&self) -> Result<Self, ortho_config::OrthoError>
+            pub fn load_from_iter<I, T>(iter: I) -> Result<#config_ident, ortho_config::OrthoError>
             where
-                Self: serde::Serialize,
+                I: IntoIterator<Item = T>,
+                T: Into<std::ffi::OsString> + Clone,
             {
+                use clap::Parser as _;
                 use figment::{Figment, providers::{Toml, Serialized}, Profile};
                 use ortho_config::CsvEnv;
                 #[cfg(feature = "json5")] use figment_json5::Json5;
@@ -158,6 +173,9 @@ pub(crate) fn build_load_impl(args: &LoadImplArgs<'_>) -> proc_macro2::TokenStre
                 use uncased::Uncased;
                 #[cfg(feature = "yaml")] use serde_yaml;
                 #[cfg(feature = "toml")] use toml;
+
+                let cli = Self::try_parse_from(iter)
+                    .map_err(ortho_config::OrthoError::CliParsing)?;
 
                 #file_discovery
                 #env_section

--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -17,7 +17,7 @@ mod derive {
 }
 
 use derive::build::{
-    build_append_logic, build_config_env_var, build_default_struct_fields,
+    build_append_logic, build_cli_struct_fields, build_config_env_var, build_default_struct_fields,
     build_default_struct_init, build_dotfile_name, build_env_provider, build_override_struct,
     build_xdg_snippet, collect_append_fields,
 };
@@ -37,20 +37,12 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
         Err(e) => return e.to_compile_error().into(),
     };
 
-    let components = build_macro_components(&ident, &fields, &struct_attrs, &field_attrs);
-    let defaults_struct = generate_defaults_struct(
-        &components.defaults_ident,
-        &components.default_struct_fields,
-    );
-    let trait_impl =
-        generate_trait_implementation(&ident, &components.load_impl, components.prefix_fn);
-    let override_struct_ts = components.override_struct_ts;
-
-    let expanded = quote! {
-        #defaults_struct
-        #override_struct_ts
-        #trait_impl
+    let components = match build_macro_components(&ident, &fields, &struct_attrs, &field_attrs) {
+        Ok(v) => v,
+        Err(e) => return e.to_compile_error().into(),
     };
+
+    let expanded = generate_trait_implementation(&ident, &components);
 
     TokenStream::from(expanded)
 }
@@ -59,6 +51,8 @@ pub fn derive_ortho_config(input: TokenStream) -> TokenStream {
 struct MacroComponents {
     defaults_ident: syn::Ident,
     default_struct_fields: Vec<proc_macro2::TokenStream>,
+    cli_ident: syn::Ident,
+    cli_struct_fields: Vec<proc_macro2::TokenStream>,
     override_struct_ts: proc_macro2::TokenStream,
     load_impl: proc_macro2::TokenStream,
     prefix_fn: Option<proc_macro2::TokenStream>,
@@ -70,9 +64,11 @@ fn build_macro_components(
     fields: &[syn::Field],
     struct_attrs: &derive::parse::StructAttrs,
     field_attrs: &[derive::parse::FieldAttrs],
-) -> MacroComponents {
+) -> syn::Result<MacroComponents> {
     let defaults_ident = format_ident!("__{}Defaults", ident);
     let default_struct_fields = build_default_struct_fields(fields);
+    let cli_ident = format_ident!("__{}Cli", ident);
+    let cli_struct_fields = build_cli_struct_fields(fields, field_attrs)?;
     let default_struct_init = build_default_struct_init(fields, field_attrs);
     let env_provider = build_env_provider(struct_attrs);
     let config_env_var = build_config_env_var(struct_attrs);
@@ -86,7 +82,8 @@ fn build_macro_components(
         .any(|f| f.ident.as_ref().is_some_and(|id| id == "config_path"));
     let load_impl = build_load_impl(&LoadImplArgs {
         idents: LoadImplIdents {
-            ident,
+            cli_ident: &cli_ident,
+            config_ident: ident,
             defaults_ident: &defaults_ident,
         },
         tokens: LoadImplTokens {
@@ -108,63 +105,61 @@ fn build_macro_components(
         }
     });
 
-    MacroComponents {
+    Ok(MacroComponents {
         defaults_ident,
         default_struct_fields,
+        cli_ident,
+        cli_struct_fields,
         override_struct_ts,
         load_impl,
         prefix_fn,
-    }
+    })
 }
 
-/// Generate the hidden defaults struct for the macro output.
-fn generate_defaults_struct(
-    ident: &syn::Ident,
-    fields: &[proc_macro2::TokenStream],
-) -> proc_macro2::TokenStream {
-    quote! {
-        #[derive(serde::Serialize)]
-        struct #ident {
-            #( #fields, )*
-        }
-    }
-}
-
-/// Generate the `OrthoConfig` trait implementation.
 fn generate_trait_implementation(
-    ident: &syn::Ident,
-    load_impl: &proc_macro2::TokenStream,
-    prefix_fn: Option<proc_macro2::TokenStream>,
+    config_ident: &syn::Ident,
+    components: &MacroComponents,
 ) -> proc_macro2::TokenStream {
-    let prefix_fn = prefix_fn.unwrap_or_else(|| quote! {});
+    let MacroComponents {
+        defaults_ident,
+        default_struct_fields,
+        cli_ident,
+        cli_struct_fields,
+        override_struct_ts,
+        load_impl,
+        prefix_fn,
+    } = components;
+    let prefix_fn = prefix_fn.clone().unwrap_or_else(|| quote! {});
     quote! {
+        #[derive(clap::Parser, serde::Serialize)]
+        struct #cli_ident {
+            #( #cli_struct_fields, )*
+        }
+
+        #[derive(serde::Serialize)]
+        struct #defaults_ident {
+            #( #default_struct_fields, )*
+        }
+
+        #override_struct_ts
+
         #load_impl
 
-        impl ortho_config::OrthoConfig for #ident {
-            fn load_and_merge(&self) -> Result<Self, ortho_config::OrthoError>
+        impl ortho_config::OrthoConfig for #config_ident {
+            fn load_from_iter<I, T>(iter: I) -> Result<Self, ortho_config::OrthoError>
             where
-                Self: serde::Serialize,
+                I: IntoIterator<Item = T>,
+                T: Into<std::ffi::OsString> + Clone,
             {
-                #ident::load_and_merge(self)
-            }
-
-            #[deprecated(
-                since = "0.4.0",
-                note = "Use `YourConfig::parse().load_and_merge()` instead",
-            )]
-            fn load() -> Result<Self, ortho_config::OrthoError> {
-                use clap::Parser as _;
-                Self::try_parse()
-                    .map_err(ortho_config::OrthoError::CliParsing)?
-                    .load_and_merge()
+                #cli_ident::load_from_iter(iter)
             }
 
             #prefix_fn
         }
 
         const _: () = {
-            fn _assert_serialize<T: serde::Serialize>() {}
-            let _ = _assert_serialize::<#ident>;
+            fn _assert_deser<T: serde::de::DeserializeOwned>() {}
+            let _ = _assert_deser::<#config_ident>;
         };
     }
 }

--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -68,7 +68,17 @@ fn build_macro_components(
     let defaults_ident = format_ident!("__{}Defaults", ident);
     let default_struct_fields = build_default_struct_fields(fields);
     let cli_ident = format_ident!("__{}Cli", ident);
-    let cli_struct_fields = build_cli_struct_fields(fields, field_attrs)?;
+    let has_user_config_path = fields
+        .iter()
+        .any(|f| f.ident.as_ref().is_some_and(|id| id == "config_path"));
+    let mut cli_struct_fields = build_cli_struct_fields(fields, field_attrs)?;
+    if !has_user_config_path {
+        cli_struct_fields.push(quote! {
+            #[arg(long = "config-path", hide = true)]
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub config_path: Option<std::path::PathBuf>
+        });
+    }
     let default_struct_init = build_default_struct_init(fields, field_attrs);
     let env_provider = build_env_provider(struct_attrs);
     let config_env_var = build_config_env_var(struct_attrs);
@@ -77,9 +87,7 @@ fn build_macro_components(
     let append_fields = collect_append_fields(fields, field_attrs);
     let (override_struct_ts, override_init_ts) = build_override_struct(ident, &append_fields);
     let append_logic = build_append_logic(&append_fields);
-    let has_config_path = fields
-        .iter()
-        .any(|f| f.ident.as_ref().is_some_and(|id| id == "config_path"));
+    let has_config_path = true;
     let load_impl = build_load_impl(&LoadImplArgs {
         idents: LoadImplIdents {
             cli_ident: &cli_ident,
@@ -116,31 +124,50 @@ fn build_macro_components(
     })
 }
 
-fn generate_trait_implementation(
-    config_ident: &syn::Ident,
-    components: &MacroComponents,
-) -> proc_macro2::TokenStream {
+/// Generate the hidden `clap::Parser` struct.
+fn generate_cli_struct(components: &MacroComponents) -> proc_macro2::TokenStream {
     let MacroComponents {
-        defaults_ident,
-        default_struct_fields,
         cli_ident,
         cli_struct_fields,
-        override_struct_ts,
-        load_impl,
-        prefix_fn,
+        ..
     } = components;
-    let prefix_fn = prefix_fn.clone().unwrap_or_else(|| quote! {});
     quote! {
         #[derive(clap::Parser, serde::Serialize)]
         struct #cli_ident {
             #( #cli_struct_fields, )*
         }
+    }
+}
 
+/// Generate the struct used to store default values.
+fn generate_defaults_struct(components: &MacroComponents) -> proc_macro2::TokenStream {
+    let MacroComponents {
+        defaults_ident,
+        default_struct_fields,
+        ..
+    } = components;
+    quote! {
         #[derive(serde::Serialize)]
         struct #defaults_ident {
             #( #default_struct_fields, )*
         }
+    }
+}
 
+/// Generate the `OrthoConfig` trait implementation.
+fn generate_ortho_impl(
+    config_ident: &syn::Ident,
+    components: &MacroComponents,
+) -> proc_macro2::TokenStream {
+    let MacroComponents {
+        cli_ident,
+        override_struct_ts,
+        load_impl,
+        prefix_fn,
+        ..
+    } = components;
+    let prefix_fn = prefix_fn.clone().unwrap_or_else(|| quote! {});
+    quote! {
         #override_struct_ts
 
         #load_impl
@@ -161,5 +188,19 @@ fn generate_trait_implementation(
             fn _assert_deser<T: serde::de::DeserializeOwned>() {}
             let _ = _assert_deser::<#config_ident>;
         };
+    }
+}
+
+fn generate_trait_implementation(
+    config_ident: &syn::Ident,
+    components: &MacroComponents,
+) -> proc_macro2::TokenStream {
+    let cli_struct = generate_cli_struct(components);
+    let defaults_struct = generate_defaults_struct(components);
+    let ortho_impl = generate_ortho_impl(config_ident, components);
+    quote! {
+        #cli_struct
+        #defaults_struct
+        #ortho_impl
     }
 }


### PR DESCRIPTION
## Summary
- generate an internal clap `Parser` struct and expose a `load_from_iter` API
- document the automatic CLI flag generation and updated loading flow
- cover CLI precedence with unit and cucumber tests
- correct Mermaid example so `make nixie` validates documentation

## Testing
- `make fmt`
- `make lint`
- `TRYBUILD=overwrite make test`
- `make markdownlint`
- `make nixie` *(fails: error: too many arguments. Expected 0 arguments but got 1.)*

------
https://chatgpt.com/codex/tasks/task_e_689299f2537483228323afb8ddc1cbd5

## Summary by Sourcery

Generate an internal clap Parser behind the scenes and provide a streamlined load API, implement automatic and collision-safe flag derivation (including reserved names), refactor the derive macro into clear components, update docs accordingly, and extend tests to cover the new behavior.

New Features:
- Derive macro now emits a hidden clap::Parser struct and exposes a unified load_from_iter API with a convenience load() method
- Automatic CLI flag generation with long names derived from kebab-case and short names from field initials, including collision resolution and reserved-flag validation
- Built-in --config-path option for overriding the configuration file location at runtime

Enhancements:
- Remove the public clap::Parser requirement from OrthoConfig trait and refactor it to only require serde and the new load/load_from_iter methods
- Refactor macro code into distinct components (CLI struct, defaults struct, OrthoConfig impl) and consolidate shared snippets for XDG discovery and flag validation
- Revise documentation to explain hidden parser, automatic flag naming, and updated loading flow, and correct Mermaid diagram syntax

Documentation:
- Update user guide and design docs to remove manual clap derive, describe automatic CLI generation, and reflect new load API
- Fix mermaid example to satisfy documentation lints

Tests:
- Update integration, unit, cucumber, and UI tests to use load_from_iter/load(), cover flag precedence, validation errors, duplicate flags, short-flag collisions, missing required values, config_path overrides, merge strategies, and subcommand loading