### PR TITLE
Introduce SubcmdConfigMerge trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ manual aliasing.
   strongly typed Rust structs.
 - **Easy to Use:** A simple `#[derive(OrthoConfig)]` macro enables a quick
   start.
-  - **Customisable:** Field-level attributes allow fine-grained control over
+  - **Customizable:** Field-level attributes allow fine-grained control over
     naming, defaults, and merging behaviour.
 - **Nested Configuration:** Naturally supports nested structs for organized
   configuration.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ manual aliasing.
   strongly typed Rust structs.
 - **Easy to Use:** A simple `#[derive(OrthoConfig)]` macro enables a quick
   start.
-- **Customizable:** Field-level attributes allow fine-grained control over
-  naming, defaults, and merging behavior.
+  - **Customisable:** Field-level attributes allow fine-grained control over
+    naming, defaults, and merging behaviour.
 - **Nested Configuration:** Naturally supports nested structs for organized
   configuration.
-- **Sensible Defaults:** Aims for intuitive behavior out-of-the-box.
+  - **Sensible Defaults:** Aims for intuitive behaviour out-of-the-box.
 
 ## Quick Start
 <!-- markdownlint-disable MD029 -->
@@ -203,7 +203,7 @@ configurable via:
 - TOML file: `max_connections = <value>`
 - JSON5 file: `max_connections` or `maxConnections` (configurable)
 
-You can customize these mappings using `#[ortho_config(…)]` attributes.
+You can customise these mappings using `#[ortho_config(…)]` attributes.
 
 ## Field Attributes `#[ortho_config(…)]`
 
@@ -228,10 +228,12 @@ Customize behaviour for each field:
 ## Subcommand Configuration
 
 Applications using `clap` subcommands can keep per-command defaults in a
-dedicated `cmds` namespace. The `SubcmdConfigMerge` trait provides a
-`load_and_merge` method that reads these values from configuration files and
-environment variables using the struct's `prefix()` function (which defaults to
-an empty string) and merges them underneath the CLI arguments.
+dedicated `cmds` namespace. The `SubcmdConfigMerge` trait exposes
+`load_and_merge(&self) -> Result<Self, ortho_config::OrthoError>`, which reads
+these values from configuration files and environment variables using the
+struct's `prefix()` function (default: empty string) and merges them beneath
+the CLI arguments. The method borrows `self` and returns a new merged instance,
+so the original values remain accessible.
 
 ```rust
 use clap::Parser;
@@ -337,18 +339,18 @@ fn main() -> Result<(), String> {
   files for persistent settings).
 - **Clear Precedence:** Predictable configuration resolution.
 
-## Migrating from 0.1 to 0.2
+## Migrating from 0.2 to 0.3
 
-Version 0.2 introduces a small API refinement:
+Version 0.3 introduces an API refinement:
 
 - `load_subcommand_config_for` now only loads default values from files and
   environment variables. Use [`load_and_merge`](#subcommand-configuration) to
-  merge these defaults with CLI arguments.
+  merge these defaults with CLI arguments via the `SubcmdConfigMerge` trait.
 - Types deriving `OrthoConfig` expose an associated `prefix()` function. Use
   this if you need the configured prefix directly.
 
-Update the `Cargo.toml` to depend on `ortho_config = "0.2"` and adjust code to
-call `load_and_merge` instead of manually merging defaults.
+Update the `Cargo.toml` to depend on `ortho_config = "0.3"` (or newer) and call
+`load_and_merge` instead of manually merging defaults.
 
 ## Contributing
 

--- a/docs/clap-dispatch-and-ortho-config-integration.md
+++ b/docs/clap-dispatch-and-ortho-config-integration.md
@@ -12,7 +12,7 @@ the dispatch logic can become cumbersome.
 
 The `clap-dispatch` crate aims to alleviate this by providing an ergonomic
 mechanism for dispatching CLI subcommands.3 It leverages Rust's trait system
-and procedural macros to reduce boilerplate and improve code organization when
+and procedural macros to reduce boilerplate and improve code organisation when
 subcommands represent different ways of performing a similar action.
 
 This report serves a dual purpose. Firstly, it provides comprehensive,
@@ -118,7 +118,7 @@ In CLIs with numerous subcommands or deeply nested subcommand trees,
   more easily. For example, the `sort` method of `QuickArgs` can be called
   directly with test data, isolating its logic from the CLI parsing and main
   dispatch mechanisms. This facilitates focused testing of each subcommand's
-  specific behavior.
+  specific behaviour.
 
 ## III. Practical Guide: Implementing Subcommands with `clap-dispatch`
 
@@ -786,7 +786,7 @@ This design offers several advantages:
 
 - **Consistency:** Extends `ortho-config`'s orthographic configuration principle
   to subcommands, providing a uniform user experience.
-- **Flexibility:** Users can configure subcommand behavior via their preferred
+- **Flexibility:** Users can configure subcommand behaviour via their preferred
   method: CLI flags for ad-hoc changes, environment variables for CI/CD or
   containerized environments, or configuration files for persistent settings.
 - **Reduced Boilerplate:** `clap-dispatch` handles the command dispatch logic,
@@ -841,7 +841,7 @@ and effectiveness in structuring subcommand logic.
 The proposed integration of `clap-dispatch` with `ortho-config` via a "cmds"
 namespace aims to extend `ortho-config`'s powerful orthographic configuration
 capabilities to subcommands. This design promises enhanced consistency,
-allowing users to configure subcommand behavior through CLI arguments,
+allowing users to configure subcommand behaviour through CLI arguments,
 environment variables, or configuration files in a predictable manner. The
 layering of these configuration sources, with clear precedence rules, ensures
 flexibility while maintaining control.

--- a/docs/clap-dispatch-and-ortho-config-integration.md
+++ b/docs/clap-dispatch-and-ortho-config-integration.md
@@ -12,7 +12,7 @@ the dispatch logic can become cumbersome.
 
 The `clap-dispatch` crate aims to alleviate this by providing an ergonomic
 mechanism for dispatching CLI subcommands.3 It leverages Rust's trait system
-and procedural macros to reduce boilerplate and improve code organisation when
+and procedural macros to reduce boilerplate and improve code organization when
 subcommands represent different ways of performing a similar action.
 
 This report serves a dual purpose. Firstly, it provides comprehensive,
@@ -760,6 +760,7 @@ env vars) let ortho_config_store = OrthoConfigStore::load("mycli")?;
     match cli_args.command { Commands::List(clap_parsed_list_args) => { // 4.
     Merge CLI values over ortho-config defaults for the subcommand let
     final_list_args =
+    // `load_and_merge` borrows `self` and returns a merged instance.
     clap_parsed_list_args.load_and_merge()?;
     Commands::List(final_list_args) } // Commands::Add(clap_parsed_add_args) =>
     { /* similar logic for Add command */ } };

--- a/docs/clap-dispatch-and-ortho-config-integration.md
+++ b/docs/clap-dispatch-and-ortho-config-integration.md
@@ -748,7 +748,7 @@ pub struct ListArgs {
    Example of final resolution println!("  Default Format: {:?}",
    self.default_format.as_deref().unwrap_or("text")); Ok(()) } }
 
-// --- Merging Logic --- use ortho_config::load_and_merge_subcommand_for;
+// --- Merging Logic --- use ortho_config::SubcmdConfigMerge;
 
 
 fn main() -> Result<(), String> { // 1. Initialize ortho-config (load files,
@@ -760,7 +760,7 @@ env vars) let ortho_config_store = OrthoConfigStore::load("mycli")?;
     match cli_args.command { Commands::List(clap_parsed_list_args) => { // 4.
     Merge CLI values over ortho-config defaults for the subcommand let
     final_list_args =
-    load_and_merge_subcommand_for::<ListArgs>(&clap_parsed_list_args)?;
+    clap_parsed_list_args.load_and_merge()?;
     Commands::List(final_list_args) } // Commands::Add(clap_parsed_add_args) =>
     { /* similar logic for Add command */ } };
 
@@ -775,10 +775,10 @@ env vars) let ortho_config_store = OrthoConfigStore::load("mycli")?;
 This conceptual code illustrates the key stages: loading `ortho-config`
 defaults, parsing CLI arguments with `clap`, merging these layers with defined
 precedence, and finally dispatching the command using the method provided by
-`clap-dispatch`. The critical merging step now uses
-`load_and_merge_subcommand_for`, which loads the subcommand defaults and
-applies any CLI overrides. A more generic merging strategy might involve
-reflection or a trait implemented by all argument structs.
+`clap-dispatch`. The critical merging step now uses `load_and_merge`, which
+loads the subcommand defaults and applies any CLI overrides. A more generic
+merging strategy might involve reflection or a trait implemented by all
+argument structs.
 
 ### E. Benefits and Rationale for the Proposed Design
 

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -737,7 +737,7 @@ without modifying existing dispatcher code (aligning with the Open/Closed
 Principle). However, it's important to ensure that the dispatch mechanism
 itself remains clear and that the proliferation of small classes doesn't lead
 to Ravioli Code, where the overall system flow becomes obscured. Clear naming
-conventions and logical organisation are vital.
+conventions and logical organization are vital.
 
 The **State pattern** is a related behavioural pattern useful when an object's
 behaviour changes depending on its internal state. Instead of using large

--- a/docs/ddlint-gap-analysis.md
+++ b/docs/ddlint-gap-analysis.md
@@ -61,8 +61,10 @@ the relevant configuration file sections and environment variables before
 applying CLI arguments.
 
 ```rust
+use ortho_config::SubcmdConfigMerge;
+
 // Reads `[cmds.add-user]` sections and `APP_CMDS_ADD_USER_*` variables then merges with CLI
-let args = load_and_merge_subcommand_for::<AddUserArgs>(&cli)?;
+let args = cli.load_and_merge()?;
 ```
 
 Configuration file example:

--- a/docs/ddlint-gap-analysis.md
+++ b/docs/ddlint-gap-analysis.md
@@ -56,9 +56,9 @@ earlier ones:
 4. **Command-Line Arguments:** Parsed using `clap` conventions. Long flags are
    derived from field names (e.g., `my_field` becomes `--my-field`).
 
-Subcommands can load defaults from a `cmds` namespace. The helper below merges
-the relevant configuration file sections and environment variables before
-applying CLI arguments.
+Subcommands can load defaults from a `cmds` namespace. The method below borrows
+`self` and merges the relevant configuration file sections and environment
+variables before applying CLI arguments.
 
 ```rust
 use ortho_config::SubcmdConfigMerge;

--- a/docs/design.md
+++ b/docs/design.md
@@ -326,9 +326,11 @@ fulfil missing defaults and eliminates workarounds like
 retained but deprecated.
 
 To remove repeated `load_and_merge` implementations on each subcommand struct,
-the crate now exposes a blanket `SubcmdConfigMerge` trait. The trait provides a
-`load_and_merge` method that borrows `self`, returning a merged instance while
-leaving the original values untouched.
+the crate now exposes a blanket `SubcmdConfigMerge` trait. The trait provides
+`load_and_merge(&self) -> Result<Self, OrthoError>`, borrowing `self` and
+returning a merged instance while leaving the original values untouched. The
+blanket implementation applies when the type implements:
+`OrthoConfig + serde::Serialize + Default + clap::builder::CommandFactory`.
 
 ### 4.10. Dynamic rule tables
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -325,6 +325,11 @@ fulfil missing defaults and eliminates workarounds like
 `load_with_reference_fallback`. The legacy `load_subcommand_config` helpers are
 retained but deprecated.
 
+To remove repeated `load_and_merge` implementations on each subcommand struct,
+the crate now exposes a blanket `SubcmdConfigMerge` trait. The trait provides a
+`load_and_merge` method that borrows `self`, returning a merged instance while
+leaving the original values untouched.
+
 ### 4.10. Dynamic rule tables
 
 Configuration structures may include map fields such as

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -630,8 +630,8 @@ July 15, 2025, <https://doc.rust-lang.org/rustdoc/documentation-tests.html>
 <https://ebarnard.github.io/2019-06-03-rust-smaller-trait-implementers-docs/rustdoc/documentation-tests.html>
 [^5]: Documentation tests - - MIT, accessed on July 15, 2025,
 <http://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/rustdoc/documentation-tests.html>
-[^6]: How to organize your Rust tests - LogRocket Blog, accessed on July 15,
-2025, <https://blog.logrocket.com/how-to-organize-rust-tests/>
+[^6]: How to organise your Rust tests - Reddit thread, accessed on July 15,
+2025,
 <https://www.reddit.com/r/rust/comments/qk77iu/best_way_to_organise_tests_in_rust/>
 [^7]: Writing Rust Documentation - DEV Community, accessed on July 15, 2025,
 <https://dev.to/gritmax/writing-rust-documentation-5hn5>

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -630,7 +630,7 @@ July 15, 2025, <https://doc.rust-lang.org/rustdoc/documentation-tests.html>
 <https://ebarnard.github.io/2019-06-03-rust-smaller-trait-implementers-docs/rustdoc/documentation-tests.html>
 [^5]: Documentation tests - - MIT, accessed on July 15, 2025,
 <http://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/rustdoc/documentation-tests.html>
-[^6]: How to organise your Rust tests - Reddit thread, accessed on July 15,
+[^6]: How to organize your Rust tests – Reddit thread, accessed on July 15,
 2025,
 <https://www.reddit.com/r/rust/comments/qk77iu/best_way_to_organise_tests_in_rust/>
 [^7]: Writing Rust Documentation - DEV Community, accessed on July 15, 2025,

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -153,7 +153,7 @@ In this example, `answer_to_life` is a public function marked with
 `#[fixture]`. It takes no arguments and returns a `u32` value of 42. The
 `#[fixture]` macro effectively registers this function with the `rstest`
 system, transforming it into a component that `rstest` can discover and
-utilise. The return type of the fixture function (here, `u32`) defines the type
+utilize. The return type of the fixture function (here, `u32`) defines the type
 of the data that will be injected into tests requesting this fixture. Fixtures
 can return any valid Rust type, from simple primitives to complex structs or
 trait objects. Fixtures can also depend on other fixtures, allowing for
@@ -162,7 +162,7 @@ compositional setup.
 ### C. Injecting Fixtures into Tests with `#[rstest]`
 
 Once a fixture is defined, it can be used in a test function. Test functions
-that utilise `rstest` features, including fixture injection, must be annotated
+that utilize `rstest` features, including fixture injection, must be annotated
 with the `#[rstest]` attribute. The fixture is then injected by simply
 declaring an argument in the test function with the same name as the fixture
 function.
@@ -1071,7 +1071,7 @@ significantly increase binary size if used with large data files.
 
 ## VIII. Reusability and Organization
 
-As test suites grow, maintaining reusability and clear organisation becomes
+As test suites grow, maintaining reusability and clear organization becomes
 paramount. `rstest` and its ecosystem provide tools and encourage practices
 that support these goals.
 
@@ -1132,7 +1132,7 @@ applying them.
 
 ### B. Best Practices for Organizing Fixtures and Tests
 
-Good fixture and test organisation mirrors good software design principles. As
+Good fixture and test organization mirrors good software design principles. As
 the number of tests and fixtures grows, a well-structured approach is critical
 for maintainability and scalability.
 
@@ -1169,7 +1169,7 @@ external dependencies, also applies and is well-supported by `rstest`'s design.
 ## IX. `rstest` in Context: Comparison and Considerations
 
 Understanding how `rstest` compares to standard Rust testing approaches and its
-potential trade-offs helps in deciding when and how to best utilise it.
+potential trade-offs helps in deciding when and how to best utilize it.
 
 ### A. `rstest` vs. Standard Rust `#[test]` and Manual Setup
 

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -153,7 +153,7 @@ In this example, `answer_to_life` is a public function marked with
 `#[fixture]`. It takes no arguments and returns a `u32` value of 42. The
 `#[fixture]` macro effectively registers this function with the `rstest`
 system, transforming it into a component that `rstest` can discover and
-utilize. The return type of the fixture function (here, `u32`) defines the type
+utilise. The return type of the fixture function (here, `u32`) defines the type
 of the data that will be injected into tests requesting this fixture. Fixtures
 can return any valid Rust type, from simple primitives to complex structs or
 trait objects. Fixtures can also depend on other fixtures, allowing for
@@ -162,7 +162,7 @@ compositional setup.
 ### C. Injecting Fixtures into Tests with `#[rstest]`
 
 Once a fixture is defined, it can be used in a test function. Test functions
-that utilize `rstest` features, including fixture injection, must be annotated
+that utilise `rstest` features, including fixture injection, must be annotated
 with the `#[rstest]` attribute. The fixture is then injected by simply
 declaring an argument in the test function with the same name as the fixture
 function.
@@ -1071,7 +1071,7 @@ significantly increase binary size if used with large data files.
 
 ## VIII. Reusability and Organization
 
-As test suites grow, maintaining reusability and clear organization becomes
+As test suites grow, maintaining reusability and clear organisation becomes
 paramount. `rstest` and its ecosystem provide tools and encourage practices
 that support these goals.
 
@@ -1132,7 +1132,7 @@ applying them.
 
 ### B. Best Practices for Organizing Fixtures and Tests
 
-Good fixture and test organization mirrors good software design principles. As
+Good fixture and test organisation mirrors good software design principles. As
 the number of tests and fixtures grows, a well-structured approach is critical
 for maintainability and scalability.
 
@@ -1169,7 +1169,7 @@ external dependencies, also applies and is well-supported by `rstest`'s design.
 ## IX. `rstest` in Context: Comparison and Considerations
 
 Understanding how `rstest` compares to standard Rust testing approaches and its
-potential trade-offs helps in deciding when and how to best utilize it.
+potential trade-offs helps in deciding when and how to best utilise it.
 
 ### A. `rstest` vs. Standard Rust `#[test]` and Manual Setup
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -311,14 +311,16 @@ results in `ignore_patterns = [".git/", "build/", "target/"]`.
 
 Many CLI applications use `clap` subcommands to perform different operations.
 `OrthoConfig` supports per‑subcommand defaults via a dedicated `cmds`
-namespace. The `SubcmdConfigMerge` trait offers a `load_and_merge` method that
-loads defaults for a specific subcommand and merges them beneath the CLI
-values. The merged struct is returned as a new instance; the original `cli`
-struct remains unchanged. CLI fields left unset (`None`) do not override
-environment or file defaults, avoiding accidental loss of configuration.
+namespace. The `SubcmdConfigMerge` trait provides
+`load_and_merge(&self) -> Result<Self, ortho_config::OrthoError>`, which reads
+these values from configuration files and environment variables using the
+struct’s `prefix()` function (default: empty string) and merges them beneath
+the CLI arguments. The method borrows `self` and returns a new merged instance,
+so the original CLI value remains usable. CLI fields left unset (`None`) do not
+override environment or file defaults, avoiding accidental loss of
+configuration.
 
-The `SubcmdConfigMerge` trait is re‑exported to remove boilerplate. Its
-`load_and_merge` method borrows `self` and returns a merged instance.
+The `SubcmdConfigMerge` trait is re‑exported to remove boilerplate.
 
 ### How it works
 
@@ -450,7 +452,7 @@ Missing required values:
 
 - **Changing naming conventions** – Currently, only the default
   snake/kebab/upper snake mappings are supported. Future versions may introduce
-  attributes such as `file_key` or `env` to customize names further.
+  attributes such as `file_key` or `env` to customise names further.
 
 - **Testing** – Because the CLI and environment variables are merged at
   runtime, integration tests should set environment variables and construct CLI

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -317,6 +317,10 @@ struct is returned as a new instance; the original `cli` struct remains
 unchanged. CLI fields left unset (`None`) do not override environment or file
 defaults, avoiding accidental loss of configuration.
 
+For ergonomic use, a `SubcmdConfigMerge` trait is re‑exported. It provides a
+`load_and_merge` method that borrows `self` and returns a merged instance,
+removing the need for each subcommand struct to define its own helper method.
+
 ### How it works
 
 When a struct derives `OrthoConfig`, it also implements the associated

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -452,7 +452,7 @@ Missing required values:
 
 - **Changing naming conventions** – Currently, only the default
   snake/kebab/upper snake mappings are supported. Future versions may introduce
-  attributes such as `file_key` or `env` to customise names further.
+  attributes such as `file_key` or `env` to customize names further.
 
 - **Testing** – Because the CLI and environment variables are merged at
   runtime, integration tests should set environment variables and construct CLI

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -336,7 +336,7 @@ might be defined as follows:
 
 ```rust
 use clap::Parser;
-use ortho_config::{OrthoConfig, load_and_merge_subcommand_for};
+use ortho_config::{OrthoConfig, SubcmdConfigMerge};
 use serde::{Deserialize, Serialize};
 
 #[derive(Parser, Deserialize, Serialize, Debug, OrthoConfig, Clone, Default)]
@@ -356,7 +356,7 @@ pub struct PrArgs {
 fn main() -> Result<(), ortho_config::OrthoError> {
     let cli_pr = PrArgs::parse();
     // Merge defaults from [cmds.pr] and VK_CMDS_PR_* over CLI
-    let merged_pr = load_and_merge_subcommand_for::<PrArgs>(&cli_pr)?;
+    let merged_pr = cli_pr.load_and_merge()?;
     println!("PrArgs after merging: {:#?}", merged_pr);
     Ok(())
 }

--- a/examples/registry_ctl.rs
+++ b/examples/registry_ctl.rs
@@ -2,10 +2,10 @@
 
 use clap::Parser;
 use clap_dispatch::clap_dispatch;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use ortho_config::{OrthoConfig, SubcmdConfigMerge};
 
-#[derive(Parser, Deserialize, Default, Debug, Clone, OrthoConfig)]
+#[derive(Parser, Deserialize, Serialize, Default, Debug, Clone, OrthoConfig)]
 #[ortho_config(prefix = "REGCTL_")]
 pub struct AddUserArgs {
     #[arg(long)]
@@ -14,7 +14,7 @@ pub struct AddUserArgs {
     admin: Option<bool>,
 }
 
-#[derive(Parser, Deserialize, Default, Debug, Clone, OrthoConfig)]
+#[derive(Parser, Deserialize, Serialize, Default, Debug, Clone, OrthoConfig)]
 #[ortho_config(prefix = "REGCTL_")]
 pub struct ListItemsArgs {
     #[arg(long)]

--- a/examples/registry_ctl.rs
+++ b/examples/registry_ctl.rs
@@ -3,7 +3,7 @@
 use clap::Parser;
 use clap_dispatch::clap_dispatch;
 use serde::Deserialize;
-use ortho_config::{load_and_merge_subcommand_for, OrthoConfig};
+use ortho_config::{OrthoConfig, SubcmdConfigMerge};
 
 #[derive(Parser, Deserialize, Default, Debug, Clone, OrthoConfig)]
 #[ortho_config(prefix = "REGCTL_")]
@@ -60,13 +60,11 @@ fn main() -> Result<(), String> {
     let db_url = "postgres://user:pass@localhost/registry";
     let final_cmd = match cli {
         Commands::AddUser(args) => {
-            let merged = load_and_merge_subcommand_for::<AddUserArgs>(&args)
-                .map_err(|e| e.to_string())?;
+            let merged = args.load_and_merge().map_err(|e| e.to_string())?;
             Commands::AddUser(merged)
         }
         Commands::ListItems(args) => {
-            let merged = load_and_merge_subcommand_for::<ListItemsArgs>(&args)
-                .map_err(|e| e.to_string())?;
+            let merged = args.load_and_merge().map_err(|e| e.to_string())?;
             Commands::ListItems(merged)
         }
     };

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -14,14 +14,13 @@ pub mod subcommand;
 #[expect(deprecated, reason = "Retain helper for backwards compatibility")]
 pub use merge::merge_cli_over_defaults;
 pub use merge::{sanitize_value, sanitized_provider, value_without_nones};
+pub use subcommand::{SubcmdConfigMerge, load_and_merge_subcommand, load_and_merge_subcommand_for};
+
 #[expect(
     deprecated,
     reason = "Re-export deprecated subcommand helpers for back-compat. FIXME: remove in the next minor release"
 )]
-pub use subcommand::{
-    SubcmdConfigMerge, load_and_merge_subcommand, load_and_merge_subcommand_for,
-    load_subcommand_config, load_subcommand_config_for,
-};
+pub use subcommand::{load_subcommand_config, load_subcommand_config_for};
 
 /// Normalize a prefix by trimming trailing underscores and converting
 /// to lowercase ASCII.

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -14,7 +14,7 @@ pub mod subcommand;
 #[expect(deprecated, reason = "Retain helper for backwards compatibility")]
 pub use merge::merge_cli_over_defaults;
 pub use merge::{sanitize_value, sanitized_provider, value_without_nones};
-pub use subcommand::{SubcmdConfigMerge, load_and_merge_subcommand, load_and_merge_subcommand_for};
+pub use subcommand::{SubcmdConfigMerge, load_and_merge_subcommand};
 
 #[expect(
     deprecated,

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -19,8 +19,8 @@ pub use merge::{sanitize_value, sanitized_provider, value_without_nones};
     reason = "Re-export deprecated subcommand helpers for back-compat. FIXME: remove in the next minor release"
 )]
 pub use subcommand::{
-    load_and_merge_subcommand, load_and_merge_subcommand_for, load_subcommand_config,
-    load_subcommand_config_for,
+    SubcmdConfigMerge, load_and_merge_subcommand, load_and_merge_subcommand_for,
+    load_subcommand_config, load_subcommand_config_for,
 };
 
 /// Normalize a prefix by trimming trailing underscores and converting

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -47,6 +47,9 @@ fn merge_works_for_subcommand() {
         let Commands::Run(args) = cli.cmd;
         let cfg = args.load_and_merge()?;
         assert_eq!(cfg.option.as_deref(), Some("cli"));
+        // `load_and_merge` borrows `self`, so the original `args` remains
+        // accessible afterwards.
+        assert_eq!(args.option.as_deref(), Some("cli"));
         Ok(())
     });
 }

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -17,7 +17,7 @@
 //!   - no CLI, no environment  => `option = "file"` (file wins)
 
 use clap::{Parser, Subcommand};
-use ortho_config::{OrthoConfig, subcommand::load_and_merge_subcommand_for};
+use ortho_config::{OrthoConfig, SubcmdConfigMerge};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Parser)]
@@ -45,7 +45,7 @@ fn merge_works_for_subcommand() {
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run", "--option", "cli"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = load_and_merge_subcommand_for(&args)?;
+        let cfg = args.load_and_merge()?;
         assert_eq!(cfg.option.as_deref(), Some("cli"));
         Ok(())
     });
@@ -57,7 +57,7 @@ fn merge_falls_back_to_env_when_cli_none() {
         j.set_env("APP_CMDS_RUN_OPTION", "env");
         let cli = Cli::parse_from(["prog", "run"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = load_and_merge_subcommand_for(&args)?;
+        let cfg = args.load_and_merge()?;
         assert_eq!(cfg.option.as_deref(), Some("env"));
         Ok(())
     });
@@ -71,7 +71,7 @@ fn merge_falls_back_to_file_when_cli_none() {
         j.create_file(".app.toml", "[cmds.run]\noption = \"file\"")?;
         let cli = Cli::parse_from(["prog", "run"]);
         let Commands::Run(args) = cli.cmd;
-        let cfg = load_and_merge_subcommand_for(&args)?;
+        let cfg = args.load_and_merge()?;
         assert_eq!(cfg.option.as_deref(), Some("file"));
         Ok(())
     });

--- a/ortho_config/tests/steps/subcommand_steps.rs
+++ b/ortho_config/tests/steps/subcommand_steps.rs
@@ -8,7 +8,7 @@
 use crate::{PrArgs, World};
 use clap::Parser;
 use cucumber::{given, then, when};
-use ortho_config::subcommand::load_and_merge_subcommand_for;
+use ortho_config::SubcmdConfigMerge;
 
 /// Check if all configuration sources are absent.
 fn has_no_config_sources(world: &World) -> bool {
@@ -64,7 +64,7 @@ fn setup_test_environment(world: &World, cli: &PrArgs) -> Result<PrArgs, ortho_c
         if let Some(ref val) = world.sub_env {
             j.set_env("APP_CMDS_TEST_REFERENCE", val);
         }
-        result = Some(load_and_merge_subcommand_for::<PrArgs>(cli));
+        result = Some(cli.load_and_merge());
         Ok(())
     });
     result.expect("jail setup should complete")

--- a/ortho_config/tests/subcommand.rs
+++ b/ortho_config/tests/subcommand.rs
@@ -141,7 +141,7 @@ fn merge_helper_combines_defaults_and_cli() {
     assert_eq!(merged.bar, None);
 }
 
-#[derive(Debug, Deserialize, serde::Serialize, OrthoConfig, Default, PartialEq, Parser)]
+#[derive(Debug, Deserialize, serde::Serialize, OrthoConfig, Default, PartialEq, Parser, Clone)]
 #[command(name = "test")]
 #[ortho_config(prefix = "APP_")]
 struct MergePrefixed {

--- a/ortho_config/tests/util.rs
+++ b/ortho_config/tests/util.rs
@@ -11,8 +11,7 @@
 use clap::CommandFactory;
 use ortho_config::subcommand::{CmdName, Prefix};
 use ortho_config::{
-    OrthoConfig, OrthoError, SubcmdConfigMerge, load_and_merge_subcommand, load_subcommand_config,
-    load_subcommand_config_for,
+    OrthoConfig, OrthoError, SubcmdConfigMerge, load_subcommand_config, load_subcommand_config_for,
 };
 use serde::de::DeserializeOwned;
 
@@ -78,7 +77,7 @@ where
 }
 
 /// Runs `setup` in a jailed environment, then loads defaults for the `test`
-/// subcommand and merges them with `cli` using the `APP_` prefix.
+/// subcommand and merges them with `cli`.
 ///
 /// # Errors
 ///
@@ -90,27 +89,7 @@ where
 pub fn with_merged_subcommand_cli<F, T>(setup: F, cli: &T) -> Result<T, OrthoError>
 where
     F: FnOnce(&mut figment::Jail) -> figment::error::Result<()>,
-    T: serde::Serialize + DeserializeOwned + Default + CommandFactory,
-{
-    with_jail(setup, || {
-        load_and_merge_subcommand(&Prefix::new("APP_"), cli)
-    })
-}
-
-/// Runs `setup` in a jailed environment, then loads defaults for the `test`
-/// subcommand using `T`'s prefix and merges them with `cli`.
-///
-/// # Errors
-///
-/// Returns an error if configuration loading or merging fails.
-#[expect(
-    clippy::result_large_err,
-    reason = "tests need full error details for assertions"
-)]
-pub fn with_merged_subcommand_cli_for<F, T>(setup: F, cli: &T) -> Result<T, OrthoError>
-where
-    F: FnOnce(&mut figment::Jail) -> figment::error::Result<()>,
-    T: OrthoConfig + serde::Serialize + Clone + Default + CommandFactory,
+    T: OrthoConfig + serde::Serialize + Default + CommandFactory,
 {
     with_jail(setup, || cli.load_and_merge())
 }

--- a/ortho_config/tests/util.rs
+++ b/ortho_config/tests/util.rs
@@ -11,8 +11,8 @@
 use clap::CommandFactory;
 use ortho_config::subcommand::{CmdName, Prefix};
 use ortho_config::{
-    OrthoConfig, OrthoError, load_and_merge_subcommand, load_and_merge_subcommand_for,
-    load_subcommand_config, load_subcommand_config_for,
+    OrthoConfig, OrthoError, SubcmdConfigMerge, load_and_merge_subcommand, load_subcommand_config,
+    load_subcommand_config_for,
 };
 use serde::de::DeserializeOwned;
 
@@ -110,7 +110,7 @@ where
 pub fn with_merged_subcommand_cli_for<F, T>(setup: F, cli: &T) -> Result<T, OrthoError>
 where
     F: FnOnce(&mut figment::Jail) -> figment::error::Result<()>,
-    T: OrthoConfig + serde::Serialize + Default + CommandFactory,
+    T: OrthoConfig + serde::Serialize + Clone + Default + CommandFactory,
 {
-    with_jail(setup, || load_and_merge_subcommand_for(cli))
+    with_jail(setup, || cli.load_and_merge())
 }


### PR DESCRIPTION
## Summary
- add `SubcmdConfigMerge` trait to remove boilerplate when merging subcommand configs
- re-export trait and update example, tests, and docs to use `load_and_merge`

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68aa135e8230832283a58112f00edb25

## Summary by Sourcery

Introduce a SubcmdConfigMerge trait to streamline merging of subcommand configurations and update code, examples, tests, and documentation to use its load_and_merge method instead of manual helper calls.

New Features:
- Add SubcmdConfigMerge trait with a blanket implementation to provide a load_and_merge method for subcommand argument types.

Enhancements:
- Re-export SubcmdConfigMerge in the crate’s public API.
- Replace uses of load_and_merge_subcommand_for with the new load_and_merge on subcommand args in code and examples.

Documentation:
- Revise user guide and example imports to use SubcmdConfigMerge and load_and_merge.

Tests:
- Update tests to call args.load_and_merge() instead of load_and_merge_subcommand_for.