### PR TITLE
Refactor short flag resolution

### DIFF
--- a/ortho_config/tests/ui/invalid_cli_short.rs
+++ b/ortho_config/tests/ui/invalid_cli_short.rs
@@ -1,7 +1,6 @@
 use ortho_config::OrthoConfig;
-use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, OrthoConfig)]
+#[derive(OrthoConfig)]
 struct Bad {
     #[ortho_config(cli_short = '?')]
     field: String,

--- a/ortho_config/tests/ui/invalid_cli_short.rs
+++ b/ortho_config/tests/ui/invalid_cli_short.rs
@@ -1,6 +1,7 @@
 use ortho_config::OrthoConfig;
+use serde::{Deserialize, Serialize};
 
-#[derive(OrthoConfig)]
+#[derive(Deserialize, Serialize, OrthoConfig)]
 struct Bad {
     #[ortho_config(cli_short = '?')]
     field: String,

--- a/ortho_config/tests/ui/invalid_cli_short.stderr
+++ b/ortho_config/tests/ui/invalid_cli_short.stderr
@@ -1,4 +1,4 @@
-error: invalid `cli_short` value '?': must be an ASCII alphanumeric character
+error: invalid `cli_short` '?': must be ASCII alnum
  --> tests/ui/invalid_cli_short.rs:6:5
   |
 6 |     field: String,

--- a/ortho_config/tests/ui/invalid_cli_short.stderr
+++ b/ortho_config/tests/ui/invalid_cli_short.stderr
@@ -1,11 +1,11 @@
-error: invalid `cli_short` '?': must be ASCII alnum
- --> tests/ui/invalid_cli_short.rs:7:5
+error: invalid `cli_short` '?': must be ASCII alphanumeric
+ --> tests/ui/invalid_cli_short.rs:6:5
   |
-7 |     field: String,
+6 |     field: String,
   |     ^^^^^
 
 error[E0601]: `main` function not found in crate `$CRATE`
- --> tests/ui/invalid_cli_short.rs:8:2
+ --> tests/ui/invalid_cli_short.rs:7:2
   |
-8 | }
+7 | }
   |  ^ consider adding a `main` function to `$DIR/tests/ui/invalid_cli_short.rs`

--- a/ortho_config/tests/ui/invalid_cli_short.stderr
+++ b/ortho_config/tests/ui/invalid_cli_short.stderr
@@ -1,11 +1,11 @@
 error: invalid `cli_short` '?': must be ASCII alnum
- --> tests/ui/invalid_cli_short.rs:6:5
+ --> tests/ui/invalid_cli_short.rs:7:5
   |
-6 |     field: String,
+7 |     field: String,
   |     ^^^^^
 
 error[E0601]: `main` function not found in crate `$CRATE`
- --> tests/ui/invalid_cli_short.rs:7:2
+ --> tests/ui/invalid_cli_short.rs:8:2
   |
-7 | }
+8 | }
   |  ^ consider adding a `main` function to `$DIR/tests/ui/invalid_cli_short.rs`

--- a/ortho_config/tests/ui/short_flag_collision.stderr
+++ b/ortho_config/tests/ui/short_flag_collision.stderr
@@ -1,4 +1,4 @@
-error: short flag collision; supply `cli_short`
+error: short flag collision; supply `cli_short` to disambiguate
  --> tests/ui/short_flag_collision.rs:8:5
   |
 8 |     spare: Option<String>,

--- a/ortho_config_macros/src/derive/build.rs
+++ b/ortho_config_macros/src/derive/build.rs
@@ -42,7 +42,7 @@ fn resolve_short_flag(
     attrs: &FieldAttrs,
     used_shorts: &mut HashSet<char>,
 ) -> syn::Result<char> {
-    // Handle user-supplied cli_short first
+    // 1) If the user explicitly set `cli_short`, handle that first:
     if let Some(user) = attrs.cli_short {
         if !user.is_ascii_alphanumeric() {
             return Err(syn::Error::new_spanned(
@@ -57,15 +57,12 @@ fn resolve_short_flag(
             ));
         }
         if !used_shorts.insert(user) {
-            return Err(syn::Error::new_spanned(
-                name,
-                "short flag collision; choose a different `cli_short` value",
-            ));
+            return Err(syn::Error::new_spanned(name, "duplicate `cli_short` value"));
         }
         return Ok(user);
     }
 
-    // Try default lowercase then uppercase
+    // 2) Otherwise, try default lowercase then uppercase:
     let default = name
         .to_string()
         .chars()
@@ -77,7 +74,7 @@ fn resolve_short_flag(
         }
     }
 
-    // Both defaults failed, must be a collision
+    // 3) If both default attempts fail, it must be a collision:
     Err(syn::Error::new_spanned(
         name,
         "short flag collision; supply `cli_short` to disambiguate",
@@ -363,7 +360,7 @@ mod tests {
     #[case(
         'f',
         HashSet::from(['f']),
-        "short flag collision; choose a different `cli_short` value",
+        "duplicate `cli_short` value",
     )]
     fn rejects_invalid_short_flags(
         #[case] cli_short: char,

--- a/ortho_config_macros/src/derive/parse.rs
+++ b/ortho_config_macros/src/derive/parse.rs
@@ -161,9 +161,10 @@ fn type_inner<'a>(ty: &'a Type, wrapper: &str) -> Option<&'a Type> {
         let _ = segs.next();
 
         if let PathArguments::AngleBracketed(args) = &last.arguments {
-            if let Some(GenericArgument::Type(inner)) = args.args.first() {
-                return Some(inner);
-            }
+            return args.args.first().and_then(|arg| match arg {
+                GenericArgument::Type(inner) => Some(inner),
+                _ => None,
+            });
         }
     }
     None


### PR DESCRIPTION
## Summary
- simplify short flag resolution using iterator-based candidate filtering
- add coverage for short flag selection and errors
- align compile-fail expectations with updated messages

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893e471dce083228cea43878a58f8f7

## Summary by Sourcery

Refactor the short flag resolution to use iterator-based candidate filtering and simplify validation logic, update documentation example, and add comprehensive tests for short flag selection and error scenarios.

Enhancements:
- Simplify resolve_short_flag by iterating over default lowercase and uppercase candidates and filtering them by ASCII alphanumeric, reserved, and used sets
- Consolidate validation and error reporting for invalid, reserved, and duplicate CLI short flags into a single flow

Documentation:
- Update the doc comment example to use expect instead of unwrap for short flag resolution

Tests:
- Add rstest-based tests for default lowercase selection, uppercase fallback, and invalid, reserved, and duplicate cli_short error cases
- Align compile-fail UI test expectations for invalid and collision error messages