### PR TITLE
Remove legacy subcommand config helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,18 +331,17 @@ fn main() -> Result<(), String> {
   files for persistent settings).
 - **Clear Precedence:** Predictable configuration resolution.
 
-## Migrating from 0.1 to 0.2
+## Migrating from 0.4 to 0.5
 
-Version 0.2 introduces a small API refinement:
+Version 0.5 introduces a small API refinement:
 
-- `load_subcommand_config_for` now only loads default values from files and
-  environment variables. Use
-  [`load_and_merge_subcommand_for`](#subcommand-configuration) to merge these
-  defaults with CLI arguments.
+- `load_subcommand_config_for` has been removed. Use
+  [`load_and_merge_subcommand_for`](#subcommand-configuration) to load defaults
+  and merge them with CLI arguments.
 - Types deriving `OrthoConfig` expose an associated `prefix()` function. Use
   this if you need the configured prefix directly.
 
-Update the `Cargo.toml` to depend on `ortho_config = "0.2"` and adjust code to
+Update the `Cargo.toml` to depend on `ortho_config = "0.5"` and adjust code to
 call `load_and_merge_subcommand_for` instead of manually merging defaults.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -333,9 +333,9 @@ fn main() -> Result<(), String> {
 
 ## Migrating from 0.4 to 0.5
 
-Version 0.5 introduces a small API refinement:
+Version v0.5.0 introduces a small API refinement:
 
-- `load_subcommand_config_for` has been removed. Use
+- In v0.5.0 the helper `load_subcommand_config_for` was removed. Use
   [`load_and_merge_subcommand_for`](#subcommand-configuration) to load defaults
   and merge them with CLI arguments.
 - Types deriving `OrthoConfig` expose an associated `prefix()` function. Use

--- a/docs/design.md
+++ b/docs/design.md
@@ -325,7 +325,7 @@ when the CLI supplied those values. The revised implementation builds the
 parsed CLI struct before extraction. This ensures that required CLI arguments
 fulfil missing defaults and eliminates workarounds like
 `load_with_reference_fallback`. The legacy `load_subcommand_config` helpers
-have been removed.
+were removed in v0.5.0.
 
 ### 4.10. Dynamic rule tables
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -324,8 +324,8 @@ when the CLI supplied those values. The revised implementation builds the
 `Figment` from file and environment sources first, then merges the already
 parsed CLI struct before extraction. This ensures that required CLI arguments
 fulfil missing defaults and eliminates workarounds like
-`load_with_reference_fallback`. The legacy `load_subcommand_config` helpers are
-retained but deprecated.
+`load_with_reference_fallback`. The legacy `load_subcommand_config` helpers
+have been removed.
 
 ### 4.10. Dynamic rule tables
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,7 +55,7 @@ references the relevant design guidance.
     [[Subcommand Refinements](subcommand-refinements.md)]
 
   - [x] Remove `load_subcommand_config` and its `_for` variant in favour of a
-    unified `load_and_merge` API.
+    unified `load_and_merge` API (completed in v0.5.0).
 
 - [x] **Finish `clap` integration in the derive macro**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,8 +54,8 @@ references the relevant design guidance.
     by the already‑parsed CLI struct.
     [[Subcommand Refinements](subcommand-refinements.md)]
 
-  - [x] Deprecate and eventually remove `load_subcommand_config` and its `_for`
-    variant in favour of a unified `load_and_merge` API.
+  - [x] Remove `load_subcommand_config` and its `_for` variant in favour of a
+    unified `load_and_merge` API.
 
 - [x] **Finish `clap` integration in the derive macro**
 

--- a/docs/subcommand-refinements.md
+++ b/docs/subcommand-refinements.md
@@ -50,13 +50,13 @@ This change would make the `load_and_merge` method more intuitive, as it would
 correctly reflect the desired precedence (CLI &gt; Env &gt; File &gt; Defaults)
 without requiring all values to be defined in lower-precedence layers.
 
-### 2. Deprecating `load_subcommand_config`
+### 2. Removing `load_subcommand_config`
 
 The `load_subcommand_config` and `load_subcommand_config_for` functions, which
-only load defaults, become less useful with the improved `load_and_merge`. To
-simplify the API, these were deprecated in v0.3.0 and are scheduled for removal
-in v0.4.0. This guides users towards the more comprehensive `load_and_merge` as
-the single, recommended way to handle subcommand configuration.
+only load defaults, became less useful with the improved `load_and_merge` and
+were removed in v0.5.0. This guides users towards the more comprehensive
+`load_and_merge` as the single, recommended way to handle subcommand
+configuration.
 
 ## How this Simplifies `vk`
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -67,13 +67,13 @@ during discovery and do not cause errors if present.
 
 ## Migrating from earlier versions
 
-Projects using a pre‑0.3 release can upgrade with the following steps:
+Projects using a pre‑0.5 release can upgrade with the following steps:
 
 - `#[derive(OrthoConfig)]` remains the correct way to annotate configuration
   structs. No additional derives are required.
 - Remove any `load_with_reference_fallback` helpers. The merge logic inside
   `load_and_merge_subcommand_for` supersedes this workaround.
-- Replace calls to deprecated helpers such as `load_subcommand_config_for` with
+- Replace calls to removed helpers such as `load_subcommand_config_for` with
   `ortho_config::subcommand::load_and_merge_subcommand_for`.
 
 Each subcommand struct can expose a wrapper method that forwards to
@@ -346,12 +346,11 @@ results in `ignore_patterns = [".git/", "build/", "target/"]`.
 Many CLI applications use `clap` subcommands to perform different operations.
 `OrthoConfig` supports per‑subcommand defaults via a dedicated `cmds`
 namespace. The helper function `load_and_merge_subcommand_for` loads defaults
-for a specific subcommand and merges them beneath the CLI values. The older
-`load_subcommand_config` and `load_subcommand_config_for` helpers are
-deprecated in favour of this function. The merged struct is returned as a new
-instance; the original `cli` struct remains unchanged. CLI fields left unset
-(`None`) do not override environment or file defaults, avoiding accidental loss
-of configuration.
+for a specific subcommand and merges them beneath the CLI values. The legacy
+`load_subcommand_config` and `load_subcommand_config_for` helpers were removed
+in v0.5.0. The merged struct is returned as a new instance; the original `cli`
+struct remains unchanged. CLI fields left unset (`None`) do not override
+environment or file defaults, avoiding accidental loss of configuration.
 
 ### How it works
 

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -11,14 +11,7 @@ mod error;
 mod file;
 mod merge;
 pub mod subcommand;
-#[expect(
-    deprecated,
-    reason = "re-export legacy helpers pending removal in v0.4.0"
-)]
-pub use subcommand::{
-    load_and_merge_subcommand, load_and_merge_subcommand_for, load_subcommand_config,
-    load_subcommand_config_for,
-};
+pub use subcommand::{load_and_merge_subcommand, load_and_merge_subcommand_for};
 
 /// Normalize a prefix by trimming trailing underscores and converting
 /// to lowercase ASCII.

--- a/ortho_config/src/subcommand/mod.rs
+++ b/ortho_config/src/subcommand/mod.rs
@@ -14,7 +14,6 @@ use paths::candidate_paths;
 pub use paths::push_stem_candidates;
 pub use types::{CmdName, Prefix};
 
-
 /// Load and merge `[cmds.<name>]` sections from the given paths.
 ///
 /// For each provided path, loads the configuration file and merges the

--- a/ortho_config/tests/util.rs
+++ b/ortho_config/tests/util.rs
@@ -5,7 +5,7 @@
 //! tests by encapsulating the jail creation and configuration loading.
 
 use clap::CommandFactory;
-use ortho_config::subcommand::{CmdName, Prefix};
+use ortho_config::subcommand::Prefix;
 use ortho_config::{
     OrthoConfig, OrthoError, load_and_merge_subcommand, load_and_merge_subcommand_for,
 };
@@ -26,29 +26,6 @@ where
         Ok(())
     })?;
     Ok(result.into_inner().expect("loader executed"))
-}
-
-/// Runs `setup` in a jailed environment then loads a subcommand
-/// configuration for the `test` command using the `APP_` prefix.
-///
-/// # Errors
-///
-/// Returns an error if configuration loading fails.
-pub fn with_subcommand_config<F, T>(setup: F) -> Result<T, OrthoError>
-where
-    F: FnOnce(&mut figment::Jail) -> figment::error::Result<()>,
-    T: DeserializeOwned + Default,
-{
-    with_jail(setup, || {
-        #[expect(
-            deprecated,
-            reason = "figment's Jail uses deprecated APIs for test isolation"
-        )]
-        {
-            // FIXME: remove once figment::Jail replacement lands upstream (see https://github.com/SergioBenitez/Figment/issues/138)
-            ortho_config::load_subcommand_config::<T>(&Prefix::new("APP_"), &CmdName::new("test"))
-        }
-    })
 }
 
 /// Runs `setup` in a jailed environment, then loads defaults for the `test`

--- a/ortho_config/tests/util.rs
+++ b/ortho_config/tests/util.rs
@@ -58,5 +58,5 @@ where
     with_jail(setup, || load_and_merge_subcommand_for(cli))
 }
 
-// Intentionally no additional legacy-only helper; tests should use the
-// unified wrappers above to exercise both legacy and current behaviours.
+// These helpers keep tests focused on the unified subcommand loaders without
+// legacy-specific branches.


### PR DESCRIPTION
## Summary
- drop deprecated `load_subcommand_config` APIs
- clean up tests and docs to rely on `load_and_merge_subcommand`
- document removal of legacy subcommand loaders in v0.5.0

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68aba823df588322b0cb05a09e22f6b2

## Summary by Sourcery

Remove deprecated subcommand configuration helpers and related utilities, streamline the subcommand API surface, and update tests and documentation to use the unified `load_and_merge_subcommand` API.

Enhancements:
- Remove deprecated `load_subcommand_config` and `load_subcommand_config_for` functions and drop their supporting helpers.
- Simplify module exports to only re-export `load_and_merge_subcommand` and `load_and_merge_subcommand_for`.
- Refactor test utilities and config structs to replace `with_subcommand_config` with `with_merged_subcommand_cli` and add necessary derives.

Documentation:
- Update migration guides and user-facing documentation to reflect removal of legacy subcommand loaders in v0.5.0 and bump version references from 0.4 to 0.5.