### PR TITLE
Add usage example for normalize_prefix

### DIFF
--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -28,6 +28,7 @@ pub use subcommand::{
 /// use ortho_config::normalize_prefix;
 ///
 /// assert_eq!(normalize_prefix("FOO__"), "foo");
+/// assert_eq!(normalize_prefix("foo"), "foo");
 /// ```
 #[must_use]
 pub fn normalize_prefix(prefix: &str) -> String {

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -21,6 +21,14 @@ pub use subcommand::{
 
 /// Normalize a prefix by trimming trailing underscores and converting
 /// to lowercase ASCII.
+///
+/// # Examples
+///
+/// ```rust
+/// use ortho_config::normalize_prefix;
+///
+/// assert_eq!(normalize_prefix("FOO__"), "foo");
+/// ```
 #[must_use]
 pub fn normalize_prefix(prefix: &str) -> String {
     prefix.trim_end_matches('_').to_ascii_lowercase()

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -30,6 +30,8 @@ pub use subcommand::{
 /// assert_eq!(normalize_prefix("FOO__"), "foo");
 /// assert_eq!(normalize_prefix("foo"), "foo");
 /// assert_eq!(normalize_prefix("Another_App_"), "another_app");
+/// assert_eq!(normalize_prefix("___"), "");
+/// assert_eq!(normalize_prefix("FÖÖ_"), "fÖÖ"); // ASCII-only lowercasing; non-ASCII remains unchanged
 /// ```
 #[must_use]
 pub fn normalize_prefix(prefix: &str) -> String {

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -29,6 +29,7 @@ pub use subcommand::{
 ///
 /// assert_eq!(normalize_prefix("FOO__"), "foo");
 /// assert_eq!(normalize_prefix("foo"), "foo");
+/// assert_eq!(normalize_prefix("Another_App_"), "another_app");
 /// ```
 #[must_use]
 pub fn normalize_prefix(prefix: &str) -> String {


### PR DESCRIPTION
## Summary
- document a typical call to `normalize_prefix`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689633bfea348322b567adacd739ac22

## Summary by Sourcery

Documentation:
- Add a code example in the normalize_prefix doc comment demonstrating trailing underscore trimming and lowercase conversion