### PR TITLE
Fix crate metadata for publishing

### DIFF
--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -2,13 +2,16 @@
 name = "ortho_config"
 version = "0.3.0"
 edition = "2024"
+description.workspace = true
+license.workspace = true
+repository.workspace = true
 
 
 [lints]
 workspace = true
 
 [dependencies]
-ortho_config_macros = { path = "../ortho_config_macros" }
+ortho_config_macros = { version = "0.3.0", path = "../ortho_config_macros" }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }

--- a/ortho_config_macros/Cargo.toml
+++ b/ortho_config_macros/Cargo.toml
@@ -2,6 +2,9 @@
 name = "ortho_config_macros"
 version = "0.3.0"
 edition = "2024"
+description = "Procedural macros for ortho_config"
+license.workspace = true
+repository.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- add missing package metadata to `ortho_config` and `ortho_config_macros`
- declare version for `ortho_config_macros` dependency

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68abaa997ffc832296de484f94bac2d0