### PR TITLE
Box large error variants in OrthoError

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -239,7 +239,7 @@ impl std::fmt::Display for AggregatedErrors {
 #[derive(Debug, Error)]
 pub enum OrthoError {
     #[error("Failed to parse command-line arguments: {0}")]
-    CliParsing(#[from] clap::Error),
+    CliParsing(#[from] Box<clap::Error>),
 
     #[error("Configuration file error in '{path}': {source}")]
     File {
@@ -249,13 +249,13 @@ pub enum OrthoError {
     },
 
     #[error("Failed to gather configuration: {0}")]
-    Gathering(#[from] figment::Error),
+    Gathering(#[from] Box<figment::Error>),
 
     #[error("Failed to merge CLI with configuration: {source}")]
-    Merge { #[source] source: figment::Error },
+    Merge { #[source] source: Box<figment::Error> },
 
     #[error("multiple configuration errors:\n{0}")]
-    Aggregate(AggregatedErrors),
+    Aggregate(Box<AggregatedErrors>),
 
     // More specific errors as needed
     #[error("Validation failed for '{key}': {message}")]

--- a/docs/subcommand-refinements.md
+++ b/docs/subcommand-refinements.md
@@ -68,7 +68,6 @@ function would no longer be necessary. The `main` function would look like this:
 // Simplified vk/src/main.rs
 
 #[tokio::main]
-#[allow(clippy::result_large_err)]
 async fn main() -> Result<(), VkError> {
     let cli = Cli::parse();
     let mut global = GlobalArgs::load_from_iter(std::env::args_os().take(1))?;

--- a/ortho_config/src/error.rs
+++ b/ortho_config/src/error.rs
@@ -64,9 +64,7 @@ impl From<figment::Error> for OrthoError {
 /// use ortho_config::OrthoError;
 /// let e = OrthoError::aggregate(vec![
 ///     OrthoError::Validation { key: "port".into(), message: "must be positive".into() },
-///     OrthoError::CliParsing(
-///         clap::Error::raw(clap::error::ErrorKind::InvalidValue, "bad flag").into(),
-///     ),
+///     clap::Error::raw(clap::error::ErrorKind::InvalidValue, "bad flag").into(),
 /// ]);
 /// if let OrthoError::Aggregate(agg) = e {
 ///     assert_eq!(agg.len(), 2);

--- a/ortho_config/src/error.rs
+++ b/ortho_config/src/error.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 pub enum OrthoError {
     /// Error parsing command-line arguments.
     #[error("Failed to parse command-line arguments: {0}")]
-    CliParsing(#[from] clap::Error),
+    CliParsing(#[from] Box<clap::Error>),
 
     /// Error originating from a configuration file.
     #[error("Configuration file error in '{path}': {source}")]
@@ -26,13 +26,13 @@ pub enum OrthoError {
 
     /// Error while gathering configuration from providers.
     #[error("Failed to gather configuration: {0}")]
-    Gathering(#[from] figment::Error),
+    Gathering(#[from] Box<figment::Error>),
 
     /// Failure merging CLI values over configuration sources.
     #[error("Failed to merge CLI with configuration: {source}")]
     Merge {
         #[source]
-        source: figment::Error,
+        source: Box<figment::Error>,
     },
 
     /// Validation failures when building configuration.
@@ -41,7 +41,19 @@ pub enum OrthoError {
 
     /// Multiple errors occurred while loading configuration.
     #[error("multiple configuration errors:\n{0}")]
-    Aggregate(AggregatedErrors),
+    Aggregate(Box<AggregatedErrors>),
+}
+
+impl From<clap::Error> for OrthoError {
+    fn from(e: clap::Error) -> Self {
+        OrthoError::CliParsing(e.into())
+    }
+}
+
+impl From<figment::Error> for OrthoError {
+    fn from(e: figment::Error) -> Self {
+        OrthoError::Gathering(e.into())
+    }
 }
 
 /// Collection of [`OrthoError`]s produced during a single load attempt.
@@ -52,7 +64,9 @@ pub enum OrthoError {
 /// use ortho_config::OrthoError;
 /// let e = OrthoError::aggregate(vec![
 ///     OrthoError::Validation { key: "port".into(), message: "must be positive".into() },
-///     OrthoError::CliParsing(clap::Error::raw(clap::error::ErrorKind::InvalidValue, "bad flag")),
+///     OrthoError::CliParsing(
+///         clap::Error::raw(clap::error::ErrorKind::InvalidValue, "bad flag").into(),
+///     ),
 /// ]);
 /// if let OrthoError::Aggregate(agg) = e {
 ///     assert_eq!(agg.len(), 2);
@@ -107,7 +121,7 @@ impl OrthoError {
         if errors.len() == 1 {
             errors.into_iter().next().expect("one error")
         } else {
-            OrthoError::Aggregate(AggregatedErrors::new(errors))
+            OrthoError::Aggregate(Box::new(AggregatedErrors::new(errors)))
         }
     }
 
@@ -123,7 +137,9 @@ impl OrthoError {
     /// ```
     #[must_use]
     pub fn merge(source: figment::Error) -> Self {
-        OrthoError::Merge { source }
+        OrthoError::Merge {
+            source: Box::new(source),
+        }
     }
 }
 
@@ -132,7 +148,7 @@ impl From<OrthoError> for FigmentError {
     fn from(e: OrthoError) -> Self {
         match e {
             // Preserve the original Figment error (keeps kind, metadata, and sources).
-            OrthoError::Gathering(fe) | OrthoError::Merge { source: fe } => fe,
+            OrthoError::Gathering(fe) | OrthoError::Merge { source: fe } => *fe,
             // Fall back to a message for other variants.
             other => FigmentError::from(other.to_string()),
         }

--- a/ortho_config/src/file.rs
+++ b/ortho_config/src/file.rs
@@ -1,8 +1,4 @@
 //! Helpers for reading configuration files into Figment.
-#![expect(
-    clippy::result_large_err,
-    reason = "OrthoError is intentionally large throughout this module"
-)]
 
 use crate::OrthoError;
 #[cfg(feature = "yaml")]

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -50,33 +50,23 @@ pub use file::load_config_file;
 pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// Loads configuration from command-line arguments, environment variables
     /// and configuration files using the standard precedence rules.
-    ///
     /// Command-line arguments have the highest precedence, followed by
     /// environment variables and finally configuration files. Default values
     /// specified via `#[ortho_config(default = ...)]` sit at the lowest
     /// precedence level.
-    ///
     /// ```rust,no_run
     /// use ortho_config::{OrthoConfig, OrthoError};
     /// use serde::Deserialize;
-    ///
     /// #[derive(Deserialize, OrthoConfig)]
     /// struct AppConfig {
     ///     port: u16,
     /// }
-    ///
     /// # fn main() -> Result<(), OrthoError> {
     /// let _cfg = AppConfig::load()?;
     /// # Ok(())
     /// # }
     /// ```
-    #[expect(
-        clippy::result_large_err,
-        reason = "Return OrthoError to keep a single error type across the public API"
-    )]
-    ///
     /// # Errors
-    ///
     /// Returns an [`OrthoError`] if parsing command-line arguments, reading
     /// files or deserializing configuration fails.
     fn load() -> Result<Self, OrthoError> {
@@ -85,13 +75,7 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
 
     /// Loads configuration from the provided iterator of command-line
     /// arguments.
-    #[expect(
-        clippy::result_large_err,
-        reason = "Return OrthoError to keep a single error type across the public API"
-    )]
-    ///
     /// # Errors
-    ///
     /// Returns an [`OrthoError`] if parsing command-line arguments, reading
     /// files or deserializing configuration fails.
     fn load_from_iter<I, T>(iter: I) -> Result<Self, OrthoError>

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -65,7 +65,7 @@ pub fn value_without_nones<T: Serialize>(cli: &T) -> Result<Value, serde_json::E
 }
 
 fn convert_gathering_error(e: &serde_json::Error) -> OrthoError {
-    OrthoError::Gathering(figment::Error::from(e.to_string()))
+    OrthoError::Gathering(figment::Error::from(e.to_string()).into())
 }
 
 /// Serialize `value` to JSON, pruning `None` fields and mapping errors to
@@ -87,10 +87,6 @@ fn convert_gathering_error(e: &serde_json::Error) -> OrthoError {
 /// # Errors
 ///
 /// Returns an [`OrthoError`] if JSON serialization fails.
-#[expect(
-    clippy::result_large_err,
-    reason = "Return OrthoError to keep a single error type across the public API"
-)]
 pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
     value_without_nones(value).map_err(|e| convert_gathering_error(&e))
 }
@@ -118,10 +114,6 @@ pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
 /// # Errors
 ///
 /// Returns an [`OrthoError`] if JSON serialization fails.
-#[expect(
-    clippy::result_large_err,
-    reason = "Return OrthoError to keep a single error type across the public API"
-)]
 pub fn sanitized_provider<T: Serialize>(
     value: &T,
 ) -> Result<Serialized<serde_json::Value>, OrthoError> {

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -65,7 +65,7 @@ pub fn value_without_nones<T: Serialize>(cli: &T) -> Result<Value, serde_json::E
 }
 
 fn convert_gathering_error(e: &serde_json::Error) -> OrthoError {
-    OrthoError::Gathering(figment::Error::from(e.to_string()).into())
+    figment::Error::from(e.to_string()).into()
 }
 
 /// Serialize `value` to JSON, pruning `None` fields and mapping errors to

--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -381,7 +381,7 @@ where
 
     fig = fig.merge(subcommand_env_provider(prefix, name));
 
-    fig.extract().map_err(|e| OrthoError::Gathering(e.into()))
+    fig.extract().map_err(Into::into)
 }
 
 /// Load default values for a subcommand using `T`'s configured prefix.

--- a/ortho_config/src/subcommand.rs
+++ b/ortho_config/src/subcommand.rs
@@ -275,7 +275,6 @@ fn candidate_paths(prefix: &Prefix) -> Vec<PathBuf> {
 }
 
 /// Load and merge `[cmds.<name>]` sections from the given paths.
-#[allow(clippy::result_large_err)]
 /// Loads and merges configuration for a subcommand from the specified files.
 ///
 /// For each provided path, loads the configuration file and merges the `[cmds.<name>]` section into a single `Figment` instance. Only the focused section for the given subcommand is merged from each file.
@@ -343,7 +342,6 @@ fn subcommand_env_provider(prefix: &Prefix, name: &CmdName) -> Env {
 ///
 /// Use [`load_and_merge_subcommand`] or [`load_and_merge_subcommand_for`] instead
 /// to load defaults and apply CLI overrides in one step.
-#[allow(clippy::result_large_err)]
 #[deprecated(note = "use `load_and_merge_subcommand` or `load_and_merge_subcommand_for` instead")]
 /// Loads configuration for a specific subcommand from files and environment variables.
 ///
@@ -383,7 +381,7 @@ where
 
     fig = fig.merge(subcommand_env_provider(prefix, name));
 
-    fig.extract().map_err(OrthoError::Gathering)
+    fig.extract().map_err(|e| OrthoError::Gathering(e.into()))
 }
 
 /// Load default values for a subcommand using `T`'s configured prefix.
@@ -396,7 +394,6 @@ where
 /// # Errors
 ///
 /// Returns an [`OrthoError`] if file loading or deserialization fails.
-#[allow(clippy::result_large_err)]
 /// Loads configuration defaults for a subcommand using the prefix defined by the type.
 ///
 /// This function retrieves the configuration for the specified subcommand, using the prefix provided by the `OrthoConfig` implementation of `T`. It loads and merges configuration from files and environment variables, returning the resulting configuration as type `T`.
@@ -441,7 +438,6 @@ where
 /// # Errors
 ///
 /// Returns an [`OrthoError`] if file loading or deserialization fails.
-#[allow(clippy::result_large_err)]
 /// Loads configuration defaults for a subcommand and merges CLI-provided values over them.
 ///
 /// This function determines the subcommand name from the type `T`, loads its default configuration from files and environment variables using the given prefix, and overlays values provided via the CLI. The resulting configuration is returned as type `T`.
@@ -490,7 +486,6 @@ where
 /// # Errors
 ///
 /// Returns an [`OrthoError`] if file loading or deserialization fails.
-#[allow(clippy::result_large_err)]
 /// Loads and merges configuration for a subcommand using the prefix defined by its type.
 ///
 /// Loads default configuration values for the subcommand from files and environment variables, then merges CLI-provided values over these defaults. The prefix is determined by the `OrthoConfig` implementation of the type.

--- a/ortho_config/tests/steps/flatten_steps.rs
+++ b/ortho_config/tests/steps/flatten_steps.rs
@@ -7,10 +7,6 @@ use figment::{Figment, providers::Serialized};
 use ortho_config::{OrthoError, load_config_file, sanitized_provider};
 use std::path::Path;
 
-#[expect(
-    clippy::result_large_err,
-    reason = "test helper returns library error type"
-)]
 fn load_flat(file: Option<&str>, args: &[&str]) -> Result<FlatArgs, OrthoError> {
     let mut res = None;
     figment::Jail::expect_with(|j| {

--- a/ortho_config/tests/steps/subcommand_steps.rs
+++ b/ortho_config/tests/steps/subcommand_steps.rs
@@ -51,10 +51,6 @@ fn load_sub(world: &mut World) {
 }
 
 /// Set up test environment with configuration file and environment variables.
-#[expect(
-    clippy::result_large_err,
-    reason = "OrthoError size is acceptable in test helper"
-)]
 fn setup_test_environment(world: &World, cli: &PrArgs) -> Result<PrArgs, ortho_config::OrthoError> {
     let mut result = None;
     figment::Jail::expect_with(|j| {

--- a/ortho_config/tests/util.rs
+++ b/ortho_config/tests/util.rs
@@ -16,10 +16,6 @@ use ortho_config::{
 };
 use serde::de::DeserializeOwned;
 
-#[expect(
-    clippy::result_large_err,
-    reason = "tests need full error details for assertions"
-)]
 fn with_jail<F, L, T>(setup: F, loader: L) -> Result<T, OrthoError>
 where
     F: FnOnce(&mut figment::Jail) -> figment::error::Result<()>,
@@ -43,10 +39,6 @@ where
 /// # Errors
 ///
 /// Returns an error if configuration loading fails.
-#[expect(
-    clippy::result_large_err,
-    reason = "tests need full error details for assertions"
-)]
 pub fn with_subcommand_config<F, T>(setup: F) -> Result<T, OrthoError>
 where
     F: FnOnce(&mut figment::Jail) -> figment::error::Result<()>,
@@ -63,10 +55,6 @@ where
 /// # Errors
 ///
 /// Returns an error if configuration loading fails.
-#[expect(
-    clippy::result_large_err,
-    reason = "tests need full error details for assertions"
-)]
 pub fn with_typed_subcommand_config<F, T>(setup: F) -> Result<T, OrthoError>
 where
     F: FnOnce(&mut figment::Jail) -> figment::error::Result<()>,
@@ -83,10 +71,6 @@ where
 /// # Errors
 ///
 /// Returns an error if configuration loading or merging fails.
-#[expect(
-    clippy::result_large_err,
-    reason = "tests need full error details for assertions"
-)]
 pub fn with_merged_subcommand_cli<F, T>(setup: F, cli: &T) -> Result<T, OrthoError>
 where
     F: FnOnce(&mut figment::Jail) -> figment::error::Result<()>,
@@ -103,10 +87,6 @@ where
 /// # Errors
 ///
 /// Returns an error if configuration loading or merging fails.
-#[expect(
-    clippy::result_large_err,
-    reason = "tests need full error details for assertions"
-)]
 pub fn with_merged_subcommand_cli_for<F, T>(setup: F, cli: &T) -> Result<T, OrthoError>
 where
     F: FnOnce(&mut figment::Jail) -> figment::error::Result<()>,

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -228,7 +228,7 @@ pub(crate) fn build_load_impl(args: &LoadImplArgs<'_>) -> proc_macro2::TokenStre
                 let cli = match Self::try_parse_from(iter) {
                     Ok(c) => Some(c),
                     Err(e) => {
-                        errors.push(ortho_config::OrthoError::CliParsing(e.into()));
+                        errors.push(e.into());
                         None
                     }
                 };

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -228,7 +228,7 @@ pub(crate) fn build_load_impl(args: &LoadImplArgs<'_>) -> proc_macro2::TokenStre
                 let cli = match Self::try_parse_from(iter) {
                     Ok(c) => Some(c),
                     Err(e) => {
-                        errors.push(ortho_config::OrthoError::CliParsing(e));
+                        errors.push(ortho_config::OrthoError::CliParsing(e.into()));
                         None
                     }
                 };


### PR DESCRIPTION
## Summary
- box large `clap`, `figment`, and aggregate errors to keep `OrthoError` small
- convert `clap::Error` and `figment::Error` into `OrthoError` without losing details
- drop obsolete `result_large_err` lint expectations and update docs

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a9d9e698e483228f1c30baa06f17ee

## Summary by Sourcery

Box external error types within OrthoError to reduce its size while preserving full context, implement conversion constructors for clap and figment errors, remove outdated lint directives, and update related code and documentation accordingly.

Enhancements:
- Box large external error variants (clap::Error, figment::Error, AggregatedErrors) in OrthoError to shrink its footprint
- Add From<clap::Error> and From<figment::Error> impls to convert errors without losing details
- Adjust merge, aggregation, and conversion functions to work with boxed error types

Documentation:
- Update code examples and design docs to reflect boxing of error types

Tests:
- Remove obsolete clippy::result_large_err annotations from test helpers and steps

Chores:
- Clean up redundant lint allows and expects in source and macros