### PR TITLE
Consolidate Prefix::new documentation

### DIFF
--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -22,12 +22,11 @@ pub struct Prefix {
 }
 
 impl Prefix {
-    /// Create a new `Prefix` from `raw`. The `raw` value is kept as-is for
-    /// environment variables while a normalized version is used for file paths.
-    #[must_use]
-    /// Creates a new `Prefix` from a raw string, storing both the original and a normalised lowercase version.
+    /// Creates a new `Prefix` from a raw string, storing both the original and
+    /// a normalised lowercase version.
     ///
-    /// The raw string is preserved for use in environment variable names, while the normalised form is used for file path lookups.
+    /// The raw string is preserved for use in environment variable names, while
+    /// the normalised form is used for file path lookups.
     ///
     /// # Examples
     ///
@@ -36,6 +35,7 @@ impl Prefix {
     /// let prefix = Prefix::new("MyApp");
     /// let _ = prefix;
     /// ```
+    #[must_use]
     pub fn new(raw: &str) -> Self {
         Self {
             raw: raw.to_owned(),


### PR DESCRIPTION
## Summary
- merge duplicated doc comments for `Prefix::new` into a single block before `#[must_use]`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68952090ee908322893374ee52ec31b6