### PR TITLE
Aggregate configuration errors across sources

### DIFF
--- a/docs/clap-dispatch-and-ortho-config-integration.md
+++ b/docs/clap-dispatch-and-ortho-config-integration.md
@@ -811,7 +811,7 @@ Several aspects require careful consideration during implementation:
   from both `clap` parsing and `ortho-config` loading (e.g., file not found,
   malformed config, invalid environment variable) is essential. The current
   implementation collects such failures and exposes them via the
-  `OrthoError::Aggregate` variant so callers can surface every issue in a
+  `OrthoError::Aggregate` variant, so callers can surface every issue in a
   single report.
 - **Dynamic Subcommands:** The proposed design, relying on `clap-dispatch`,
   assumes subcommands are statically defined at compile time (as variants of a

--- a/docs/clap-dispatch-and-ortho-config-integration.md
+++ b/docs/clap-dispatch-and-ortho-config-integration.md
@@ -809,7 +809,10 @@ Several aspects require careful consideration during implementation:
   accurately determine if a CLI flag was explicitly provided.
 - **Error Handling:** A robust strategy for aggregating and reporting errors
   from both `clap` parsing and `ortho-config` loading (e.g., file not found,
-  malformed config, invalid environment variable) is essential.
+  malformed config, invalid environment variable) is essential. The current
+  implementation collects such failures and exposes them via the
+  `OrthoError::Aggregate` variant so callers can surface every issue in a
+  single report.
 - **Dynamic Subcommands:** The proposed design, relying on `clap-dispatch`,
   assumes subcommands are statically defined at compile time (as variants of a
   Rust enum). If `ortho-config` were to support defining *new* subcommands

--- a/docs/design.md
+++ b/docs/design.md
@@ -222,7 +222,7 @@ pub enum OrthoError {
     #[error("Failed to gather configuration: {0}")]
     Gathering(#[from] figment::Error),
 
-    #[error("multiple configuration errors: {0}")]
+    #[error("multiple configuration errors:\n{0}")]
     Aggregate(AggregatedErrors),
 
     // More specific errors as needed

--- a/docs/design.md
+++ b/docs/design.md
@@ -206,6 +206,9 @@ pub enum OrthoError {
     
     #[error("Failed to gather configuration: {0}")]
     Gathering(#[from] figment::Error),
+
+    #[error("multiple configuration errors: {0:?}")]
+    Aggregate(Vec<OrthoError>),
     
     // More specific errors as needed
     #[error("Validation failed for '{key}': {message}")]

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,7 +77,7 @@ references the relevant design guidance.
     incorrectly overridden.
     [[Clap Dispatch](clap-dispatch-and-ortho-config-integration.md)]
 
-  - [ ] Aggregate errors from `clap` parsing, file loading and environment
+  - [x] Aggregate errors from `clap` parsing, file loading and environment
     deserialization into a coherent `OrthoError` chain.
     [[Clap Dispatch](clap-dispatch-and-ortho-config-integration.md)]
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -363,7 +363,7 @@ for a complete example.
 
 `load` and `load_and_merge_subcommand_for` return a `Result<T, OrthoError>`.
 `OrthoError` wraps errors from `clap`, file I/O and `figment`. When multiple
-sources fail, the errors are collected into the `Aggregate` variant so callers
+sources fail, the errors are collected into the `Aggregate` variant, so callers
 can inspect each individual failure. Consumers should handle these errors
 appropriately, for example by printing them to stderr and exiting. Future
 releases may include improved missing‑value error messages, but currently the

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -362,12 +362,12 @@ for a complete example.
 ## Error handling
 
 `load` and `load_and_merge_subcommand_for` return a `Result<T, OrthoError>`.
-`OrthoError` wraps errors from `clap`, file I/O and `figment`. When
-configuration cannot be gathered or deserialized, the error propagates up to
-the caller. Consumers should handle these errors appropriately, for example by
-printing them to stderr and exiting. Future releases may include improved
-missing‑value error messages, but currently the crate simply returns the
-underlying error.
+`OrthoError` wraps errors from `clap`, file I/O and `figment`. When multiple
+sources fail, the errors are collected into the `Aggregate` variant so callers
+can inspect each individual failure. Consumers should handle these errors
+appropriately, for example by printing them to stderr and exiting. Future
+releases may include improved missing‑value error messages, but currently the
+crate simply returns the underlying error information.
 
 ## Additional notes
 

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -61,20 +61,20 @@ pub struct RulesConfig {
 /// Load from environment variable `DDLINT_PORT`:
 /// ```
 /// std::env::set_var("DDLINT_PORT", "8080");
-/// let cfg = ErrorConfig::load().unwrap();
-/// assert_eq!(cfg.port, 8080);
+/// let cfg = ErrorConfig::load().expect("load ErrorConfig");
+/// assert_eq!(cfg.port, Some(8080));
 /// ```
 ///
 /// Invalid values contribute to an aggregated error:
 /// ```
 /// std::env::set_var("DDLINT_PORT", "not-a-number");
-/// let err = ErrorConfig::load().unwrap_err();
+/// let err = ErrorConfig::load().expect_err("expect aggregated error");
 /// assert!(matches!(err, ortho_config::OrthoError::Aggregate(_)));
 /// ```
 #[derive(Debug, Deserialize, Serialize, OrthoConfig, Default)]
 #[ortho_config(prefix = "DDLINT_")]
 pub struct ErrorConfig {
-    port: u32,
+    pub port: Option<u32>,
 }
 
 mod steps;

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -56,6 +56,21 @@ pub struct RulesConfig {
 }
 
 /// Configuration used to verify aggregated error reporting.
+///
+/// # Examples
+/// Load from environment variable `DDLINT_PORT`:
+/// ```
+/// std::env::set_var("DDLINT_PORT", "8080");
+/// let cfg = ErrorConfig::load().unwrap();
+/// assert_eq!(cfg.port, 8080);
+/// ```
+///
+/// Invalid values contribute to an aggregated error:
+/// ```
+/// std::env::set_var("DDLINT_PORT", "not-a-number");
+/// let err = ErrorConfig::load().unwrap_err();
+/// assert!(matches!(err, ortho_config::OrthoError::Aggregate(_)));
+/// ```
 #[derive(Debug, Deserialize, Serialize, OrthoConfig, Default)]
 #[ortho_config(prefix = "DDLINT_")]
 pub struct ErrorConfig {

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -31,6 +31,8 @@ pub struct World {
     sub_env: Option<String>,
     /// Result of subcommand configuration loading.
     pub sub_result: Option<Result<PrArgs, ortho_config::OrthoError>>,
+    /// Result of aggregated error scenario.
+    pub agg_result: Option<Result<ErrorConfig, ortho_config::OrthoError>>,
 }
 
 /// CLI struct used for subcommand behavioural tests.
@@ -51,6 +53,13 @@ pub struct PrArgs {
 pub struct RulesConfig {
     /// List of lint rules parsed from CLI or environment.
     rules: Vec<String>,
+}
+
+/// Configuration used to verify aggregated error reporting.
+#[derive(Debug, Deserialize, Serialize, OrthoConfig, Default)]
+#[ortho_config(prefix = "DDLINT_")]
+pub struct ErrorConfig {
+    port: u32,
 }
 
 mod steps;

--- a/ortho_config/tests/error_aggregation.rs
+++ b/ortho_config/tests/error_aggregation.rs
@@ -1,0 +1,38 @@
+//! Tests for aggregated error reporting across configuration sources.
+
+use ortho_config::{OrthoConfig, OrthoError};
+use rstest::rstest;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, OrthoConfig)]
+struct AggConfig {
+    #[allow(dead_code)]
+    port: u32,
+}
+
+#[rstest]
+fn aggregates_cli_file_env_errors() {
+    figment::Jail::expect_with(|j| {
+        j.create_file(".config.toml", "port = ")?; // invalid TOML
+        j.set_env("PORT", "notanumber");
+        let err = AggConfig::load_from_iter(["prog", "--bogus"]).unwrap_err();
+        match err {
+            OrthoError::Aggregate(agg) => {
+                assert_eq!(agg.len(), 3);
+                let mut kinds = agg
+                    .iter()
+                    .map(|e| match e {
+                        OrthoError::CliParsing(_) => 1,
+                        OrthoError::File { .. } => 2,
+                        OrthoError::Gathering(_) => 3,
+                        _ => 0,
+                    })
+                    .collect::<Vec<_>>();
+                kinds.sort_unstable();
+                assert_eq!(kinds, vec![1, 2, 3]);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        Ok(())
+    });
+}

--- a/ortho_config/tests/error_aggregation.rs
+++ b/ortho_config/tests/error_aggregation.rs
@@ -6,7 +6,10 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, OrthoConfig)]
 struct AggConfig {
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "Field is read via deserialisation only in this test"
+    )]
     port: u32,
 }
 
@@ -15,7 +18,8 @@ fn aggregates_cli_file_env_errors() {
     figment::Jail::expect_with(|j| {
         j.create_file(".config.toml", "port = ")?; // invalid TOML
         j.set_env("PORT", "notanumber");
-        let err = AggConfig::load_from_iter(["prog", "--bogus"]).unwrap_err();
+        let err = AggConfig::load_from_iter(["prog", "--bogus"])
+            .expect_err("expected aggregated error from CLI/file/env sources");
         match err {
             OrthoError::Aggregate(agg) => {
                 assert_eq!(agg.len(), 3);

--- a/ortho_config/tests/features/error_aggregation.feature
+++ b/ortho_config/tests/features/error_aggregation.feature
@@ -3,4 +3,4 @@ Feature: Error aggregation
     Given an invalid configuration file
     And the environment variable DDLINT_PORT is "notanumber"
     When the config is loaded with an invalid CLI argument
-    Then multiple errors are returned
+    Then CLI, file and environment errors are returned

--- a/ortho_config/tests/features/error_aggregation.feature
+++ b/ortho_config/tests/features/error_aggregation.feature
@@ -4,3 +4,7 @@ Feature: Error aggregation
     And the environment variable DDLINT_PORT is "notanumber"
     When the config is loaded with an invalid CLI argument
     Then CLI, file and environment errors are returned
+
+  Scenario: Reports a single CLI error
+    When the config is loaded with an invalid CLI argument
+    Then a CLI parsing error is returned

--- a/ortho_config/tests/features/error_aggregation.feature
+++ b/ortho_config/tests/features/error_aggregation.feature
@@ -1,0 +1,6 @@
+Feature: Error aggregation
+  Scenario: Collects errors from all sources
+    Given an invalid configuration file
+    And the environment variable DDLINT_PORT is "notanumber"
+    When the config is loaded with an invalid CLI argument
+    Then multiple errors are returned

--- a/ortho_config/tests/steps/error_steps.rs
+++ b/ortho_config/tests/steps/error_steps.rs
@@ -52,8 +52,23 @@ fn cli_file_env_errors(world: &mut World) {
                     _ => {}
                 }
             }
-            assert!(saw_cli && saw_file && saw_env);
+            assert!(saw_cli, "expected CLI parsing error in aggregate");
+            assert!(saw_file, "expected file error in aggregate");
+            assert!(saw_env, "expected environment error in aggregate");
         }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[then("a CLI parsing error is returned")]
+fn cli_error_only(world: &mut World) {
+    let err = world
+        .agg_result
+        .take()
+        .expect("missing test result")
+        .expect_err("expected CLI parsing error");
+    match err {
+        ortho_config::OrthoError::CliParsing(_) => {}
         other => panic!("unexpected error: {other:?}"),
     }
 }

--- a/ortho_config/tests/steps/error_steps.rs
+++ b/ortho_config/tests/steps/error_steps.rs
@@ -1,0 +1,44 @@
+//! Steps verifying aggregated error reporting.
+
+use crate::{ErrorConfig, World};
+use cucumber::{given, then, when};
+use ortho_config::OrthoConfig;
+
+#[given("an invalid configuration file")]
+fn invalid_file(world: &mut World) {
+    world.file_value = Some("port = ".into());
+}
+
+#[given(expr = "the environment variable DDLINT_PORT is {string}")]
+fn env_port(world: &mut World, val: String) {
+    world.env_value = Some(val);
+}
+
+#[when("the config is loaded with an invalid CLI argument")]
+fn load_invalid_cli(world: &mut World) {
+    let file_val = world.file_value.clone();
+    let env_val = world.env_value.clone();
+    let mut result = None;
+    figment::Jail::expect_with(|j| {
+        if let Some(f) = file_val {
+            j.create_file(".ddlint.toml", &f)?;
+        }
+        if let Some(e) = env_val {
+            j.set_env("DDLINT_PORT", &e);
+        }
+        result = Some(ErrorConfig::load_from_iter(["prog", "--bogus"]));
+        Ok(())
+    });
+    world.agg_result = result;
+}
+
+#[then("multiple errors are returned")]
+fn multiple_errors(world: &mut World) {
+    let err = world.agg_result.take().expect("result").unwrap_err();
+    match err {
+        ortho_config::OrthoError::Aggregate(ref agg) => {
+            assert!(agg.len() > 1);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}

--- a/ortho_config/tests/steps/mod.rs
+++ b/ortho_config/tests/steps/mod.rs
@@ -1,4 +1,5 @@
 pub mod cli_steps;
 pub mod env_steps;
+pub mod error_steps;
 pub mod extends_steps;
 pub mod subcommand_steps;

--- a/ortho_config_macros/src/derive/build.rs
+++ b/ortho_config_macros/src/derive/build.rs
@@ -307,7 +307,7 @@ fn build_xdg_config_discovery() -> proc_macro2::TokenStream {
                         *fig = new_fig;
                         break;
                     }
-                    Err(e) => errors.push(e),
+                    Err(e) => discovery_errors.push(e),
                 }
             }
         };
@@ -338,7 +338,11 @@ pub(crate) fn build_xdg_snippet(struct_attrs: &StructAttrs) -> proc_macro2::Toke
             } else {
                 xdg::BaseDirectories::with_prefix(&xdg_base)
             };
+            let mut discovery_errors: Vec<ortho_config::OrthoError> = Vec::new();
             #config_discovery
+            if file_fig.is_none() {
+                errors.extend(discovery_errors);
+            }
         }
     }
 }
@@ -410,7 +414,6 @@ pub(crate) fn build_append_logic(fields: &[(Ident, &Type)]) -> proc_macro2::Toke
         }
     });
     quote! {
-        let env_figment = Figment::from(env_provider.clone());
         let cli_figment = Figment::from(Serialized::defaults(&cli));
         #( #logic )*
     }

--- a/ortho_config_macros/src/derive/build.rs
+++ b/ortho_config_macros/src/derive/build.rs
@@ -249,15 +249,21 @@ pub(crate) fn build_dotfile_name(struct_attrs: &StructAttrs) -> proc_macro2::Tok
 fn build_xdg_config_discovery() -> proc_macro2::TokenStream {
     quote! {
         if let Some(p) = xdg_dirs.find_config_file("config.toml") {
-            file_fig = ortho_config::load_config_file(&p)?;
+            match ortho_config::load_config_file(&p) {
+                Ok(fig) => file_fig = fig,
+                Err(e) => errors.push(e),
+            }
         }
         #[cfg(feature = "json5")]
         if file_fig.is_none() {
             for ext in &["json", "json5"] {
                 let filename = format!("config.{}", ext);
                 if let Some(p) = xdg_dirs.find_config_file(&filename) {
-                    file_fig = ortho_config::load_config_file(&p)?;
-                    break;
+                    match ortho_config::load_config_file(&p) {
+                        Ok(fig) => file_fig = fig,
+                        Err(e) => errors.push(e),
+                    }
+                    if file_fig.is_some() { break; }
                 }
             }
         }
@@ -266,8 +272,11 @@ fn build_xdg_config_discovery() -> proc_macro2::TokenStream {
             for ext in &["yaml", "yml"] {
                 let filename = format!("config.{}", ext);
                 if let Some(p) = xdg_dirs.find_config_file(&filename) {
-                    file_fig = ortho_config::load_config_file(&p)?;
-                    break;
+                    match ortho_config::load_config_file(&p) {
+                        Ok(fig) => file_fig = fig,
+                        Err(e) => errors.push(e),
+                    }
+                    if file_fig.is_some() { break; }
                 }
             }
         }

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -82,7 +82,9 @@ pub(crate) fn build_file_discovery(
                 Err(e) => errors.push(e),
             }
         }
+        let mut discovery_errors: Vec<ortho_config::OrthoError> = Vec::new();
         #xdg_snippet
+        errors.extend(discovery_errors);
     }
 }
 

--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -132,7 +132,7 @@ fn generate_cli_struct(components: &MacroComponents) -> proc_macro2::TokenStream
         ..
     } = components;
     quote! {
-        #[derive(clap::Parser, serde::Serialize)]
+        #[derive(clap::Parser, serde::Serialize, Default)]
         struct #cli_ident {
             #( #cli_struct_fields, )*
         }


### PR DESCRIPTION
## Summary
- collect CLI parsing, file loading and environment errors into `OrthoError::Aggregate`
- document aggregated error reporting and mark roadmap task complete
- test error aggregation with rstest and cucumber scenarios

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_689e41f8946c8322a127e55a5cd27ff9