### PR TITLE
Improve CLI and config merging with flatten support

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -91,6 +91,33 @@ The primary data flow for a user calling `AppConfig::load()` will be:
    is used.
 6. The result, either `Ok(AppConfig)` or `Err(OrthoError)`, is returned.
 
+### CLI and Configuration Merge Flow
+
+```mermaid
+flowchart TD
+    CLI[CLI Arguments]
+    Flattened[Flattened Groups]
+    Prune[Prune Empty Objects]
+    Config[Config File/Env]
+    Merge[Merged Config]
+    Error[OrthoError::Merge on Failure]
+
+    CLI --> Flattened
+    Flattened --> Prune
+    Prune --> Merge
+    Config --> Merge
+    Merge -->|Success| Merged
+    Merge -->|Failure| Error
+```
+
+```mermaid
+erDiagram
+    CLI_ARGS ||--o{ FLATTENED_GROUPS : contains
+    FLATTENED_GROUPS ||--o| CONFIG : merged_into
+    CONFIG ||--o| MERGED_CONFIG : produces
+    MERGED_CONFIG ||--o| ORTHOERROR : error_on_failure
+```
+
 ## 4. Component Deep Dive
 
 ### 4.1. The `OrthoConfig` Trait

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -81,7 +81,7 @@ references the relevant design guidance.
     deserialization into a coherent `OrthoError` chain.
     [[Clap Dispatch](clap-dispatch-and-ortho-config-integration.md)]
 
-  - [ ] Consider interactions with `#[clap(flatten)]` and nested argument
+  - [x] Consider interactions with `#[clap(flatten)]` and nested argument
     structs to ensure predictable behaviour.
     [[Clap Dispatch](clap-dispatch-and-ortho-config-integration.md)]
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -236,6 +236,12 @@ names with double underscores. For example, if `AppConfig` has a nested
 `database.url` field. If a nested struct has its own prefix attribute, that
 prefix is used for its fields (e.g. `APP_DB_URL`).
 
+When `clap`'s `flatten` attribute is employed to compose argument groups, the
+flattened struct is initialised even if no CLI flags within the group are
+specified. During merging, `ortho-config` discards these empty groups so that
+values from configuration files or the environment remain in place unless a
+field is explicitly supplied on the command line.
+
 ### Using defaults and optional fields
 
 Fields of type `Option<T>` are treated as optional values. If no source
@@ -362,12 +368,14 @@ for a complete example.
 ## Error handling
 
 `load` and `load_and_merge_subcommand_for` return a `Result<T, OrthoError>`.
-`OrthoError` wraps errors from `clap`, file I/O and `figment`. When multiple
-sources fail, the errors are collected into the `Aggregate` variant, so callers
-can inspect each individual failure. Consumers should handle these errors
-appropriately, for example by printing them to stderr and exiting. Future
-releases may include improved missing‑value error messages, but currently the
-crate simply returns the underlying error information.
+`OrthoError` wraps errors from `clap`, file I/O and `figment`. Failures during
+the final merge of CLI values over configuration sources surface as the `Merge`
+variant, providing clearer diagnostics when the combined data is invalid. When
+multiple sources fail, the errors are collected into the `Aggregate` variant so
+callers can inspect each individual failure. Consumers should handle these
+errors appropriately, for example by printing them to stderr and exiting.
+Future releases may include improved missing‑value error messages, but
+currently the crate simply returns the underlying error information.
 
 ## Additional notes
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -238,7 +238,7 @@ prefix is used for its fields (e.g. `APP_DB_URL`).
 
 When `clap`'s `flatten` attribute is employed to compose argument groups, the
 flattened struct is initialised even if no CLI flags within the group are
-specified. During merging, `ortho-config` discards these empty groups so that
+specified. During merging, `ortho_config` discards these empty groups so that
 values from configuration files or the environment remain in place unless a
 field is explicitly supplied on the command line.
 

--- a/ortho_config/src/error.rs
+++ b/ortho_config/src/error.rs
@@ -28,6 +28,13 @@ pub enum OrthoError {
     #[error("Failed to gather configuration: {0}")]
     Gathering(#[from] figment::Error),
 
+    /// Failure merging CLI values over configuration sources.
+    #[error("Failed to merge CLI with configuration: {source}")]
+    Merge {
+        #[source]
+        source: figment::Error,
+    },
+
     /// Validation failures when building configuration.
     #[error("Validation failed for '{key}': {message}")]
     Validation { key: String, message: String },
@@ -109,9 +116,8 @@ impl From<OrthoError> for FigmentError {
     /// Allow using `?` in tests and examples that return `figment::Error`.
     fn from(e: OrthoError) -> Self {
         match e {
-            // Preserve the original Figment error (keeps kind, metadata, and
-            // sources).
-            OrthoError::Gathering(fe) => fe,
+            // Preserve the original Figment error (keeps kind, metadata, and sources).
+            OrthoError::Gathering(fe) | OrthoError::Merge { source: fe } => fe,
             // Fall back to a message for other variants.
             other => FigmentError::from(other.to_string()),
         }

--- a/ortho_config/src/error.rs
+++ b/ortho_config/src/error.rs
@@ -110,6 +110,21 @@ impl OrthoError {
             OrthoError::Aggregate(AggregatedErrors::new(errors))
         }
     }
+
+    /// Construct a merge error from a [`figment::Error`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ortho_config::OrthoError;
+    /// let fe = figment::Error::from("boom");
+    /// let e = OrthoError::merge(fe);
+    /// assert!(matches!(e, OrthoError::Merge { .. }));
+    /// ```
+    #[must_use]
+    pub fn merge(source: figment::Error) -> Self {
+        OrthoError::Merge { source }
+    }
 }
 
 impl From<OrthoError> for FigmentError {

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -15,7 +15,8 @@ use serde_json::Value;
 ///
 /// This is intended for CLI sanitisation so unset [`Option`] fields and
 /// untouched flattened structs do not override defaults from files or
-/// environment variables.
+/// environment variables. Returns `true` when the provided `value` should be
+/// pruned from its parent after null-stripping.
 fn strip_nulls(value: &mut Value) -> bool {
     match value {
         Value::Object(map) => {

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -15,8 +15,11 @@ use serde_json::Value;
 ///
 /// This is intended for CLI sanitisation so unset [`Option`] fields and
 /// untouched flattened structs do not override defaults from files or
-/// environment variables. Returns `true` when the provided `value` should be
-/// pruned from its parent after null-stripping.
+/// environment variables.
+///
+/// Returns `true` if `value` becomes empty after pruning (that is, it is
+/// `Null` or an object with no remaining fields). Arrays never return `true`,
+/// even when emptied, to preserve explicit clearing semantics.
 fn strip_nulls(value: &mut Value) -> bool {
     match value {
         Value::Object(map) => {

--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -452,7 +452,7 @@ where
 
     fig.merge(sanitized_provider(cli)?)
         .extract()
-        .map_err(OrthoError::Gathering)
+        .map_err(|e| OrthoError::Merge { source: e })
 }
 
 /// Wrapper around [`load_and_merge_subcommand`] using the struct's configured prefix.

--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -452,7 +452,7 @@ where
 
     fig.merge(sanitized_provider(cli)?)
         .extract()
-        .map_err(|e| OrthoError::Merge { source: e })
+        .map_err(OrthoError::merge)
 }
 
 /// Wrapper around [`load_and_merge_subcommand`] using the struct's configured prefix.

--- a/ortho_config/tests/clap_integration.rs
+++ b/ortho_config/tests/clap_integration.rs
@@ -94,7 +94,7 @@ fn invalid_cli_wrong_type_maps_error() {
 fn invalid_cli_missing_required_maps_error() {
     figment::Jail::expect_with(|_| {
         let err = RequiredConfig::load_from_iter(["prog"]).unwrap_err();
-        assert!(matches!(err, OrthoError::Gathering(_)));
+        assert!(matches!(err, OrthoError::Merge { .. }));
         Ok(())
     });
 }

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -3,7 +3,7 @@
 //! Exercises end-to-end configuration loading using [`CsvEnv`] and the
 //! derive macro.
 
-use clap::Parser;
+use clap::{Args, Parser};
 use cucumber::World as _;
 use ortho_config::OrthoConfig;
 use serde::{Deserialize, Serialize};
@@ -33,6 +33,10 @@ pub struct World {
     pub sub_result: Option<Result<PrArgs, ortho_config::OrthoError>>,
     /// Result of aggregated error scenario.
     pub agg_result: Option<Result<ErrorConfig, ortho_config::OrthoError>>,
+    /// File value for flattened merging scenarios.
+    flat_file: Option<String>,
+    /// Result of flattened configuration loading.
+    pub flat_result: Option<Result<FlatArgs, ortho_config::OrthoError>>,
 }
 
 /// CLI struct used for subcommand behavioural tests.
@@ -42,6 +46,19 @@ pub struct World {
 pub struct PrArgs {
     #[arg(long, required = true)]
     reference: Option<String>,
+}
+
+/// CLI struct used for flattened merging tests.
+#[derive(Debug, Deserialize, Serialize, Parser, Default, Clone)]
+pub struct FlatArgs {
+    #[command(flatten)]
+    pub nested: NestedArgs,
+}
+
+#[derive(Debug, Deserialize, Serialize, Args, Default, Clone)]
+pub struct NestedArgs {
+    #[arg(long)]
+    pub value: Option<String>,
 }
 
 /// Configuration struct used in integration tests.

--- a/ortho_config/tests/cucumber.rs
+++ b/ortho_config/tests/cucumber.rs
@@ -33,10 +33,10 @@ pub struct World {
     pub sub_result: Option<Result<PrArgs, ortho_config::OrthoError>>,
     /// Result of aggregated error scenario.
     pub agg_result: Option<Result<ErrorConfig, ortho_config::OrthoError>>,
-    /// File value for flattened merging scenarios.
+    /// File contents for flattened merging scenarios.
     flat_file: Option<String>,
     /// Result of flattened configuration loading.
-    pub flat_result: Option<Result<FlatArgs, ortho_config::OrthoError>>,
+    pub(crate) flat_result: Option<Result<FlatArgs, ortho_config::OrthoError>>,
 }
 
 /// CLI struct used for subcommand behavioural tests.
@@ -50,15 +50,16 @@ pub struct PrArgs {
 
 /// CLI struct used for flattened merging tests.
 #[derive(Debug, Deserialize, Serialize, Parser, Default, Clone)]
-pub struct FlatArgs {
+pub(crate) struct FlatArgs {
     #[command(flatten)]
-    pub nested: NestedArgs,
+    pub(crate) nested: NestedArgs,
 }
 
+/// Nested group flattened into [`FlatArgs`]; mimics `#[command(flatten)]` usage.
 #[derive(Debug, Deserialize, Serialize, Args, Default, Clone)]
-pub struct NestedArgs {
+pub(crate) struct NestedArgs {
     #[arg(long)]
-    pub value: Option<String>,
+    pub(crate) value: Option<String>,
 }
 
 /// Configuration struct used in integration tests.

--- a/ortho_config/tests/error_aggregation.rs
+++ b/ortho_config/tests/error_aggregation.rs
@@ -28,7 +28,7 @@ fn aggregates_cli_file_env_errors() {
                     .map(|e| match e {
                         OrthoError::CliParsing(_) => 1,
                         OrthoError::File { .. } => 2,
-                        OrthoError::Gathering(_) => 3,
+                        OrthoError::Merge { .. } | OrthoError::Gathering(_) => 3,
                         _ => 0,
                     })
                     .collect::<Vec<_>>();

--- a/ortho_config/tests/features/flatten.feature
+++ b/ortho_config/tests/features/flatten.feature
@@ -9,6 +9,11 @@ Feature: Flattened argument merging
     When the flattened config is loaded with CLI value "cli"
     Then the flattened value is "cli"
 
+  Scenario: invalid flattened value fails
+    Given a flattened configuration file with invalid value
+    When the flattened config is loaded without CLI overrides
+    Then flattening fails with a merge error
+
   Scenario: malformed flattened configuration fails
     Given a malformed flattened configuration file
     When the flattened config is loaded without CLI overrides

--- a/ortho_config/tests/features/flatten.feature
+++ b/ortho_config/tests/features/flatten.feature
@@ -1,0 +1,10 @@
+Feature: Flattened argument merging
+  Scenario: configuration retains flattened defaults
+    Given the flattened configuration file has value "file"
+    When the flattened config is loaded without CLI overrides
+    Then the flattened value is "file"
+
+  Scenario: CLI overrides flattened configuration
+    Given the flattened configuration file has value "file"
+    When the flattened config is loaded with CLI value "cli"
+    Then the flattened value is "cli"

--- a/ortho_config/tests/features/flatten.feature
+++ b/ortho_config/tests/features/flatten.feature
@@ -8,3 +8,8 @@ Feature: Flattened argument merging
     Given the flattened configuration file has value "file"
     When the flattened config is loaded with CLI value "cli"
     Then the flattened value is "cli"
+
+  Scenario: malformed flattened configuration fails
+    Given a malformed flattened configuration file
+    When the flattened config is loaded without CLI overrides
+    Then flattening fails with a merge error

--- a/ortho_config/tests/flatten_merge.rs
+++ b/ortho_config/tests/flatten_merge.rs
@@ -1,0 +1,33 @@
+//! Tests ensuring flattened CLI structs merge without overriding defaults.
+
+use figment::{Figment, providers::Serialized};
+use ortho_config::sanitized_provider;
+use rstest::rstest;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
+struct Inner {
+    val: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
+struct Outer {
+    inner: Inner,
+}
+
+fn merge(defaults: &Outer, cli: &Outer) -> Outer {
+    Figment::from(Serialized::defaults(defaults))
+        .merge(sanitized_provider(cli).expect("sanitize"))
+        .extract()
+        .expect("merge")
+}
+
+#[rstest]
+fn empty_flatten_like_struct_preserves_defaults() {
+    let defaults = Outer {
+        inner: Inner { val: Some(7) },
+    };
+    let cli = Outer::default();
+    let merged = merge(&defaults, &cli);
+    assert_eq!(merged, defaults);
+}

--- a/ortho_config/tests/steps/error_steps.rs
+++ b/ortho_config/tests/steps/error_steps.rs
@@ -48,7 +48,8 @@ fn cli_file_env_errors(world: &mut World) {
                 match e {
                     ortho_config::OrthoError::CliParsing(_) => saw_cli = true,
                     ortho_config::OrthoError::File { .. } => saw_file = true,
-                    ortho_config::OrthoError::Gathering(_) => saw_env = true,
+                    ortho_config::OrthoError::Merge { .. }
+                    | ortho_config::OrthoError::Gathering(_) => saw_env = true,
                     _ => {}
                 }
             }

--- a/ortho_config/tests/steps/flatten_steps.rs
+++ b/ortho_config/tests/steps/flatten_steps.rs
@@ -46,6 +46,11 @@ fn malformed_flat_file(world: &mut World) {
     world.flat_file = Some("nested = 5".into());
 }
 
+#[given("a flattened configuration file with invalid value")]
+fn invalid_flat_file(world: &mut World) {
+    world.flat_file = Some("nested = { value = 5 }".into());
+}
+
 #[when("the flattened config is loaded without CLI overrides")]
 fn load_without_cli(world: &mut World) {
     world.flat_result = Some(load_flat(world.flat_file.as_deref(), &["prog"]));

--- a/ortho_config/tests/steps/flatten_steps.rs
+++ b/ortho_config/tests/steps/flatten_steps.rs
@@ -7,32 +7,48 @@ use figment::{Figment, providers::Serialized};
 use ortho_config::{OrthoError, load_config_file, sanitized_provider};
 use std::path::Path;
 
+#[expect(
+    clippy::result_large_err,
+    reason = "test helper returns library error type"
+)]
+fn load_flat(file: Option<&str>, args: &[&str]) -> Result<FlatArgs, OrthoError> {
+    let mut res = None;
+    figment::Jail::expect_with(|j| {
+        if let Some(contents) = file {
+            j.create_file(".flat.toml", contents)?;
+        }
+        let cli = FlatArgs::parse_from(args);
+        let mut fig = Figment::from(Serialized::defaults(&FlatArgs::default()));
+        if let Some(f) = load_config_file(Path::new(".flat.toml"))? {
+            fig = fig.merge(f);
+        }
+        res = Some(
+            fig.merge(sanitized_provider(&cli)?)
+                .extract()
+                .map_err(OrthoError::merge),
+        );
+        Ok(())
+    });
+    res.expect("result")
+}
+
 #[given(expr = "the flattened configuration file has value {string}")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step signature requires owned String"
+)]
 fn flattened_file(world: &mut World, val: String) {
-    world.flat_file = Some(val);
+    world.flat_file = Some(format!("nested = {{ value = \"{val}\" }}"));
+}
+
+#[given("a malformed flattened configuration file")]
+fn malformed_flat_file(world: &mut World) {
+    world.flat_file = Some("nested = 5".into());
 }
 
 #[when("the flattened config is loaded without CLI overrides")]
 fn load_without_cli(world: &mut World) {
-    let file_val = world.flat_file.clone();
-    let mut result = None;
-    figment::Jail::expect_with(|j| {
-        if let Some(v) = file_val {
-            j.create_file(".flat.toml", &format!("nested = {{ value = \"{v}\" }}"))?;
-        }
-        result = Some((|| -> Result<FlatArgs, OrthoError> {
-            let cli = FlatArgs::parse_from(["prog"]);
-            let mut fig = Figment::from(Serialized::defaults(&FlatArgs::default()));
-            if let Some(f) = load_config_file(Path::new(".flat.toml"))? {
-                fig = fig.merge(f);
-            }
-            fig.merge(sanitized_provider(&cli)?)
-                .extract()
-                .map_err(OrthoError::from)
-        })());
-        Ok(())
-    });
-    world.flat_result = result;
+    world.flat_result = Some(load_flat(world.flat_file.as_deref(), &["prog"]));
 }
 
 #[when(expr = "the flattened config is loaded with CLI value {string}")]
@@ -41,25 +57,10 @@ fn load_without_cli(world: &mut World) {
     reason = "Cucumber step signature requires owned String"
 )]
 fn load_with_cli(world: &mut World, cli: String) {
-    let file_val = world.flat_file.clone();
-    let mut result = None;
-    figment::Jail::expect_with(|j| {
-        if let Some(v) = file_val {
-            j.create_file(".flat.toml", &format!("nested = {{ value = \"{v}\" }}"))?;
-        }
-        result = Some((|| -> Result<FlatArgs, OrthoError> {
-            let cli = FlatArgs::parse_from(["prog", "--value", &cli]);
-            let mut fig = Figment::from(Serialized::defaults(&FlatArgs::default()));
-            if let Some(f) = load_config_file(Path::new(".flat.toml"))? {
-                fig = fig.merge(f);
-            }
-            fig.merge(sanitized_provider(&cli)?)
-                .extract()
-                .map_err(OrthoError::from)
-        })());
-        Ok(())
-    });
-    world.flat_result = result;
+    world.flat_result = Some(load_flat(
+        world.flat_file.as_deref(),
+        &["prog", "--value", &cli],
+    ));
 }
 
 #[then(expr = "the flattened value is {string}")]
@@ -70,4 +71,14 @@ fn load_with_cli(world: &mut World, cli: String) {
 fn check_flattened(world: &mut World, expected: String) {
     let cfg = world.flat_result.take().expect("result").expect("ok");
     assert_eq!(cfg.nested.value.as_deref(), Some(expected.as_str()));
+}
+
+#[then("flattening fails with a merge error")]
+fn flattening_fails(world: &mut World) {
+    let err = world
+        .flat_result
+        .take()
+        .expect("result")
+        .expect_err("expected merge error");
+    assert!(matches!(err, OrthoError::Merge { .. }));
 }

--- a/ortho_config/tests/steps/flatten_steps.rs
+++ b/ortho_config/tests/steps/flatten_steps.rs
@@ -1,0 +1,73 @@
+//! Steps for scenarios involving flattened CLI structures.
+
+use crate::{FlatArgs, World};
+use clap::Parser;
+use cucumber::{given, then, when};
+use figment::{Figment, providers::Serialized};
+use ortho_config::{OrthoError, load_config_file, sanitized_provider};
+use std::path::Path;
+
+#[given(expr = "the flattened configuration file has value {string}")]
+fn flattened_file(world: &mut World, val: String) {
+    world.flat_file = Some(val);
+}
+
+#[when("the flattened config is loaded without CLI overrides")]
+fn load_without_cli(world: &mut World) {
+    let file_val = world.flat_file.clone();
+    let mut result = None;
+    figment::Jail::expect_with(|j| {
+        if let Some(v) = file_val {
+            j.create_file(".flat.toml", &format!("nested = {{ value = \"{v}\" }}"))?;
+        }
+        result = Some((|| -> Result<FlatArgs, OrthoError> {
+            let cli = FlatArgs::parse_from(["prog"]);
+            let mut fig = Figment::from(Serialized::defaults(&FlatArgs::default()));
+            if let Some(f) = load_config_file(Path::new(".flat.toml"))? {
+                fig = fig.merge(f);
+            }
+            fig.merge(sanitized_provider(&cli)?)
+                .extract()
+                .map_err(OrthoError::from)
+        })());
+        Ok(())
+    });
+    world.flat_result = result;
+}
+
+#[when(expr = "the flattened config is loaded with CLI value {string}")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step signature requires owned String"
+)]
+fn load_with_cli(world: &mut World, cli: String) {
+    let file_val = world.flat_file.clone();
+    let mut result = None;
+    figment::Jail::expect_with(|j| {
+        if let Some(v) = file_val {
+            j.create_file(".flat.toml", &format!("nested = {{ value = \"{v}\" }}"))?;
+        }
+        result = Some((|| -> Result<FlatArgs, OrthoError> {
+            let cli = FlatArgs::parse_from(["prog", "--value", &cli]);
+            let mut fig = Figment::from(Serialized::defaults(&FlatArgs::default()));
+            if let Some(f) = load_config_file(Path::new(".flat.toml"))? {
+                fig = fig.merge(f);
+            }
+            fig.merge(sanitized_provider(&cli)?)
+                .extract()
+                .map_err(OrthoError::from)
+        })());
+        Ok(())
+    });
+    world.flat_result = result;
+}
+
+#[then(expr = "the flattened value is {string}")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step signature requires owned String"
+)]
+fn check_flattened(world: &mut World, expected: String) {
+    let cfg = world.flat_result.take().expect("result").expect("ok");
+    assert_eq!(cfg.nested.value.as_deref(), Some(expected.as_str()));
+}

--- a/ortho_config/tests/steps/mod.rs
+++ b/ortho_config/tests/steps/mod.rs
@@ -2,4 +2,5 @@ pub mod cli_steps;
 pub mod env_steps;
 pub mod error_steps;
 pub mod extends_steps;
+pub mod flatten_steps;
 pub mod subcommand_steps;

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -184,7 +184,7 @@ pub(crate) fn build_merge_section(
                 }
             }
             Err(e) => {
-                errors.push(ortho_config::OrthoError::Gathering(e));
+                errors.push(ortho_config::OrthoError::Merge { source: e });
                 Err(ortho_config::OrthoError::aggregate(errors))
             }
         }

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -184,7 +184,7 @@ pub(crate) fn build_merge_section(
                 }
             }
             Err(e) => {
-                errors.push(ortho_config::OrthoError::Merge { source: e });
+                errors.push(ortho_config::OrthoError::merge(e));
                 Err(ortho_config::OrthoError::aggregate(errors))
             }
         }


### PR DESCRIPTION
## Summary
- prune empty CLI objects to stop flattened groups clobbering defaults
- surface merge failures via a dedicated `OrthoError::Merge` variant
- document flatten behaviour and error reporting improvements

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a427afb28c8322b68b876005604313

## Summary by Sourcery

Prune empty CLI-derived objects during JSON sanitization to prevent clap-flattened groups from overwriting defaults, introduce a dedicated OrthoError::Merge variant for clearer merge failure diagnostics, and update documentation and tests to cover and describe this behavior

New Features:
- Prune empty flattened CLI objects so that clap-flattened groups don’t clobber configuration defaults
- Add a new OrthoError::Merge variant to report failures during the merge of CLI values over other config sources

Enhancements:
- Enhance strip_nulls to return emptiness and recursively remove null or empty nested objects
- Map Figment merge errors to OrthoError::Merge across subcommand loading, macro expansion, and error conversions

Documentation:
- Document flatten behavior and merge-error reporting improvements in the user guide, design docs, and roadmap

Tests:
- Add integration and Cucumber tests for flattened-struct merging and update existing tests to expect the Merge error variant