### PR TITLE
Introduce generic config discovery helper

### DIFF
--- a/ortho_config_macros/src/derive/build.rs
+++ b/ortho_config_macros/src/derive/build.rs
@@ -249,13 +249,17 @@ pub(crate) fn build_dotfile_name(struct_attrs: &StructAttrs) -> proc_macro2::Tok
 /// Builds discovery code for configuration files with the given extensions.
 ///
 /// The extensions are tried sequentially; earlier entries take precedence over
-/// later ones. Passing `["json", "json5", "yaml"]` will therefore try
-/// `config.json` before `config.json5` and `config.yaml`.
+/// later ones. Passing `["json", "json5", "yaml", "yml"]` will therefore
+/// try `config.json` before `config.json5` and either `config.yaml` or
+/// `config.yml`.
+///
+/// JSON and JSON5 support are only available when the `json5` feature is
+/// enabled, and YAML/YML support requires the `yaml` feature.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// let tokens = build_discovery(["json", "json5", "yaml"]);
+/// let tokens = build_discovery(["json", "json5", "yaml", "yml"]);
 /// assert!(!tokens.is_empty());
 /// ```
 fn build_discovery<I, S>(exts: I) -> proc_macro2::TokenStream


### PR DESCRIPTION
## Summary
- add `build_discovery` to generate `try_load_config` blocks for given extensions
- simplify XDG discovery by replacing format-specific helpers

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a5274656188322b5fb0ebde63a36da

## Summary by Sourcery

Introduce a generic build_discovery helper to generate try_load_config blocks for arbitrary extensions and refactor XDG discovery to use this new helper

New Features:
- Add build_discovery function that generates try_load_config code for a list of file extensions

Enhancements:
- Remove specific TOML, JSON, and YAML discovery helpers
- Update XDG config discovery to invoke build_discovery instead of format-specific functions