### PR TITLE
Document subcommand merge tests

### DIFF
--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -1,6 +1,10 @@
 //! Integration tests for subcommand merge behaviour:
 //! - CLI values override file/env.
 //! - CLI None must not override file/env defaults (sanitised provider).
+//!
+//! Precedence (lowest → highest): struct defaults < file < env < CLI.
+//! Omitting a CLI flag (yielding `None`) must not shadow values from file/env;
+//! the sanitised provider ignores `None` and preserves the prior source.
 
 use clap::{Parser, Subcommand};
 use ortho_config::{OrthoConfig, subcommand::load_and_merge_subcommand_for};

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -1,9 +1,9 @@
 //! Integration tests for subcommand merge behaviour:
-//! - CLI values override file/env.
-//! - CLI None must not override file/env values (sanitized provider).
+//! - CLI values override file/environment.
+//! - CLI None must not override file/environment values (sanitized provider).
 //!
-//! Precedence (lowest -> highest): struct defaults < file < env < CLI.
-//! Omitting a CLI flag (yielding `None`) must not shadow values from file/env;
+//! Precedence (lowest -> highest): struct defaults < file < environment < CLI.
+//! Omitting a CLI flag (yielding `None`) must not shadow values from file/environment;
 //! the sanitized provider ignores `None` and preserves the prior source.
 
 use clap::{Parser, Subcommand};

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -1,6 +1,6 @@
 //! Integration tests for subcommand merge behaviour:
 //! - CLI values override file/env.
-//! - CLI None must not override file/env defaults (sanitized provider).
+//! - CLI None must not override file/env values (sanitized provider).
 //!
 //! Precedence (lowest -> highest): struct defaults < file < env < CLI.
 //! Omitting a CLI flag (yielding `None`) must not shadow values from file/env;

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -1,3 +1,7 @@
+//! Integration tests for subcommand merge behaviour:
+//! - CLI values override file/env.
+//! - CLI None must not override file/env defaults (sanitised provider).
+
 use clap::{Parser, Subcommand};
 use ortho_config::{OrthoConfig, subcommand::load_and_merge_subcommand_for};
 use serde::{Deserialize, Serialize};

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -1,10 +1,20 @@
 //! Integration tests for subcommand merge behaviour:
+//!
 //! - CLI values override file/environment.
 //! - CLI-provided `None` must not override file/environment values (sanitized provider).
 //!
 //! Precedence (lowest -> highest): struct defaults < file < environment < CLI.
 //! Omitting a CLI flag (yielding `None`) must not shadow values from file/environment;
 //! the sanitized provider ignores `None` and preserves the prior source.
+//!
+//! Example:
+//! - Given `.app.toml` with:
+//!   `[cmds.run]`
+//!   `option = "file"`
+//! - And `APP_CMDS_RUN_OPTION=env` in the environment:
+//!   - `prog run --option cli` => `option = "cli"` (CLI wins)
+//!   - `prog run`              => `option = "env"` (CLI is `None`, environment wins)
+//!   - no CLI, no environment  => `option = "file"` (file wins)
 
 use clap::{Parser, Subcommand};
 use ortho_config::{OrthoConfig, subcommand::load_and_merge_subcommand_for};

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -1,6 +1,6 @@
 //! Integration tests for subcommand merge behaviour:
 //! - CLI values override file/environment.
-//! - CLI None must not override file/environment values (sanitized provider).
+//! - CLI-provided `None` must not override file/environment values (sanitized provider).
 //!
 //! Precedence (lowest -> highest): struct defaults < file < environment < CLI.
 //! Omitting a CLI flag (yielding `None`) must not shadow values from file/environment;

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -1,10 +1,10 @@
 //! Integration tests for subcommand merge behaviour:
 //! - CLI values override file/env.
-//! - CLI None must not override file/env defaults (sanitised provider).
+//! - CLI None must not override file/env defaults (sanitized provider).
 //!
-//! Precedence (lowest → highest): struct defaults < file < env < CLI.
+//! Precedence (lowest -> highest): struct defaults < file < env < CLI.
 //! Omitting a CLI flag (yielding `None`) must not shadow values from file/env;
-//! the sanitised provider ignores `None` and preserves the prior source.
+//! the sanitized provider ignores `None` and preserves the prior source.
 
 use clap::{Parser, Subcommand};
 use ortho_config::{OrthoConfig, subcommand::load_and_merge_subcommand_for};


### PR DESCRIPTION
## Summary
- clarify intent of subcommand merge integration tests by adding a module-level doc comment

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e346fd0688322a6bb82de7d5a7bce

## Summary by Sourcery

Documentation:
- Add a module-level doc comment in the clap_subcommand tests to explain the intent of the merge subcommand tests