### PR TITLE
Document sanitisation helpers and refine error mapping

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -75,15 +75,17 @@ The primary data flow for a user calling `AppConfig::load()` will be:
      loads the configuration file.
    - **Environment Provider:** An `Env` provider configured with the correct
      prefix and key-mapping rules.
+
    - **CLI Provider:** The `clap`-parsed arguments are serialized into a
-   `figment` provider and merged last. Fields left as `None` are removed before
-   merging so that environment or file defaults remain untouched. This
-   serialization step relies on `serde_json` and introduces a small overhead;
-   if configuration loading becomes a hotspot, benchmark to evaluate a more
-   direct approach. A helper, `sanitized_provider`, wraps sanitisation and
-   provider construction to avoid repeating the pattern. Empty objects are
-   pruned during sanitisation, ensuring that `#[clap(flatten)]` groups with no
-   CLI overrides do not wipe out defaults from files or environment variables.
+     `figment` provider and merged last. Fields left as `None` are removed
+     before merging so that environment or file defaults remain untouched. This
+     serialization step relies on `serde_json` and introduces a small overhead;
+     if configuration loading becomes a hotspot, benchmark to evaluate a more
+     direct approach. A helper, `sanitized_provider`, wraps sanitization and
+     provider construction to avoid repeating the pattern. Empty objects are
+     pruned during sanitization, ensuring that `#[clap(flatten)]` groups with
+     no CLI overrides do not wipe out defaults from files or environment
+     variables.
 
 4. `figment`'s `extract()` method is called to deserialize the merged
    configuration into the user's `AppConfig` struct.
@@ -270,7 +272,7 @@ The implementation must be careful to wrap errors from `clap`, `figment`, and
 file IO into this enum, adding contextual information (like file paths) where
 possible. `Gathering` covers failures while sourcing defaults from files or the
 environment. When CLI values are overlaid onto those defaults, any merge or
-deserialisation failures map to `Merge`.
+deserialization failures map to `Merge`.
 
 ### 4.6. Configuration File Discovery
 

--- a/ortho_config/src/error.rs
+++ b/ortho_config/src/error.rs
@@ -144,8 +144,8 @@ impl OrthoError {
     }
 }
 
-/// Convert any [`serde_json::Error`], whether from serialisation or
-/// deserialisation, into [`OrthoError::Gathering`].
+/// Convert any [`serde_json::Error`], whether from serialization or
+/// deserialization, into [`OrthoError::Gathering`].
 ///
 /// # Examples
 ///

--- a/ortho_config/src/error.rs
+++ b/ortho_config/src/error.rs
@@ -127,10 +127,25 @@ impl OrthoError {
             source: Box::new(source),
         }
     }
+
+    /// Construct a gathering error from a [`figment::Error`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ortho_config::OrthoError;
+    /// let fe = figment::Error::from("boom");
+    /// let e = OrthoError::gathering(fe);
+    /// assert!(matches!(e, OrthoError::Gathering(_)));
+    /// ```
+    #[must_use]
+    pub fn gathering(source: figment::Error) -> Self {
+        OrthoError::Gathering(Box::new(source))
+    }
 }
 
-/// Convert any [`serde_json::Error`], whether from serialization or
-/// deserialization, into [`OrthoError::Gathering`].
+/// Convert any [`serde_json::Error`], whether from serialisation or
+/// deserialisation, into [`OrthoError::Gathering`].
 ///
 /// # Examples
 ///

--- a/ortho_config/src/error.rs
+++ b/ortho_config/src/error.rs
@@ -144,19 +144,8 @@ impl OrthoError {
     }
 }
 
-/// Convert any [`serde_json::Error`], whether from serialization or
-/// deserialization, into [`OrthoError::Gathering`].
-///
-/// # Examples
-///
-/// ```
-/// use ortho_config::OrthoError;
-///
-/// let json_err = serde_json::from_str::<u8>("not a number")
-///     .expect_err("invalid number");
-/// let err: OrthoError = json_err.into();
-/// assert!(matches!(err, OrthoError::Gathering(_)));
-/// ```
+/// Convert JSON encoding or decoding failures into
+/// [`OrthoError::Gathering`].
 impl From<serde_json::Error> for OrthoError {
     fn from(e: serde_json::Error) -> Self {
         OrthoError::Gathering(Box::new(figment::Error::from(format!(

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -1,8 +1,8 @@
 //! Core crate for the `OrthoConfig` configuration framework.
 //!
-//! This crate defines the [`OrthoConfig`] trait and supporting error types. The
-//! actual implementation of the derive macro lives in the companion
-//! `ortho_config_macros` crate.
+//! Defines the [`OrthoConfig`] trait, error types and sanitization helpers used
+//! to layer configuration from the CLI, files and environment. The derive macro
+//! lives in the companion `ortho_config_macros` crate.
 
 pub use ortho_config_macros::OrthoConfig;
 
@@ -42,7 +42,7 @@ pub fn normalize_prefix(prefix: &str) -> String {
 pub use csv_env::CsvEnv;
 pub use error::OrthoError;
 pub use file::load_config_file;
-/// Re-export sanitisation helpers used to strip `None` fields and produce a
+/// Re-export sanitization helpers used to strip `None` fields and produce a
 /// Figment provider.
 ///
 /// # Examples
@@ -55,7 +55,7 @@ pub use file::load_config_file;
 /// # fn main() -> Result<(), OrthoError> {
 /// let cli = CLI { flag: None };
 /// let provider = sanitized_provider(&cli)?; // ready to merge over defaults
-/// let _json = sanitize_value(&cli)?;        // raw serialised value with `None`s removed
+/// let _json = sanitize_value(&cli)?;        // raw serialized value with `None`s removed
 /// # let _ = provider;
 /// # Ok(())
 /// # }
@@ -90,7 +90,7 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// # Errors
     ///
     /// Returns an [`OrthoError`] if parsing command-line arguments, reading
-    /// files or deserialising configuration fails.
+    /// files or deserializing configuration fails.
     fn load() -> Result<Self, OrthoError> {
         Self::load_from_iter(std::env::args_os())
     }
@@ -101,7 +101,7 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// # Errors
     ///
     /// Returns an [`OrthoError`] if parsing command-line arguments, reading
-    /// files or deserialising configuration fails.
+    /// files or deserializing configuration fails.
     fn load_from_iter<I, T>(iter: I) -> Result<Self, OrthoError>
     where
         I: IntoIterator<Item = T>,

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -1,6 +1,6 @@
 //! Core crate for the `OrthoConfig` configuration framework.
 //!
-//! Defines the [`OrthoConfig`] trait, error types and sanitisation helpers used
+//! Defines the [`OrthoConfig`] trait, error types and sanitization helpers used
 //! to layer configuration from the CLI, files and environment. The derive macro
 //! lives in the companion `ortho_config_macros` crate.
 
@@ -42,7 +42,7 @@ pub fn normalize_prefix(prefix: &str) -> String {
 pub use csv_env::CsvEnv;
 pub use error::OrthoError;
 pub use file::load_config_file;
-/// Re-export sanitisation helpers used to strip `None` fields and produce a
+/// Re-export sanitization helpers used to strip `None` fields and produce a
 /// Figment provider.
 ///
 /// # Examples
@@ -55,7 +55,7 @@ pub use file::load_config_file;
 /// # fn main() -> Result<(), OrthoError> {
 /// let cli = CLI { flag: None };
 /// let provider = sanitized_provider(&cli)?; // ready to merge over defaults
-/// let _json = sanitize_value(&cli)?;        // raw serialised value with `None`s removed
+/// let _json = sanitize_value(&cli)?;        // raw serialized value with `None`s removed
 /// # let _ = provider;
 /// # Ok(())
 /// # }
@@ -90,7 +90,7 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// # Errors
     ///
     /// Returns an [`OrthoError`] if parsing command-line arguments, reading
-    /// files or deserialising configuration fails.
+    /// files or deserializing configuration fails.
     fn load() -> Result<Self, OrthoError> {
         Self::load_from_iter(std::env::args_os())
     }
@@ -101,7 +101,7 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// # Errors
     ///
     /// Returns an [`OrthoError`] if parsing command-line arguments, reading
-    /// files or deserialising configuration fails.
+    /// files or deserializing configuration fails.
     fn load_from_iter<I, T>(iter: I) -> Result<Self, OrthoError>
     where
         I: IntoIterator<Item = T>,

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -42,6 +42,24 @@ pub fn normalize_prefix(prefix: &str) -> String {
 pub use csv_env::CsvEnv;
 pub use error::OrthoError;
 pub use file::load_config_file;
+/// Re-export sanitisation helpers used to strip `None` fields and produce a
+/// Figment provider.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use ortho_config::{sanitize_value, sanitized_provider, OrthoError};
+/// #[derive(serde::Serialize)]
+/// struct CLI { flag: Option<()> }
+///
+/// # fn main() -> Result<(), OrthoError> {
+/// let cli = CLI { flag: None };
+/// let provider = sanitized_provider(&cli)?; // ready to merge over defaults
+/// let _json = sanitize_value(&cli)?;        // raw serialised value with `None`s removed
+/// # let _ = provider;
+/// # Ok(())
+/// # }
+/// ```
 pub use merge::{sanitize_value, sanitized_provider};
 
 /// Trait implemented for structs that represent application configuration.
@@ -72,7 +90,7 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// # Errors
     ///
     /// Returns an [`OrthoError`] if parsing command-line arguments, reading
-    /// files or deserializing configuration fails.
+    /// files or deserialising configuration fails.
     fn load() -> Result<Self, OrthoError> {
         Self::load_from_iter(std::env::args_os())
     }
@@ -83,7 +101,7 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// # Errors
     ///
     /// Returns an [`OrthoError`] if parsing command-line arguments, reading
-    /// files or deserializing configuration fails.
+    /// files or deserialising configuration fails.
     fn load_from_iter<I, T>(iter: I) -> Result<Self, OrthoError>
     where
         I: IntoIterator<Item = T>,

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -1,6 +1,6 @@
 //! Core crate for the `OrthoConfig` configuration framework.
 //!
-//! Defines the [`OrthoConfig`] trait, error types and sanitization helpers used
+//! Defines the [`OrthoConfig`] trait, error types and sanitisation helpers used
 //! to layer configuration from the CLI, files and environment. The derive macro
 //! lives in the companion `ortho_config_macros` crate.
 
@@ -42,7 +42,7 @@ pub fn normalize_prefix(prefix: &str) -> String {
 pub use csv_env::CsvEnv;
 pub use error::OrthoError;
 pub use file::load_config_file;
-/// Re-export sanitization helpers used to strip `None` fields and produce a
+/// Re-export sanitisation helpers used to strip `None` fields and produce a
 /// Figment provider.
 ///
 /// # Examples
@@ -55,7 +55,7 @@ pub use file::load_config_file;
 /// # fn main() -> Result<(), OrthoError> {
 /// let cli = CLI { flag: None };
 /// let provider = sanitized_provider(&cli)?; // ready to merge over defaults
-/// let _json = sanitize_value(&cli)?;        // raw serialized value with `None`s removed
+/// let _json = sanitize_value(&cli)?;        // raw serialised value with `None`s removed
 /// # let _ = provider;
 /// # Ok(())
 /// # }
@@ -90,7 +90,7 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// # Errors
     ///
     /// Returns an [`OrthoError`] if parsing command-line arguments, reading
-    /// files or deserializing configuration fails.
+    /// files or deserialising configuration fails.
     fn load() -> Result<Self, OrthoError> {
         Self::load_from_iter(std::env::args_os())
     }
@@ -101,7 +101,7 @@ pub trait OrthoConfig: Sized + serde::de::DeserializeOwned {
     /// # Errors
     ///
     /// Returns an [`OrthoError`] if parsing command-line arguments, reading
-    /// files or deserializing configuration fails.
+    /// files or deserialising configuration fails.
     fn load_from_iter<I, T>(iter: I) -> Result<Self, OrthoError>
     where
         I: IntoIterator<Item = T>,

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -1,4 +1,4 @@
-//! Helpers for sanitising and merging command-line arguments with
+//! Helpers for sanitizing and merging command-line arguments with
 //! configuration defaults.
 
 use crate::OrthoError;
@@ -14,7 +14,7 @@ use serde_json::Value;
 /// - Array elements equal to null are removed, dropping `None` entries in
 ///   `Vec<_>` but retaining empty arrays to allow deliberate clearing.
 ///
-/// Intended for CLI sanitisation so unset [`Option`] fields and untouched
+/// Intended for CLI sanitization so unset [`Option`] fields and untouched
 /// flattened structs do not override defaults from files or environment
 /// variables.
 /// Arrays are never removed, even when emptied; this function only removes
@@ -43,7 +43,7 @@ fn strip_nulls(value: &mut Value) -> bool {
     }
 }
 
-/// Serialise a CLI struct to JSON, removing fields set to `None`.
+/// Serialize a CLI struct to JSON, removing fields set to `None`.
 ///
 /// # Examples
 ///
@@ -55,20 +55,20 @@ fn strip_nulls(value: &mut Value) -> bool {
 /// struct Args { count: Option<u32> }
 ///
 /// let v = value_without_nones(&Args { count: None })
-///     .expect("expected serialisation to succeed");
+///     .expect("expected serialization to succeed");
 /// assert_eq!(v, serde_json::json!({}));
 /// ```
 ///
 /// # Errors
 ///
-/// Returns any [`serde_json::Error`] encountered during serialisation.
+/// Returns any [`serde_json::Error`] encountered during serialization.
 pub fn value_without_nones<T: Serialize>(cli: &T) -> Result<Value, serde_json::Error> {
     let mut value = serde_json::to_value(cli)?;
     let _ = strip_nulls(&mut value);
     Ok(value)
 }
 
-/// Serialise `value` to JSON, pruning `None` fields and mapping errors to
+/// Serialize `value` to JSON, pruning `None` fields and mapping errors to
 /// [`OrthoError`].
 ///
 /// # Examples
@@ -80,13 +80,13 @@ pub fn value_without_nones<T: Serialize>(cli: &T) -> Result<Value, serde_json::E
 /// #[derive(Serialize)]
 /// struct Args { count: Option<u32> }
 /// let v = sanitize_value(&Args { count: None })
-///     .expect("expected sanitisation to succeed");
+///     .expect("expected sanitization to succeed");
 /// assert_eq!(v, serde_json::json!({}));
 /// ```
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if JSON serialisation fails.
+/// Returns an [`OrthoError`] if JSON serialization fails.
 pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
     value_without_nones(value).map_err(OrthoError::from)
 }
@@ -116,7 +116,7 @@ pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if JSON serialisation fails.
+/// Returns an [`OrthoError`] if JSON serialization fails.
 pub fn sanitized_provider<T: Serialize>(
     value: &T,
 ) -> Result<Serialized<serde_json::Value>, OrthoError> {

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -1,4 +1,5 @@
-//! Helpers for sanitizing and merging command-line arguments with configuration defaults.
+//! Helpers for sanitising and merging command-line arguments with
+//! configuration defaults.
 
 use crate::OrthoError;
 use figment::providers::Serialized;
@@ -13,8 +14,9 @@ use serde_json::Value;
 /// - Array elements equal to null are removed, dropping `None` entries in
 ///   `Vec<_>` but retaining empty arrays to allow deliberate clearing.
 ///
-/// Intended for CLI sanitization so unset [`Option`] fields and untouched
-/// flattened structs do not override defaults from files or environment variables.
+/// Intended for CLI sanitisation so unset [`Option`] fields and untouched
+/// flattened structs do not override defaults from files or environment
+/// variables.
 /// Arrays are never removed, even when emptied; this function only removes
 /// [`Option::None`] fields.
 ///
@@ -41,7 +43,7 @@ fn strip_nulls(value: &mut Value) -> bool {
     }
 }
 
-/// Serialize a CLI struct to JSON, removing fields set to `None`.
+/// Serialise a CLI struct to JSON, removing fields set to `None`.
 ///
 /// # Examples
 ///
@@ -53,13 +55,13 @@ fn strip_nulls(value: &mut Value) -> bool {
 /// struct Args { count: Option<u32> }
 ///
 /// let v = value_without_nones(&Args { count: None })
-///     .expect("expected serialization to succeed");
+///     .expect("expected serialisation to succeed");
 /// assert_eq!(v, serde_json::json!({}));
 /// ```
 ///
 /// # Errors
 ///
-/// Returns any [`serde_json::Error`] encountered during serialization.
+/// Returns any [`serde_json::Error`] encountered during serialisation.
 pub fn value_without_nones<T: Serialize>(cli: &T) -> Result<Value, serde_json::Error> {
     let mut value = serde_json::to_value(cli)?;
     let _ = strip_nulls(&mut value);
@@ -68,7 +70,7 @@ pub fn value_without_nones<T: Serialize>(cli: &T) -> Result<Value, serde_json::E
 
 /// Convert a [`serde_json::Error`] into [`OrthoError::Gathering`].
 ///
-/// This helper is used by [`sanitize_value`] to map JSON serialization
+/// This helper is used by [`sanitize_value`] to map JSON serialisation
 /// failures into the crate's error type.
 ///
 /// ```ignore
@@ -80,7 +82,7 @@ fn convert_gathering_error(e: serde_json::Error) -> OrthoError {
     e.into()
 }
 
-/// Serialize `value` to JSON, pruning `None` fields and mapping errors to
+/// Serialise `value` to JSON, pruning `None` fields and mapping errors to
 /// [`OrthoError`].
 ///
 /// # Examples
@@ -92,13 +94,13 @@ fn convert_gathering_error(e: serde_json::Error) -> OrthoError {
 /// #[derive(Serialize)]
 /// struct Args { count: Option<u32> }
 /// let v = sanitize_value(&Args { count: None })
-///     .expect("expected sanitization to succeed");
+///     .expect("expected sanitisation to succeed");
 /// assert_eq!(v, serde_json::json!({}));
 /// ```
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if JSON serialization fails.
+/// Returns an [`OrthoError`] if JSON serialisation fails.
 pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
     value_without_nones(value).map_err(convert_gathering_error)
 }
@@ -128,7 +130,7 @@ pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if JSON serialization fails.
+/// Returns an [`OrthoError`] if JSON serialisation fails.
 pub fn sanitized_provider<T: Serialize>(
     value: &T,
 ) -> Result<Serialized<serde_json::Value>, OrthoError> {

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -88,7 +88,7 @@ pub fn value_without_nones<T: Serialize>(cli: &T) -> Result<Value, serde_json::E
 ///
 /// Returns an [`OrthoError`] if JSON serialization fails.
 pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
-    value_without_nones(value).map_err(OrthoError::from)
+    value_without_nones(value).map_err(Into::into)
 }
 
 /// Produce a Figment provider from `value` with `None` fields removed.

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -1,4 +1,4 @@
-//! Helpers for sanitising and merging command-line arguments with
+//! Helpers for sanitizing and merging command-line arguments with
 //! configuration defaults.
 
 use crate::OrthoError;
@@ -14,7 +14,7 @@ use serde_json::Value;
 /// - Array elements equal to null are removed, dropping `None` entries in
 ///   `Vec<_>` but retaining empty arrays to allow deliberate clearing.
 ///
-/// Intended for CLI sanitisation so unset [`Option`] fields and untouched
+/// Intended for CLI sanitization so unset [`Option`] fields and untouched
 /// flattened structs do not override defaults from files or environment
 /// variables.
 /// Arrays are never removed, even when emptied; this function only removes
@@ -43,7 +43,7 @@ fn strip_nulls(value: &mut Value) -> bool {
     }
 }
 
-/// Serialise a CLI struct to JSON, removing fields set to `None`.
+/// Serialize a CLI struct to JSON, removing fields set to `None`.
 ///
 /// # Examples
 ///
@@ -55,34 +55,20 @@ fn strip_nulls(value: &mut Value) -> bool {
 /// struct Args { count: Option<u32> }
 ///
 /// let v = value_without_nones(&Args { count: None })
-///     .expect("expected serialisation to succeed");
+///     .expect("expected serialization to succeed");
 /// assert_eq!(v, serde_json::json!({}));
 /// ```
 ///
 /// # Errors
 ///
-/// Returns any [`serde_json::Error`] encountered during serialisation.
+/// Returns any [`serde_json::Error`] encountered during serialization.
 pub fn value_without_nones<T: Serialize>(cli: &T) -> Result<Value, serde_json::Error> {
     let mut value = serde_json::to_value(cli)?;
     let _ = strip_nulls(&mut value);
     Ok(value)
 }
 
-/// Convert a [`serde_json::Error`] into [`OrthoError::Gathering`].
-///
-/// This helper is used by [`sanitize_value`] to map JSON serialisation
-/// failures into the crate's error type.
-///
-/// ```ignore
-/// fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
-///     value_without_nones(value).map_err(convert_gathering_error)
-/// }
-/// ```
-fn convert_gathering_error(e: serde_json::Error) -> OrthoError {
-    e.into()
-}
-
-/// Serialise `value` to JSON, pruning `None` fields and mapping errors to
+/// Serialize `value` to JSON, pruning `None` fields and mapping errors to
 /// [`OrthoError`].
 ///
 /// # Examples
@@ -94,15 +80,15 @@ fn convert_gathering_error(e: serde_json::Error) -> OrthoError {
 /// #[derive(Serialize)]
 /// struct Args { count: Option<u32> }
 /// let v = sanitize_value(&Args { count: None })
-///     .expect("expected sanitisation to succeed");
+///     .expect("expected sanitization to succeed");
 /// assert_eq!(v, serde_json::json!({}));
 /// ```
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if JSON serialisation fails.
+/// Returns an [`OrthoError`] if JSON serialization fails.
 pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
-    value_without_nones(value).map_err(convert_gathering_error)
+    value_without_nones(value).map_err(OrthoError::from)
 }
 
 /// Produce a Figment provider from `value` with `None` fields removed.
@@ -130,7 +116,7 @@ pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if JSON serialisation fails.
+/// Returns an [`OrthoError`] if JSON serialization fails.
 pub fn sanitized_provider<T: Serialize>(
     value: &T,
 ) -> Result<Serialized<serde_json::Value>, OrthoError> {

--- a/ortho_config/src/merge.rs
+++ b/ortho_config/src/merge.rs
@@ -1,4 +1,4 @@
-//! Helpers for sanitizing and merging command-line arguments with
+//! Helpers for sanitising and merging command-line arguments with
 //! configuration defaults.
 
 use crate::OrthoError;
@@ -14,7 +14,7 @@ use serde_json::Value;
 /// - Array elements equal to null are removed, dropping `None` entries in
 ///   `Vec<_>` but retaining empty arrays to allow deliberate clearing.
 ///
-/// Intended for CLI sanitization so unset [`Option`] fields and untouched
+/// Intended for CLI sanitisation so unset [`Option`] fields and untouched
 /// flattened structs do not override defaults from files or environment
 /// variables.
 /// Arrays are never removed, even when emptied; this function only removes
@@ -43,7 +43,7 @@ fn strip_nulls(value: &mut Value) -> bool {
     }
 }
 
-/// Serialize a CLI struct to JSON, removing fields set to `None`.
+/// Serialise a CLI struct to JSON, removing fields set to `None`.
 ///
 /// # Examples
 ///
@@ -55,20 +55,20 @@ fn strip_nulls(value: &mut Value) -> bool {
 /// struct Args { count: Option<u32> }
 ///
 /// let v = value_without_nones(&Args { count: None })
-///     .expect("expected serialization to succeed");
+///     .expect("expected serialisation to succeed");
 /// assert_eq!(v, serde_json::json!({}));
 /// ```
 ///
 /// # Errors
 ///
-/// Returns any [`serde_json::Error`] encountered during serialization.
+/// Returns any [`serde_json::Error`] encountered during serialisation.
 pub fn value_without_nones<T: Serialize>(cli: &T) -> Result<Value, serde_json::Error> {
     let mut value = serde_json::to_value(cli)?;
     let _ = strip_nulls(&mut value);
     Ok(value)
 }
 
-/// Serialize `value` to JSON, pruning `None` fields and mapping errors to
+/// Serialise `value` to JSON, pruning `None` fields and mapping errors to
 /// [`OrthoError`].
 ///
 /// # Examples
@@ -80,13 +80,13 @@ pub fn value_without_nones<T: Serialize>(cli: &T) -> Result<Value, serde_json::E
 /// #[derive(Serialize)]
 /// struct Args { count: Option<u32> }
 /// let v = sanitize_value(&Args { count: None })
-///     .expect("expected sanitization to succeed");
+///     .expect("expected sanitisation to succeed");
 /// assert_eq!(v, serde_json::json!({}));
 /// ```
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if JSON serialization fails.
+/// Returns an [`OrthoError`] if JSON serialisation fails.
 pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
     value_without_nones(value).map_err(OrthoError::from)
 }
@@ -116,7 +116,7 @@ pub fn sanitize_value<T: Serialize>(value: &T) -> Result<Value, OrthoError> {
 ///
 /// # Errors
 ///
-/// Returns an [`OrthoError`] if JSON serialization fails.
+/// Returns an [`OrthoError`] if JSON serialisation fails.
 pub fn sanitized_provider<T: Serialize>(
     value: &T,
 ) -> Result<Serialized<serde_json::Value>, OrthoError> {

--- a/ortho_config/src/subcommand/mod.rs
+++ b/ortho_config/src/subcommand/mod.rs
@@ -78,7 +78,7 @@ where
     fig = fig.merge(env_provider);
 
     // Extraction only gathers defaults, so map failures accordingly.
-    fig.extract().map_err(|e| OrthoError::Gathering(e.into()))
+    fig.extract().map_err(OrthoError::gathering)
 }
 
 /// Loads configuration defaults for a subcommand using the prefix defined by the
@@ -126,6 +126,8 @@ pub fn load_subcommand_config_for<T>(name: &CmdName) -> Result<T, OrthoError>
 where
     T: crate::OrthoConfig + Default,
 {
+    // FIXME: Remove once `load_subcommand_config` is deleted in v0.4.0.
+    // See docs/roadmap.md.
     #[expect(
         deprecated,
         reason = "delegates to deprecated helper during transition"

--- a/ortho_config/src/subcommand/mod.rs
+++ b/ortho_config/src/subcommand/mod.rs
@@ -129,8 +129,8 @@ pub fn load_subcommand_config_for<T>(name: &CmdName) -> Result<T, OrthoError>
 where
     T: crate::OrthoConfig + Default,
 {
-    // FIXME: Remove once `load_subcommand_config` is deleted in v0.4.0.
-    // See docs/roadmap.md.
+    // FIXME: Remove once `load_subcommand_config` is deleted in v0.4.0 (see
+    // docs/roadmap.md).
     #[expect(
         deprecated,
         reason = "delegates to deprecated helper during transition"

--- a/ortho_config/src/subcommand/mod.rs
+++ b/ortho_config/src/subcommand/mod.rs
@@ -1,4 +1,7 @@
 //! Support for loading configuration for individual subcommands.
+//!
+//! Gathers defaults from files and environment variables before applying CLI
+//! overrides for a focused subcommand.
 
 use crate::{OrthoError, load_config_file, sanitized_provider};
 use clap::CommandFactory;
@@ -54,7 +57,7 @@ fn load_from_files(paths: &[PathBuf], name: &CmdName) -> Result<Figment, OrthoEr
 /// # Errors
 ///
 /// Returns [`OrthoError::Gathering`] if configuration files cannot be loaded or
-/// if deserialisation fails.
+/// if deserialization fails.
 ///
 /// # Deprecated
 ///
@@ -93,7 +96,7 @@ where
 /// # Errors
 ///
 /// Returns [`OrthoError::Gathering`] if configuration files cannot be loaded or
-/// if deserialisation fails.
+/// if deserialization fails.
 ///
 /// # Examples
 ///
@@ -146,7 +149,7 @@ where
 /// # Errors
 ///
 /// Returns [`OrthoError::Merge`] if CLI values cannot be merged or if
-/// deserialisation fails. Because CLI merging occurs, this function does not
+/// deserialization fails. Because CLI merging occurs, this function does not
 /// return [`OrthoError::Gathering`].
 ///
 /// # Examples
@@ -202,7 +205,7 @@ where
 /// # Errors
 ///
 /// Returns [`OrthoError::Merge`] if CLI values cannot be merged or if
-/// deserialisation fails.
+/// deserialization fails.
 ///
 /// # Examples
 ///

--- a/ortho_config/tests/error_aggregation.rs
+++ b/ortho_config/tests/error_aggregation.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 struct AggConfig {
     #[expect(
         dead_code,
-        reason = "Field is read via deserialisation only in this test"
+        reason = "Field is read via deserialization only in this test"
     )]
     port: u32,
 }

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -104,7 +104,7 @@ pub(crate) fn build_env_section(tokens: &LoadImplTokens<'_>) -> proc_macro2::Tok
     }
 }
 
-/// Build tokens that merge a sanitised CLI provider into a `Figment`.
+/// Build tokens that merge a sanitized CLI provider into a `Figment`.
 ///
 /// The generated code merges the provider when present and pushes any
 /// resulting errors onto the supplied collection.


### PR DESCRIPTION
## Summary
- document crate-level sanitisation helpers with examples
- align merge module with en-GB spelling
- mirror error mapping style with a new `OrthoError::gathering` helper and add roadmap FIXME

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ab882cf0948322958e7379d50c5e3a

## Summary by Sourcery

Document existing sanitisation utilities, align spelling conventions, and refine error-to-OrthoError mapping by introducing a dedicated helper

New Features:
- Document crate-level sanitisation helpers with examples
- Introduce OrthoError::gathering helper for consistent error mapping

Enhancements:
- Standardise spelling to en-GB for sanitisation and serialisation
- Simplify error mapping by using the new OrthoError::gathering method

Documentation:
- Add examples and API docs for sanitize_value and sanitized_provider

Chores:
- Add roadmap FIXME to remove deprecated subcommand loader in v0.4.0