### PR TITLE
Remove unfulfilled lint expectation for prefix

### DIFF
--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -97,11 +97,7 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
 
     /// Prefix used for environment variables and subcommand configuration.
     #[must_use]
-    #[expect(
-        clippy::missing_const_for_fn,
-        reason = "Trait method uses runtime information (intended to be overridable); keeping signature stable"
-    )]
-    #[allow(unfulfilled_lint_expectations)] // Clippy no longer emits this lint for trait methods
+    // Intentionally non-const so implementations can read runtime information.
     fn prefix() -> &'static str {
         ""
     }


### PR DESCRIPTION
## Summary
- drop unneeded clippy expectation on `prefix`
- document intentional runtime dependency for prefix

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d3d0e4b9c83229fee9f20ffb08626

## Summary by Sourcery

Remove obsolete Clippy lint attributes from the prefix() trait method and add an explanatory comment clarifying its intentional runtime dependency

Enhancements:
- Drop unneeded #[expect] and #[allow(unfulfilled_lint_expectations)] annotations from prefix()
- Add comment to document the intentional non-const nature of prefix() for runtime configurability