### PR TITLE
Update user guide for modern API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,22 +64,6 @@ struct DatabaseConfig {
     pool_size: Option<u32>, // Optional value, defaults to `Some(5)`
 }
 
-impl std::str::FromStr for DatabaseConfig {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut parts = s.splitn(2, ',');
-        let url = parts
-            .next()
-            .ok_or_else(|| "missing url".to_string())?
-            .to_string();
-        let pool_size = parts
-            .next()
-            .and_then(|p| p.parse::<u32>().ok());
-        Ok(DatabaseConfig { url, pool_size })
-    }
-}
-
 #[derive(Debug, Deserialize, Serialize, OrthoConfig)]
 #[ortho_config(prefix = "APP")] // Prefix for environment variables (e.g., APP_LOG_LEVEL)
 struct AppConfig {

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ use clap::Parser;
 use serde::Deserialize;
 use ortho_config::{load_and_merge_subcommand_for, OrthoConfig};
 
-#[derive(Debug, Deserialize, OrthoConfig)]
+#[derive(Debug, Deserialize, Parser, OrthoConfig)]
 #[ortho_config(prefix = "APP_")]
 pub struct AddUserArgs {
     username: Option<String>,

--- a/README.md
+++ b/README.md
@@ -222,12 +222,10 @@ use clap::Parser;
 use serde::Deserialize;
 use ortho_config::{load_and_merge_subcommand_for, OrthoConfig};
 
-#[derive(Parser, Deserialize, Default, Debug, OrthoConfig)]
+#[derive(Debug, Deserialize, OrthoConfig)]
 #[ortho_config(prefix = "APP_")]
 pub struct AddUserArgs {
-    #[arg(long)]
     username: Option<String>,
-    #[arg(long)]
     admin: Option<bool>,
 }
 
@@ -267,13 +265,11 @@ Subcommands can be executed with defaults applied using
 use clap::Parser;
 use clap_dispatch::clap_dispatch;
 use serde::Deserialize;
-use ortho_config::load_and_merge_subcommand_for;
+use ortho_config::{load_and_merge_subcommand_for, OrthoConfig};
 
-#[derive(Parser, Deserialize, Default, Debug)]
+#[derive(Debug, Deserialize, OrthoConfig)]
 pub struct ListItemsArgs {
-    #[arg(long)]
     category: Option<String>,
-    #[arg(long)]
     all: Option<bool>,
 }
 

--- a/README.md
+++ b/README.md
@@ -218,22 +218,29 @@ struct's `prefix()` function (which defaults to an empty string) and merges
 them underneath the CLI arguments.
 
 ```rust
-use clap::Parser;
+use clap::{Args, Parser};
 use serde::Deserialize;
 use ortho_config::{load_and_merge_subcommand_for, OrthoConfig};
 
-#[derive(Debug, Deserialize, Parser, OrthoConfig)]
+#[derive(Debug, Deserialize, Args, OrthoConfig)]
 #[ortho_config(prefix = "APP_")]
 pub struct AddUserArgs {
     username: Option<String>,
     admin: Option<bool>,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cli = AddUserArgs::parse();
+#[derive(Parser)]
+struct Cli {
+    #[command(flatten)]
+    args: AddUserArgs,
+}
 
-    // Reads `[cmds.add-user]` sections and `APP_CMDS_ADD_USER_*` variables then merges with CLI
-    let args = load_and_merge_subcommand_for::<AddUserArgs>(&cli)?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    // Reads `[cmds.add-user]` sections and `APP_CMDS_ADD_USER_*` variables
+    // then merges with CLI values
+    let args = load_and_merge_subcommand_for::<AddUserArgs>(&cli.args)?;
 
     println!("Final args: {args:?}");
     Ok(())
@@ -262,12 +269,19 @@ Subcommands can be executed with defaults applied using
 [`clap-dispatch`](https://docs.rs/clap-dispatch):
 
 ```rust
-use clap::Parser;
+use clap::{Args, Parser};
 use clap_dispatch::clap_dispatch;
 use serde::Deserialize;
 use ortho_config::{load_and_merge_subcommand_for, OrthoConfig};
 
-#[derive(Debug, Deserialize, OrthoConfig)]
+#[derive(Debug, Deserialize, Args, OrthoConfig)]
+#[ortho_config(prefix = "APP_")]
+pub struct AddUserArgs {
+    username: Option<String>,
+    admin: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Args, OrthoConfig)]
 pub struct ListItemsArgs {
     category: Option<String>,
     all: Option<bool>,

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -60,9 +60,10 @@ ortho_config = { version = "0.3.0", features = ["json5", "yaml"] }
 ```
 
 Enabling the `json5` feature causes both `.json` and `.json5` files to be
-parsed using the JSON5 format. Without this feature, these files are ignored.
-The `yaml` feature similarly enables `.yaml` and `.yml` files; without it, such
-files are skipped during discovery.
+parsed using the JSON5 format. Without this feature, these files are ignored
+during discovery and do not cause errors if present. The `yaml` feature
+similarly enables `.yaml` and `.yml` files; without it, such files are skipped
+during discovery and do not cause errors if present.
 
 ## Migrating from earlier versions
 
@@ -196,8 +197,8 @@ fn main() -> Result<(), OrthoError> {
 names and `ortho_config` attributes. In this example, the `AppConfig` struct
 uses a prefix of `APP`. The `DatabaseConfig` struct declares a prefix `DB`,
 resulting in environment variables such as `APP_DB_URL`. The `features` field
-is a `Vec` and accumulates values from multiple sources rather than overwriting
-them.
+is a `Vec<String>` and accumulates values from multiple sources rather than
+overwriting them.
 
 ## Loading configuration and precedence rules
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -60,9 +60,43 @@ ortho_config = { version = "0.3.0", features = ["json5", "yaml"] }
 ```
 
 Enabling the `json5` feature causes both `.json` and `.json5` files to be
-parsed using the JSON5 format. Without this feature, attempts to load JSON
-files will fail. The `yaml` feature similarly enables YAML file discovery and
-parsing.
+parsed using the JSON5 format. Without this feature, these files are ignored.
+The `yaml` feature similarly enables `.yaml` and `.yml` files; without it, such
+files are skipped during discovery.
+
+## Migrating from earlier versions
+
+Projects using a pre‑0.3 release can upgrade with the following steps:
+
+- `#[derive(OrthoConfig)]` remains the correct way to annotate configuration
+  structs. No additional derives are required.
+- Remove any `load_with_reference_fallback` helpers. The merge logic inside
+  `load_and_merge_subcommand_for` supersedes this workaround.
+- Replace calls to deprecated helpers such as `load_subcommand_config_for` with
+  `ortho_config::subcommand::load_and_merge_subcommand_for`.
+
+Each subcommand struct can expose a wrapper method that forwards to
+`load_and_merge_subcommand_for`:
+
+```rust
+use ortho_config::{subcommand::load_and_merge_subcommand_for, OrthoConfig,
+                   OrthoError};
+use serde::Deserialize;
+
+#[derive(Deserialize, OrthoConfig)]
+struct PrArgs {
+    reference: String,
+}
+
+impl PrArgs {
+    fn load_and_merge(cli: &Cli) -> Result<Self, OrthoError> {
+        load_and_merge_subcommand_for::<Self>(cli)
+    }
+}
+```
+
+After parsing the top‑level `Cli` struct, call `PrArgs::load_and_merge(&cli)`
+to obtain the merged configuration for that subcommand.
 
 ## Defining configuration structures
 
@@ -73,7 +107,8 @@ A configuration is represented by a plain Rust struct. To take advantage of
   values and merging overrides.
 
 - The derive macro generates a hidden `clap::Parser` implementation, so
-  no manual `clap` annotations are needed.
+  no manual `clap` annotations are needed. CLI customisation is performed using
+  `ortho_config` attributes such as `cli_short` or `cli_long`.
 
 - `OrthoConfig` – provided by the library. This derive macro generates the code
   to load and merge configuration from multiple sources.
@@ -123,32 +158,27 @@ The following example illustrates many of these features:
       log_level: String,
 
     /// Port to bind on – defaults to 8080 when unspecified
-    #[arg(long)]
     #[ortho_config(default = 8080)]
     port: u16,
 
-    /// Optional list of features.  Values from files, environment and CLI are appended.
-    #[arg(long)]
+    /// Optional list of features. Values from files, environment and CLI are appended.
     #[ortho_config(merge_strategy = "append")]
     features: Vec<String>,
 
-    /// Nested configuration for the database.  A separate prefix is used to avoid ambiguity.
+    /// Nested configuration for the database. A separate prefix is used to avoid ambiguity.
     #[serde(flatten)]
     database: DatabaseConfig,
 
     /// Enable verbose output; also available as -v via cli_short
-    #[arg(long)]
     #[ortho_config(cli_short = 'v')]
     verbose: bool,
-}
+  }
 
-#[derive(Debug, Clone, Deserialize, Serialize, OrthoConfig, Parser)]
+#[derive(Debug, Clone, Deserialize, Serialize, OrthoConfig)]
 #[ortho_config(prefix = "DB")]               // used in conjunction with APP_ prefix to form APP_DB_URL
 struct DatabaseConfig {
-    #[arg(long)]
     url: String,
 
-    #[arg(long)]
     #[ortho_config(default = 5)]
     pool_size: Option<u32>,
 }
@@ -161,10 +191,12 @@ fn main() -> Result<(), OrthoError> {
 }
 ```
 
-In this example the `AppConfig` struct uses a prefix of `APP`. The
-`DatabaseConfig` struct has its own prefix `DB`, resulting in environment
-variables such as `APP_DB_URL`. The `features` field is a `Vec<String>` and
-will accumulate values from multiple sources rather than overwriting them.
+No `clap` attributes are required; flags are derived from field names and
+`ortho_config` attributes. In this example the `AppConfig` struct uses a prefix
+of `APP`. The `DatabaseConfig` struct has its own prefix `DB`, resulting in
+environment variables such as `APP_DB_URL`. The `features` field is a
+`Vec<String>` and will accumulate values from multiple sources rather than
+overwriting them.
 
 ## Loading configuration and precedence rules
 
@@ -312,10 +344,12 @@ results in `ignore_patterns = [".git/", "build/", "target/"]`.
 Many CLI applications use `clap` subcommands to perform different operations.
 `OrthoConfig` supports per‑subcommand defaults via a dedicated `cmds`
 namespace. The helper function `load_and_merge_subcommand_for` loads defaults
-for a specific subcommand and merges them beneath the CLI values. The merged
-struct is returned as a new instance; the original `cli` struct remains
-unchanged. CLI fields left unset (`None`) do not override environment or file
-defaults, avoiding accidental loss of configuration.
+for a specific subcommand and merges them beneath the CLI values. The older
+`load_subcommand_config` and `load_subcommand_config_for` helpers are
+deprecated in favour of this function. The merged struct is returned as a new
+instance; the original `cli` struct remains unchanged. CLI fields left unset
+(`None`) do not override environment or file defaults, avoiding accidental loss
+of configuration.
 
 ### How it works
 
@@ -342,7 +376,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Parser, Deserialize, Serialize, Debug, OrthoConfig, Clone, Default)]
 #[ortho_config(prefix = "VK")]               // all variables start with VK
 pub struct GlobalArgs {
-    #[arg(long)]
     pub repo: Option<String>,
 }
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -107,8 +107,9 @@ A configuration is represented by a plain Rust struct. To take advantage of
   values and merging overrides.
 
 - The derive macro generates a hidden `clap::Parser` implementation, so
-  no manual `clap` annotations are needed. CLI customisation is performed using
-  `ortho_config` attributes such as `cli_short` or `cli_long`.
+  manual `clap` annotations are not required in typical use. CLI customization
+  is performed using `ortho_config` attributes such as `cli_short`, or
+  `cli_long`.
 
 - `OrthoConfig` – provided by the library. This derive macro generates the code
   to load and merge configuration from multiple sources.
@@ -191,12 +192,12 @@ fn main() -> Result<(), OrthoError> {
 }
 ```
 
-No `clap` attributes are required; flags are derived from field names and
-`ortho_config` attributes. In this example the `AppConfig` struct uses a prefix
-of `APP`. The `DatabaseConfig` struct has its own prefix `DB`, resulting in
-environment variables such as `APP_DB_URL`. The `features` field is a
-`Vec<String>` and will accumulate values from multiple sources rather than
-overwriting them.
+`clap` attributes are not required in general; flags are derived from field
+names and `ortho_config` attributes. In this example, the `AppConfig` struct
+uses a prefix of `APP`. The `DatabaseConfig` struct declares a prefix `DB`,
+resulting in environment variables such as `APP_DB_URL`. The `features` field
+is a `Vec` and accumulates values from multiple sources rather than overwriting
+them.
 
 ## Loading configuration and precedence rules
 


### PR DESCRIPTION
## Summary
- document hidden clap integration and simplify examples
- clarify JSON5/YAML feature behaviour
- drop unrelated FromStr snippet in README
- add migration guide covering new subcommand merging API

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a9a09ebb7883229956451ba742b64b

## Summary by Sourcery

Update and modernize user guide and README to align with v0.3 API changes

Documentation:
- Expand JSON5 and YAML feature explanations to describe ignored/skipped behavior when features are disabled
- Explain that CLI customization now uses ortho_config attributes (cli_short, cli_long) instead of manual clap annotations
- Remove manual clap attributes and deprecated Parser derive from configuration examples
- Deprecate old subcommand helpers in favor of subcommand::load_and_merge_subcommand_for and clarify merge semantics
- Add a “Migrating from earlier versions” section with upgrade steps and a wrapper example
- Remove the outdated FromStr implementation snippet from README