### PR TITLE
Prevent CLI None overriding defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ readme = "README.md"
 keywords = ["config", "configuration", "cli", "env", "settings"]
 categories = ["config", "command-line-interface"]
 
-[workspace.dev-dependencies]
-cucumber = "0.21.1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 # `cargo clippy` lints configuration
 [workspace.lints.clippy]

--- a/docs/design.md
+++ b/docs/design.md
@@ -80,7 +80,8 @@ The primary data flow for a user calling `AppConfig::load()` will be:
      before merging so that environment or file defaults remain untouched. This
      serialisation step relies on `serde_json` and introduces a small overhead;
      if configuration loading becomes a hotspot, benchmark to evaluate a more
-     direct approach.
+     direct approach. A helper, `sanitized_provider`, wraps sanitisation and
+     provider construction to avoid repeating the pattern.
 
 4. `figment`'s `extract()` method is called to deserialize the merged
    configuration into the user's `AppConfig` struct.

--- a/docs/design.md
+++ b/docs/design.md
@@ -279,13 +279,15 @@ retained but deprecated.
 - **`ortho_config` (Core):**
   - `clap`: For CLI parsing. Choose a version with the `derive` feature.
   - `figment`: As the core layering engine.
-  - `serde`: For serialization/deserialization.
-  - `toml`, `figment-json5`, `json5`, `serde_json`, `serde_yaml`: As
-    optional feature-gated dependencies for different file formats. `toml`
-    should be a default feature. The `json5` feature uses `figment-json5` and
-    `json5` to parse `.json` and `.json5` files and `serde_json` for
-    validation; loading these formats without enabling `json5` should produce
-    an error, so users aren't surprised by silent TOML parsing.
+  - `serde`: For serialisation/deserialisation.
+  - `serde_json`: For manipulating configuration when pruning `None` CLI
+    values.
+  - `toml`, `figment-json5`, `json5`, `serde_yaml`: As optional feature-gated
+    dependencies for different file formats. `toml` should be a default
+    feature. The `json5` feature uses `figment-json5` and `json5` to parse
+    `.json` and `.json5` files and relies on `serde_json` for validation;
+    loading these formats without enabling `json5` should produce an error, so
+    users aren't surprised by silent TOML parsing.
   - `thiserror`: For ergonomic error type definitions.
 
 ## 6. Implementation Roadmap

--- a/docs/design.md
+++ b/docs/design.md
@@ -76,7 +76,8 @@ The primary data flow for a user calling `AppConfig::load()` will be:
    - **Environment Provider:** An `Env` provider configured with the correct
      prefix and key-mapping rules.
    - **CLI Provider:** The `clap`-parsed arguments are serialized into a
-     `figment` provider and merged last.
+     `figment` provider and merged last. Fields left as `None` are removed
+     before merging so that environment or file defaults remain untouched.
 4. `figment`'s `extract()` method is called to deserialize the merged
    configuration into the user's `AppConfig` struct.
 5. Array merging logic is applied post-deserialization if the "append" strategy

--- a/docs/design.md
+++ b/docs/design.md
@@ -78,9 +78,9 @@ The primary data flow for a user calling `AppConfig::load()` will be:
    - **CLI Provider:** The `clap`-parsed arguments are serialized into a
      `figment` provider and merged last. Fields left as `None` are removed
      before merging so that environment or file defaults remain untouched. This
-     serialisation step relies on `serde_json` and introduces a small overhead;
+     serialization step relies on `serde_json` and introduces a small overhead;
      if configuration loading becomes a hotspot, benchmark to evaluate a more
-     direct approach. A helper, `sanitized_provider`, wraps sanitisation and
+     direct approach. A helper, `sanitized_provider`, wraps sanitization and
      provider construction to avoid repeating the pattern.
 
 4. `figment`'s `extract()` method is called to deserialize the merged
@@ -284,7 +284,7 @@ retained but deprecated.
 - **`ortho_config` (Core):**
   - `clap`: For CLI parsing. Choose a version with the `derive` feature.
   - `figment`: As the core layering engine.
-  - `serde`: For serialisation/deserialisation.
+  - `serde`: For serialization/deserialization.
   - `serde_json`: For manipulating configuration when pruning `None` CLI
     values.
   - `toml`, `figment-json5`, `json5`, `serde_yaml`: As optional feature-gated

--- a/docs/design.md
+++ b/docs/design.md
@@ -77,7 +77,11 @@ The primary data flow for a user calling `AppConfig::load()` will be:
      prefix and key-mapping rules.
    - **CLI Provider:** The `clap`-parsed arguments are serialized into a
      `figment` provider and merged last. Fields left as `None` are removed
-     before merging so that environment or file defaults remain untouched.
+     before merging so that environment or file defaults remain untouched. This
+     serialisation step relies on `serde_json` and introduces a small overhead;
+     if configuration loading becomes a hotspot, benchmark to evaluate a more
+     direct approach.
+
 4. `figment`'s `extract()` method is called to deserialize the merged
    configuration into the user's `AppConfig` struct.
 5. Array merging logic is applied post-deserialization if the "append" strategy

--- a/docs/design.md
+++ b/docs/design.md
@@ -290,8 +290,8 @@ retained but deprecated.
   - `toml`, `figment-json5`, `json5`, `serde_yaml`: As optional feature-gated
     dependencies for different file formats. `toml` should be a default
     feature. The `json5` feature uses `figment-json5` and `json5` to parse
-    `.json` and `.json5` files and relies on `serde_json` for validation;
-    loading these formats without enabling `json5` should produce an error, so
+    `.json` and `.json5` files and relies on `serde_json` for validation.
+    Loading these formats without enabling `json5` should produce an error, so
     users aren't surprised by silent TOML parsing.
   - `thiserror`: For ergonomic error type definitions.
 

--- a/docs/reliable-testing-in-rust-via-dependency-injection.md
+++ b/docs/reliable-testing-in-rust-via-dependency-injection.md
@@ -1,14 +1,26 @@
 # 🛡️ Reliable Testing in Rust via Dependency Injection
 
-Writing robust, reliable, and parallelisable tests requires an intentional approach to handling external dependencies such as environment variables, the filesystem, or the system clock. Functions that directly call `std::env::var` or `SystemTime::now()` are difficult to test because they depend on global, non-deterministic state.
+Writing robust, reliable, and parallelisable tests requires an intentional
+approach to handling external dependencies such as environment variables, the
+filesystem, or the system clock. Functions that directly call `std::env::var`
+or `SystemTime::now()` are difficult to test because they depend on global,
+non-deterministic state.
 
 This leads to several problems:
 
-- **Flaky Tests:** A test might pass or fail depending on the environment it runs in.
-- **Parallel Execution Conflicts:** Tests that modify the same global environment variable (`std::env::set_var`) will interfere with each other when run with `cargo test`.
-- **State Corruption:** A test that panics can fail to clean up its changes to the environment, poisoning subsequent tests.
+- **Flaky Tests:** A test might pass or fail depending on the environment it
+  runs in.
+- **Parallel Execution Conflicts:** Tests that modify the same global
+  environment variable (`std::env::set_var`) will interfere with each other
+  when run with `cargo test`.
+- **State Corruption:** A test that panics can fail to clean up its changes to
+  the environment, poisoning subsequent tests.
 
-The solution is a classic software design pattern: **Dependency Injection (DI)**. Instead of a function reaching out to the global state, its dependencies are provided as arguments. The `mockable` crate offers a convenient set of traits (`Env`, `Clock`, etc.) to implement this pattern for common system interactions in Rust.
+The solution is a classic software design pattern: **Dependency Injection
+(DI)**. Instead of a function reaching out to the global state, its
+dependencies are provided as arguments. The `mockable` crate offers a
+convenient set of traits (`Env`, `Clock`, etc.) to implement this pattern for
+common system interactions in Rust.
 
 ---
 
@@ -38,7 +50,8 @@ pub fn get_api_key() -> Option<String> {
 
 ### 3. Refactoring for Testability (After)
 
-The function is refactored to accept a generic type that implements the `mockable::Env` trait.
+The function is refactored to accept a generic type that implements the
+`mockable::Env` trait.
 
 ```rust
 use mockable::Env;
@@ -51,11 +64,13 @@ pub fn get_api_key(env: &impl Env) -> Option<String> {
 }
 ```
 
-The function's core logic remains unchanged, but its dependency on the environment is now explicit and injectable.
+The function's core logic remains unchanged, but its dependency on the
+environment is now explicit and injectable.
 
 ### 4. Writing Isolated Unit Tests
 
-Tests can use `MockEnv`, an in-memory mock, to simulate any environmental condition without touching the actual process environment.
+Tests can use `MockEnv`, an in-memory mock, to simulate any environmental
+condition without touching the actual process environment.
 
 ```rust
 #[cfg(test)]
@@ -85,11 +100,13 @@ mod tests {
 }
 ```
 
-These tests are fast, completely isolated from each other, and will never fail due to external state.
+These tests are fast, completely isolated from each other, and will never fail
+due to external state.
 
 ### 5. Usage in Production Code
 
-In production code, inject the "real" implementation, `RealEnv`, which calls the actual `std::env` functions.
+In production code, inject the "real" implementation, `RealEnv`, which calls
+the actual `std::env` functions.
 
 ```rust
 use mockable::RealEnv;
@@ -108,7 +125,9 @@ fn main() {
 
 ## 🔩 Handling Other Non-Deterministic Dependencies
 
-This dependency injection pattern also applies to other non-deterministic dependencies such as the system clock. `mockable` provides a `Clock` trait for this purpose.
+This dependency injection pattern also applies to other non-deterministic
+dependencies such as the system clock. `mockable` provides a `Clock` trait for
+this purpose.
 
 ### Untestable Code
 
@@ -172,10 +191,17 @@ In production, an instance of `RealClock::new()` would be used.
 
 ## 📌 Key Takeaways
 
-- **The Problem is Non-Determinism:** Directly accessing global state like `std::env` or `SystemTime::now` makes code hard to test.
-- **The Solution is Dependency Injection:** Pass dependencies into functions as arguments.
-- **Use** `mockable` **Traits:** Abstract dependencies behind traits such as `impl Env` or `impl Clock`.
-- **`Mock*` for Tests:** Use `MockEnv` and `MockClock` in unit tests for isolated, deterministic control.
-- **`Real*` for Production:** Use `RealEnv` and `RealClock` in the application to interact with the actual system.
-- **`RealEnv` is NOT a Scope Guard:** `RealEnv` directly mutates the global process environment without automatic cleanup. For integration tests that require modifying the live environment, consider a crate such as `temp_env`. For unit tests, `MockEnv` is preferable.
-
+- **The Problem is Non-Determinism:** Directly accessing global state like
+  `std::env` or `SystemTime::now` makes code hard to test.
+- **The Solution is Dependency Injection:** Pass dependencies into functions as
+  arguments.
+- **Use** `mockable` **Traits:** Abstract dependencies behind traits such as
+  `impl Env` or `impl Clock`.
+- **`Mock*` for Tests:** Use `MockEnv` and `MockClock` in unit tests for
+  isolated, deterministic control.
+- **`Real*` for Production:** Use `RealEnv` and `RealClock` in the application
+  to interact with the actual system.
+- **`RealEnv` is NOT a Scope Guard:** `RealEnv` directly mutates the global
+  process environment without automatic cleanup. For integration tests that
+  require modifying the live environment, consider a crate such as `temp_env`.
+  For unit tests, `MockEnv` is preferable.

--- a/docs/reliable-testing-in-rust-via-dependency-injection.md
+++ b/docs/reliable-testing-in-rust-via-dependency-injection.md
@@ -1,6 +1,6 @@
 # 🛡️ Reliable Testing in Rust via Dependency Injection
 
-Writing robust, reliable, and parallelisable tests requires an intentional
+Writing robust, reliable, and parallelizable tests requires an intentional
 approach to handling external dependencies such as environment variables, the
 filesystem, or the system clock. Functions that directly call `std::env::var`
 or `SystemTime::now()` are difficult to test because they depend on global,
@@ -18,9 +18,10 @@ This leads to several problems:
 
 The solution is a classic software design pattern: **Dependency Injection
 (DI)**. Instead of a function reaching out to the global state, its
-dependencies are provided as arguments. The `mockable` crate offers a
-convenient set of traits (`Env`, `Clock`, etc.) to implement this pattern for
-common system interactions in Rust.
+dependencies are provided as arguments. The
+[mockable](https://docs.rs/mockable/latest/mockable/) crate offers a convenient
+set of traits (`Env`, `Clock`, etc.) to implement this pattern for common
+system interactions in Rust.
 
 ---
 
@@ -126,7 +127,7 @@ fn main() {
 ## 🔩 Handling Other Non-Deterministic Dependencies
 
 This dependency injection pattern also applies to other non-deterministic
-dependencies such as the system clock. `mockable` provides a `Clock` trait for
+dependencies, such as the system clock. `mockable` provides a `Clock` trait for
 this purpose.
 
 ### Untestable Code
@@ -203,5 +204,6 @@ In production, an instance of `RealClock::new()` would be used.
   to interact with the actual system.
 - **`RealEnv` is NOT a Scope Guard:** `RealEnv` directly mutates the global
   process environment without automatic cleanup. For integration tests that
-  require modifying the live environment, consider a crate such as `temp_env`.
-  For unit tests, `MockEnv` is preferable.
+  require modifying the live environment, consider a crate such as
+  [temp_env](https://crates.io/crates/temp-env). For unit tests, `MockEnv` is
+  preferable.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,7 +72,7 @@ references the relevant design guidance.
 - **Improve merging and error reporting when combining CLI and configuration
   sources**
 
-  - [ ] Distinguish between values explicitly provided on the command line and
+  - [x] Distinguish between values explicitly provided on the command line and
     those left as `None` so that default values from env/file are not
     incorrectly overridden.
     [[Clap Dispatch](clap-dispatch-and-ortho-config-integration.md)]

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -398,6 +398,10 @@ underlying error.
   argument vectors to exercise the merge logic. The `figment` crate makes it
   easy to inject additional providers when writing unit tests.
 
+- **Sanitised providers** – The `sanitized_provider` helper returns a `Figment`
+  provider with `None` fields removed. It aids manual layering when bypassing
+  the derive macro.
+
 ## Conclusion
 
 `OrthoConfig` streamlines configuration management in Rust applications. By

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -11,7 +11,7 @@ repository.
 ## Core concepts and motivation
 
 Rust projects often wire together `clap` for CLI parsing, `serde` for
-de/serialisation, and ad‑hoc code for loading `*.toml` files or reading
+de/serialization, and ad‑hoc code for loading `*.toml` files or reading
 environment variables. Mapping between different naming conventions (kebab‑case
 flags, `UPPER_SNAKE_CASE` environment variables, and `snake_case` struct
 fields) can be tedious. `OrthoConfig` addresses these problems by letting
@@ -398,7 +398,7 @@ underlying error.
   argument vectors to exercise the merge logic. The `figment` crate makes it
   easy to inject additional providers when writing unit tests.
 
-- **Sanitised providers** – The `sanitized_provider` helper returns a `Figment`
+- **Sanitized providers** – The `sanitized_provider` helper returns a `Figment`
   provider with `None` fields removed. It aids manual layering when bypassing
   the derive macro.
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -277,7 +277,8 @@ Many CLI applications use `clap` subcommands to perform different operations.
 namespace. The helper function `load_and_merge_subcommand_for` loads defaults
 for a specific subcommand and merges them beneath the CLI values. The merged
 struct is returned as a new instance; the original `cli` struct remains
-unchanged.
+unchanged. CLI fields left unset (`None`) do not override environment or file
+defaults, avoiding accidental loss of configuration.
 
 ### How it works
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -400,7 +400,16 @@ underlying error.
 
 - **Sanitized providers** – The `sanitized_provider` helper returns a `Figment`
   provider with `None` fields removed. It aids manual layering when bypassing
-  the derive macro.
+  the derive macro. For example:
+
+  ```rust
+  use figment::{Figment, providers::Serialized};
+  use ortho_config::sanitized_provider;
+
+  let fig = Figment::from(Serialized::defaults(&Defaults::default()))
+      .merge(sanitized_provider(&cli)?);
+  let cfg: Defaults = fig.extract()?;
+  ```
 
 ## Conclusion
 

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -19,7 +19,7 @@ toml = { version = "0.8", optional = true }
 figment-json5 = { version = "0.1", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 json5 = { version = "0.4", optional = true }
-serde_json = { version = "1", optional = true }
+serde_json = { version = "1" }
 
 [target.'cfg(not(any(unix, target_os = "redox")))'.dependencies]
 directories = "6"
@@ -30,7 +30,7 @@ xdg = "3"
 [features]
 default = ["toml"]
 toml = ["figment/toml", "dep:toml"]
-json5 = ["dep:figment-json5", "dep:json5", "dep:serde_json"]
+json5 = ["dep:figment-json5", "dep:json5"]
 yaml = ["figment/yaml", "dep:serde_yaml"]
 
 [dev-dependencies]

--- a/ortho_config/src/error.rs
+++ b/ortho_config/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types produced by the configuration loader.
 
+use figment::error::Error as FigmentError;
 use thiserror::Error;
 
 /// Errors that can occur while loading configuration.
@@ -29,4 +30,11 @@ pub enum OrthoError {
     /// Validation failures when building configuration.
     #[error("Validation failed for '{key}': {message}")]
     Validation { key: String, message: String },
+}
+
+impl From<OrthoError> for FigmentError {
+    /// Allow using `?` in tests and examples that return `figment::Error`.
+    fn from(e: OrthoError) -> Self {
+        FigmentError::from(e.to_string())
+    }
 }

--- a/ortho_config/src/error.rs
+++ b/ortho_config/src/error.rs
@@ -35,6 +35,12 @@ pub enum OrthoError {
 impl From<OrthoError> for FigmentError {
     /// Allow using `?` in tests and examples that return `figment::Error`.
     fn from(e: OrthoError) -> Self {
-        FigmentError::from(e.to_string())
+        match e {
+            // Preserve the original Figment error (keeps kind, metadata, and
+            // sources).
+            OrthoError::Gathering(fe) => fe,
+            // Fall back to a message for other variants.
+            other => FigmentError::from(other.to_string()),
+        }
     }
 }

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -85,7 +85,10 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
 
     /// Loads configuration from the provided iterator of command-line
     /// arguments.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "Return OrthoError to keep a single error type across the public API"
+    )]
     ///
     /// # Errors
     ///

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -11,9 +11,9 @@ mod error;
 mod file;
 mod merge;
 pub mod subcommand;
-pub use merge::{sanitize_value, sanitized_provider, value_without_nones};
 #[expect(deprecated, reason = "Retain helper for backwards compatibility")]
 pub use merge::merge_cli_over_defaults;
+pub use merge::{sanitize_value, sanitized_provider, value_without_nones};
 #[expect(
     deprecated,
     reason = "Re-export deprecated subcommand helpers for back-compat. FIXME: remove in the next minor release"

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -12,7 +12,7 @@ mod file;
 mod merge;
 pub mod subcommand;
 #[expect(deprecated, reason = "Retain helpers for backwards compatibility")]
-pub use merge::{merge_cli_over_defaults, sanitize_value, value_without_nones};
+pub use merge::{merge_cli_over_defaults, sanitize_value, sanitized_provider, value_without_nones};
 #[expect(deprecated, reason = "Re-export deprecated subcommand helpers")]
 pub use subcommand::{
     load_and_merge_subcommand, load_and_merge_subcommand_for, load_subcommand_config,

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -11,9 +11,9 @@ mod error;
 mod file;
 mod merge;
 pub mod subcommand;
-#[allow(deprecated)]
+#[expect(deprecated, reason = "Retain helpers for backwards compatibility")]
 pub use merge::{merge_cli_over_defaults, sanitize_value, value_without_nones};
-#[allow(deprecated)]
+#[expect(deprecated, reason = "Re-export deprecated subcommand helpers")]
 pub use subcommand::{
     load_and_merge_subcommand, load_and_merge_subcommand_for, load_subcommand_config,
     load_subcommand_config_for,
@@ -66,7 +66,10 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// # Ok(())
     /// # }
     /// ```
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "Return OrthoError to keep a single error type across the public API"
+    )]
     ///
     /// # Errors
     ///

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -11,9 +11,13 @@ mod error;
 mod file;
 mod merge;
 pub mod subcommand;
-#[expect(deprecated, reason = "Retain helpers for backwards compatibility")]
-pub use merge::{merge_cli_over_defaults, sanitize_value, sanitized_provider, value_without_nones};
-#[expect(deprecated, reason = "Re-export deprecated subcommand helpers")]
+pub use merge::{sanitize_value, sanitized_provider, value_without_nones};
+#[expect(deprecated, reason = "Retain helper for backwards compatibility")]
+pub use merge::merge_cli_over_defaults;
+#[expect(
+    deprecated,
+    reason = "Re-export deprecated subcommand helpers for back-compat. FIXME: remove in the next minor release"
+)]
 pub use subcommand::{
     load_and_merge_subcommand, load_and_merge_subcommand_for, load_subcommand_config,
     load_subcommand_config_for,

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -12,7 +12,7 @@ mod file;
 mod merge;
 pub mod subcommand;
 #[allow(deprecated)]
-pub use merge::merge_cli_over_defaults;
+pub use merge::{merge_cli_over_defaults, value_without_nones};
 #[allow(deprecated)]
 pub use subcommand::{
     load_and_merge_subcommand, load_and_merge_subcommand_for, load_subcommand_config,

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -12,7 +12,7 @@ mod file;
 mod merge;
 pub mod subcommand;
 #[allow(deprecated)]
-pub use merge::{merge_cli_over_defaults, value_without_nones};
+pub use merge::{merge_cli_over_defaults, sanitize_value, value_without_nones};
 #[allow(deprecated)]
 pub use subcommand::{
     load_and_merge_subcommand, load_and_merge_subcommand_for, load_subcommand_config,

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -5,6 +5,14 @@ use figment::{Figment, providers::Serialized};
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
 
+/// Recursively remove all [`Value::Null`] entries.
+///
+/// - Object fields equal to null are removed.
+/// - Array elements equal to null are removed, dropping `None` entries in
+///   `Vec<_>`.
+///
+/// This is intended for CLI sanitization so unset [`Option`] fields do not
+/// override defaults from files or environment variables.
 fn strip_nulls(value: &mut Value) {
     match value {
         Value::Object(map) => {
@@ -85,7 +93,7 @@ pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if serialisation fails.
+/// Returns an [`OrthoError`] if serialization fails.
 #[expect(
     clippy::result_large_err,
     reason = "Return OrthoError to keep a single error type across the public API"

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -31,6 +31,19 @@ fn strip_nulls(value: &mut Value) {
 
 /// Serialize a CLI struct to JSON, removing fields set to `None`.
 ///
+/// # Examples
+///
+/// ```rust
+/// use ortho_config::value_without_nones;
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct Args { count: Option<u32> }
+///
+/// let v = value_without_nones(&Args { count: None }).unwrap();
+/// assert_eq!(v, serde_json::json!({}));
+/// ```
+///
 /// # Errors
 ///
 /// Returns any [`serde_json::Error`] encountered during serialization.

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -75,7 +75,7 @@ fn convert_gathering_error(e: &serde_json::Error) -> OrthoError {
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if serialization fails.
+/// Returns an [`OrthoError`] if JSON serialization fails.
 #[expect(
     clippy::result_large_err,
     reason = "Return OrthoError to keep a single error type across the public API"
@@ -106,7 +106,7 @@ pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if serialization fails.
+/// Returns an [`OrthoError`] if JSON serialization fails.
 #[expect(
     clippy::result_large_err,
     reason = "Return OrthoError to keep a single error type across the public API"

--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -452,9 +452,9 @@ where
         .split("__");
     fig = fig.merge(env_provider);
 
-    let cli_value = sanitize_value(cli)?;
+    let sanitized_cli = sanitize_value(cli)?;
 
-    fig.merge(Serialized::defaults(&cli_value))
+    fig.merge(Serialized::defaults(&sanitized_cli))
         .extract()
         .map_err(OrthoError::Gathering)
 }

--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -1,6 +1,6 @@
 //! Support for loading configuration for individual subcommands.
 
-use crate::{OrthoError, load_config_file, normalize_prefix};
+use crate::{OrthoError, load_config_file, normalize_prefix, value_without_nones};
 use clap::CommandFactory;
 #[cfg(not(any(unix, target_os = "redox")))]
 use directories::BaseDirs;
@@ -452,7 +452,10 @@ where
         .split("__");
     fig = fig.merge(env_provider);
 
-    fig.merge(Serialized::defaults(cli))
+    let cli_value = value_without_nones(cli)
+        .map_err(|e| OrthoError::Gathering(figment::Error::from(e.to_string())))?;
+
+    fig.merge(Serialized::defaults(&cli_value))
         .extract()
         .map_err(OrthoError::Gathering)
 }

--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -1,6 +1,6 @@
 //! Support for loading configuration for individual subcommands.
 
-use crate::{OrthoError, load_config_file, normalize_prefix, value_without_nones};
+use crate::{OrthoError, load_config_file, normalize_prefix, sanitize_value};
 use clap::CommandFactory;
 #[cfg(not(any(unix, target_os = "redox")))]
 use directories::BaseDirs;
@@ -452,8 +452,7 @@ where
         .split("__");
     fig = fig.merge(env_provider);
 
-    let cli_value = value_without_nones(cli)
-        .map_err(|e| OrthoError::Gathering(figment::Error::from(e.to_string())))?;
+    let cli_value = sanitize_value(cli)?;
 
     fig.merge(Serialized::defaults(&cli_value))
         .extract()

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -21,17 +21,13 @@ struct RunArgs {
     option: Option<String>,
 }
 
-fn into_figment_error(e: &ortho_config::OrthoError) -> figment::error::Error {
-    figment::error::Error::from(e.to_string())
-}
-
 #[test]
 fn merge_works_for_subcommand() {
     figment::Jail::expect_with(|j| {
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run", "--option", "cli"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = load_and_merge_subcommand_for(&args).map_err(|e| into_figment_error(&e))?;
+        let cfg = load_and_merge_subcommand_for(&args)?;
         assert_eq!(cfg.option.as_deref(), Some("cli"));
         Ok(())
     });
@@ -43,7 +39,7 @@ fn merge_falls_back_to_env_when_cli_none() {
         j.set_env("APP_CMDS_RUN_OPTION", "env");
         let cli = Cli::parse_from(["prog", "run"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = load_and_merge_subcommand_for(&args).map_err(|e| into_figment_error(&e))?;
+        let cfg = load_and_merge_subcommand_for(&args)?;
         assert_eq!(cfg.option.as_deref(), Some("env"));
         Ok(())
     });
@@ -57,7 +53,7 @@ fn merge_falls_back_to_file_when_cli_none() {
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = load_and_merge_subcommand_for(&args).map_err(|e| into_figment_error(&e))?;
+        let cfg = load_and_merge_subcommand_for(&args)?;
         assert_eq!(cfg.option.as_deref(), Some("file"));
         Ok(())
     });

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -1,6 +1,5 @@
 use clap::{Parser, Subcommand};
 use ortho_config::{OrthoConfig, subcommand::load_and_merge_subcommand_for};
-use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Parser)]
@@ -21,15 +20,28 @@ struct RunArgs {
     option: Option<String>,
 }
 
-#[rstest]
+#[test]
 fn merge_works_for_subcommand() {
     figment::Jail::expect_with(|j| {
-        j.create_file(".config.toml", "[cmds.run]\noption = \"file\"")?;
+        j.create_file("config.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run", "--option", "cli"]);
         let Commands::Run(args) = cli.cmd;
         let cfg = load_and_merge_subcommand_for(&args)
             .map_err(|e| figment::error::Error::from(e.to_string()))?;
         assert_eq!(cfg.option.as_deref(), Some("cli"));
+        Ok(())
+    });
+}
+
+#[test]
+fn merge_falls_back_to_env_when_cli_none() {
+    figment::Jail::expect_with(|j| {
+        j.set_env("CMDS_RUN_OPTION", "env");
+        let cli = Cli::parse_from(["prog", "run"]);
+        let Commands::Run(args) = cli.cmd;
+        let cfg = load_and_merge_subcommand_for(&args)
+            .map_err(|e| figment::error::Error::from(e.to_string()))?;
+        assert_eq!(cfg.option.as_deref(), Some("env"));
         Ok(())
     });
 }

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -52,7 +52,8 @@ fn merge_falls_back_to_env_when_cli_none() {
 #[test]
 fn merge_falls_back_to_file_when_cli_none() {
     figment::Jail::expect_with(|j| {
-        // Strip all env vars so file fallback is deterministic.
+        // Strip all env vars so file fallback is deterministic. `Jail::clear_env`
+        // returns `()`, so no error handling is required.
         j.clear_env();
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run"]);

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -21,7 +21,7 @@ struct RunArgs {
     option: Option<String>,
 }
 
-fn to_figment(e: &ortho_config::OrthoError) -> figment::error::Error {
+fn into_figment_error(e: &ortho_config::OrthoError) -> figment::error::Error {
     figment::error::Error::from(e.to_string())
 }
 
@@ -31,7 +31,7 @@ fn merge_works_for_subcommand() {
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run", "--option", "cli"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = load_and_merge_subcommand_for(&args).map_err(|e| to_figment(&e))?;
+        let cfg = load_and_merge_subcommand_for(&args).map_err(|e| into_figment_error(&e))?;
         assert_eq!(cfg.option.as_deref(), Some("cli"));
         Ok(())
     });
@@ -43,7 +43,7 @@ fn merge_falls_back_to_env_when_cli_none() {
         j.set_env("APP_CMDS_RUN_OPTION", "env");
         let cli = Cli::parse_from(["prog", "run"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = load_and_merge_subcommand_for(&args).map_err(|e| to_figment(&e))?;
+        let cfg = load_and_merge_subcommand_for(&args).map_err(|e| into_figment_error(&e))?;
         assert_eq!(cfg.option.as_deref(), Some("env"));
         Ok(())
     });
@@ -57,7 +57,7 @@ fn merge_falls_back_to_file_when_cli_none() {
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = load_and_merge_subcommand_for(&args).map_err(|e| to_figment(&e))?;
+        let cfg = load_and_merge_subcommand_for(&args).map_err(|e| into_figment_error(&e))?;
         assert_eq!(cfg.option.as_deref(), Some("file"));
         Ok(())
     });

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -53,8 +53,9 @@ fn merge_falls_back_to_env_when_cli_none() {
 fn merge_falls_back_to_file_when_cli_none() {
     figment::Jail::expect_with(|j| {
         // Strip all env vars so file fallback is deterministic. `Jail::clear_env`
-        // returns `()`, so no error handling is required.
-        j.clear_env();
+        // is infallible, so wrap its unit return in a `Result` to satisfy the
+        // `?` operator and remain robust if the API adds error reporting.
+        figment::Result::Ok(j.clear_env())?;
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run"]);
         let Commands::Run(args) = cli.cmd;

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -52,6 +52,8 @@ fn merge_falls_back_to_env_when_cli_none() {
 #[test]
 fn merge_falls_back_to_file_when_cli_none() {
     figment::Jail::expect_with(|j| {
+        // Strip all env vars so file fallback is deterministic
+        j.clear_env();
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run"]);
         let Commands::Run(args) = cli.cmd;

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -53,6 +53,7 @@ fn merge_falls_back_to_env_when_cli_none() {
 fn merge_falls_back_to_file_when_cli_none() {
     figment::Jail::expect_with(|j| {
         // Strip all env vars so file fallback is deterministic
+        // `Jail::clear_env` is infallible so no error handling is required.
         j.clear_env();
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run"]);

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 use ortho_config::{OrthoConfig, subcommand::load_and_merge_subcommand_for};
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Parser)]
@@ -17,11 +18,10 @@ enum Commands {
 #[command(name = "run")]
 struct RunArgs {
     #[arg(long)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     option: Option<String>,
 }
 
-#[test]
+#[rstest]
 fn merge_works_for_subcommand() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "[cmds.run]\noption = \"file\"")?;

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -20,14 +20,17 @@ struct RunArgs {
     option: Option<String>,
 }
 
+fn to_figment(e: &ortho_config::OrthoError) -> figment::error::Error {
+    figment::error::Error::from(e.to_string())
+}
+
 #[test]
 fn merge_works_for_subcommand() {
     figment::Jail::expect_with(|j| {
         j.create_file("config.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run", "--option", "cli"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = load_and_merge_subcommand_for(&args)
-            .map_err(|e| figment::error::Error::from(e.to_string()))?;
+        let cfg = load_and_merge_subcommand_for(&args).map_err(|e| to_figment(&e))?;
         assert_eq!(cfg.option.as_deref(), Some("cli"));
         Ok(())
     });
@@ -39,8 +42,7 @@ fn merge_falls_back_to_env_when_cli_none() {
         j.set_env("CMDS_RUN_OPTION", "env");
         let cli = Cli::parse_from(["prog", "run"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = load_and_merge_subcommand_for(&args)
-            .map_err(|e| figment::error::Error::from(e.to_string()))?;
+        let cfg = load_and_merge_subcommand_for(&args).map_err(|e| to_figment(&e))?;
         assert_eq!(cfg.option.as_deref(), Some("env"));
         Ok(())
     });

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -52,10 +52,8 @@ fn merge_falls_back_to_env_when_cli_none() {
 #[test]
 fn merge_falls_back_to_file_when_cli_none() {
     figment::Jail::expect_with(|j| {
-        // Strip all env vars so file fallback is deterministic. `Jail::clear_env`
-        // is infallible, so wrap its unit return in a `Result` to satisfy the
-        // `?` operator and remain robust if the API adds error reporting.
-        figment::Result::Ok(j.clear_env())?;
+        // Strip all env vars so file fallback is deterministic.
+        j.clear_env();
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run"]);
         let Commands::Run(args) = cli.cmd;

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -52,8 +52,7 @@ fn merge_falls_back_to_env_when_cli_none() {
 #[test]
 fn merge_falls_back_to_file_when_cli_none() {
     figment::Jail::expect_with(|j| {
-        // Strip all env vars so file fallback is deterministic
-        // `Jail::clear_env` is infallible so no error handling is required.
+        // Strip all env vars so file fallback is deterministic.
         j.clear_env();
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run"]);

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -39,7 +39,6 @@ pub struct World {
 #[ortho_config(prefix = "APP_")]
 pub struct PrArgs {
     #[arg(long, required = true)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     reference: Option<String>,
 }
 

--- a/ortho_config/tests/features/subcommand.feature
+++ b/ortho_config/tests/features/subcommand.feature
@@ -20,3 +20,9 @@ Feature: Subcommand defaults
     And a configuration reference "https://example.com/file"
     When the subcommand configuration is loaded without defaults
     Then the merged reference is "https://example.com/cli"
+
+  Scenario: configuration file provides reference
+    Given no CLI reference
+    And a configuration reference "https://example.com/file"
+    When the subcommand configuration is loaded without defaults
+    Then the merged reference is "https://example.com/file"

--- a/ortho_config/tests/merge_utils.rs
+++ b/ortho_config/tests/merge_utils.rs
@@ -118,7 +118,7 @@ fn arrays_nulls_are_pruned_in_cli_layer() {
 
 fn merge_via_sanitized_cli<T>(defaults: &T, cli: &T) -> T
 where
-    T: Serialize + serde::de::DeserializeOwned + Default,
+    T: Serialize + serde::de::DeserializeOwned,
 {
     Figment::from(Serialized::defaults(defaults))
         .merge(sanitized_provider(cli).expect("sanitize"))

--- a/ortho_config/tests/merge_utils.rs
+++ b/ortho_config/tests/merge_utils.rs
@@ -2,17 +2,16 @@
 
 #![allow(deprecated)]
 use ortho_config::merge_cli_over_defaults;
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
 struct Sample {
-    #[serde(skip_serializing_if = "Option::is_none")]
     a: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     b: Option<String>,
 }
 
-#[test]
+#[rstest]
 fn cli_overrides_defaults() {
     let defaults = Sample {
         a: Some(1),
@@ -34,11 +33,10 @@ fn cli_overrides_defaults() {
 
 #[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
 struct Nested {
-    #[serde(skip_serializing_if = "Option::is_none")]
     inner: Option<Sample>,
 }
 
-#[test]
+#[rstest]
 fn nested_structs_merge_deeply() {
     let defaults = Nested {
         inner: Some(Sample {

--- a/ortho_config/tests/merge_utils.rs
+++ b/ortho_config/tests/merge_utils.rs
@@ -2,6 +2,7 @@
 
 #![allow(deprecated)]
 use ortho_config::merge_cli_over_defaults;
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
@@ -10,7 +11,7 @@ struct Sample {
     b: Option<String>,
 }
 
-#[test]
+#[rstest]
 fn cli_overrides_defaults() {
     let defaults = Sample {
         a: Some(1),
@@ -35,7 +36,7 @@ struct Nested {
     inner: Option<Sample>,
 }
 
-#[test]
+#[rstest]
 fn nested_structs_merge_deeply() {
     let defaults = Nested {
         inner: Some(Sample {
@@ -61,7 +62,7 @@ fn nested_structs_merge_deeply() {
     );
 }
 
-#[test]
+#[rstest]
 fn cli_none_fields_do_not_override_defaults() {
     let defaults = Sample {
         a: Some(42),
@@ -72,7 +73,7 @@ fn cli_none_fields_do_not_override_defaults() {
     assert_eq!(merged, defaults);
 }
 
-#[test]
+#[rstest]
 fn nested_structs_partial_none_merge() {
     let defaults = Nested {
         inner: Some(Sample {

--- a/ortho_config/tests/merge_utils.rs
+++ b/ortho_config/tests/merge_utils.rs
@@ -99,7 +99,7 @@ fn nested_structs_partial_none_merge() {
 }
 
 #[test]
-fn arrays_nulls_are_pruned_in_cli_layer() {
+fn arrays_nulls_are_pruned_and_replace_defaults_in_cli_layer() {
     #[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
     struct WithVec {
         #[serde(default)]
@@ -113,6 +113,7 @@ fn arrays_nulls_are_pruned_in_cli_layer() {
         items: vec![None, Some(2), None, Some(3)],
     };
     let merged = merge_via_sanitized_cli(&defaults, &cli);
+    // Arrays are replaced at the CLI layer, not appended.
     assert_eq!(merged.items, vec![Some(2), Some(3)]);
 }
 

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -129,13 +129,19 @@ pub(crate) fn build_merge_section(
             fig = fig.merge(f);
         }
 
+        let cli_value = ortho_config::value_without_nones(&cli).map_err(|e| {
+            ortho_config::OrthoError::Gathering(figment::Error::from(e.to_string()))
+        })?;
         fig = fig
             .merge(env_provider.clone())
-            .merge(Serialized::defaults(&cli));
+            .merge(Serialized::defaults(&cli_value));
 
         #append_logic
 
-        fig = fig.merge(Serialized::defaults(overrides));
+        let overrides_value = ortho_config::value_without_nones(&overrides).map_err(|e| {
+            ortho_config::OrthoError::Gathering(figment::Error::from(e.to_string()))
+        })?;
+        fig = fig.merge(Serialized::defaults(&overrides_value));
 
         fig.extract::<#config_ident>().map_err(ortho_config::OrthoError::Gathering)
     }

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -129,15 +129,15 @@ pub(crate) fn build_merge_section(
             fig = fig.merge(f);
         }
 
-        let cli_value = ortho_config::sanitize_value(&cli)?;
+        let sanitized_cli = ortho_config::sanitize_value(&cli)?;
         fig = fig
             .merge(env_provider.clone())
-            .merge(Serialized::defaults(&cli_value));
+            .merge(Serialized::defaults(&sanitized_cli));
 
         #append_logic
 
-        let overrides_value = ortho_config::sanitize_value(&overrides)?;
-        fig = fig.merge(Serialized::defaults(&overrides_value));
+        let sanitized_overrides = ortho_config::sanitize_value(&overrides)?;
+        fig = fig.merge(Serialized::defaults(&sanitized_overrides));
 
         fig.extract::<#config_ident>().map_err(ortho_config::OrthoError::Gathering)
     }

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -128,16 +128,13 @@ pub(crate) fn build_merge_section(
         if let Some(ref f) = file_fig {
             fig = fig.merge(f);
         }
-
-        let sanitized_cli = ortho_config::sanitize_value(&cli)?;
         fig = fig
             .merge(env_provider.clone())
-            .merge(Serialized::defaults(&sanitized_cli));
+            .merge(ortho_config::sanitized_provider(&cli)?);
 
         #append_logic
 
-        let sanitized_overrides = ortho_config::sanitize_value(&overrides)?;
-        fig = fig.merge(Serialized::defaults(&sanitized_overrides));
+        fig = fig.merge(ortho_config::sanitized_provider(&overrides)?);
 
         fig.extract::<#config_ident>().map_err(ortho_config::OrthoError::Gathering)
     }

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -129,18 +129,14 @@ pub(crate) fn build_merge_section(
             fig = fig.merge(f);
         }
 
-        let cli_value = ortho_config::value_without_nones(&cli).map_err(|e| {
-            ortho_config::OrthoError::Gathering(figment::Error::from(e.to_string()))
-        })?;
+        let cli_value = ortho_config::sanitize_value(&cli)?;
         fig = fig
             .merge(env_provider.clone())
             .merge(Serialized::defaults(&cli_value));
 
         #append_logic
 
-        let overrides_value = ortho_config::value_without_nones(&overrides).map_err(|e| {
-            ortho_config::OrthoError::Gathering(figment::Error::from(e.to_string()))
-        })?;
+        let overrides_value = ortho_config::sanitize_value(&overrides)?;
         fig = fig.merge(Serialized::defaults(&overrides_value));
 
         fig.extract::<#config_ident>().map_err(ortho_config::OrthoError::Gathering)


### PR DESCRIPTION
## Summary
- avoid serialising `None` CLI fields so env/file defaults remain
- document CLI merge behaviour and update roadmap
- cover CLI merge with unit and Cucumber scenarios

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a9bfd75988322a94de8935e3281c1

## Summary by Sourcery

Prevent CLI-supplied None values from overriding defaults by stripping null fields before merging, update merge logic and macros accordingly, and enhance documentation and tests to reflect and verify the new behavior.

New Features:
- Introduce value_without_nones function to serialize CLI structs without fields set to None

Enhancements:
- Refactor merge_cli_over_defaults, derive load_impl macros, and subcommand loader to apply value_without_nones and preserve environment/file defaults for unset CLI fields
- Export value_without_nones in the public API

Documentation:
- Add documentation for CLI merge behavior in design and user-guide docs
- Update roadmap to mark the OS- none-overriding-defaults item as completed

Tests:
- Add rstest unit tests for deep merging of CLI and defaults
- Add Cucumber scenarios to verify that unset CLI fields do not override file or environment defaults