### PR TITLE
Add version sync script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Ensure bump_version script is executable
+        if: runner.os == 'Linux'
+        shell: bash
         run: test -x scripts/bump_version.py
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
             coverage: false
     steps:
       - uses: actions/checkout@v4
+      - name: Ensure bump_version script is executable
+        run: test -x scripts/bump_version.py
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
       - name: Show Ninja version

--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ call `load_and_merge_subcommand_for` instead of manually merging defaults.
 
 - The `scripts/bump_version.py` helper keeps the workspace and member crates in
   version sync.
+- It requires [`uv`](https://docs.astral.sh/uv/) on the `PATH` as the shebang
+  uses `uv` for dependency resolution.
 - Run it with the desired semantic version:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -345,6 +345,16 @@ Version 0.2 introduces a small API refinement:
 Update the `Cargo.toml` to depend on `ortho_config = "0.2"` and adjust code to
 call `load_and_merge_subcommand_for` instead of manually merging defaults.
 
+## Version management
+
+- The `scripts/bump_version.py` helper keeps the workspace and member crates in
+  version sync.
+- Run it with the desired semantic version:
+
+```sh
+./scripts/bump_version.py 1.2.3
+```
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit issues, fork the

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv
+#!/usr/bin/env -S uv run
 # /// script
 # dependencies = ["tomli-w"]
 # ///
@@ -15,8 +15,11 @@ Run with the desired semantic version:
 """
 from __future__ import annotations
 
+import os
 import sys
+import tempfile
 from pathlib import Path
+
 import tomllib
 import tomli_w
 
@@ -28,22 +31,48 @@ def _set_version(toml_path: Path, version: str) -> None:
         data["workspace"]["package"]["version"] = version
     elif "package" in data:
         data["package"]["version"] = version
-    toml_path.write_text(tomli_w.dumps(data))
+
+    text = tomli_w.dumps(data)
+    temp_dir = toml_path.parent
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=temp_dir, delete=False
+    ) as tf:
+        tf.write(text)
+        temp_name = tf.name
+    os.replace(temp_name, toml_path)
 
 def main(argv: list[str]) -> int:
+    """Update the workspace and member crate versions to the supplied value."""
     if len(argv) != 2:
         prog = Path(argv[0]).name
-        print(f"Usage: {prog} <version>")
+        print(f"Usage: {prog} <version>", file=sys.stderr)
         return 1
     version = argv[1]
     root = Path(__file__).resolve().parent.parent
     workspace = root / "Cargo.toml"
-    with workspace.open("rb") as fh:
-        data = tomllib.load(fh)
+    try:
+        with workspace.open("rb") as fh:
+            data = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:  # pragma: no cover - defensive
+        print(f"Error: Failed to parse {workspace}: {exc}", file=sys.stderr)
+        return 1
     members = data.get("workspace", {}).get("members", [])
     _set_version(workspace, version)
     for member in members:
-        _set_version(root / member / "Cargo.toml", version)
+        member_path = root / member / "Cargo.toml"
+        if not member_path.exists():
+            print(
+                f"Warning: Skipping missing member Cargo.toml at {member_path}",
+                file=sys.stderr,
+            )
+            continue
+        try:
+            _set_version(member_path, version)
+        except Exception as exc:  # pragma: no cover - defensive
+            print(
+                f"Error: Failed to set version for {member_path}: {exc}",
+                file=sys.stderr,
+            )
     return 0
 
 if __name__ == "__main__":  # pragma: no cover

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -42,6 +42,167 @@ def _set_version(toml_path: Path, version: str) -> None:
     os.replace(temp_name, toml_path)
 
 
+def _validate_args_and_setup(argv: list[str]) -> tuple[str, Path] | None:
+    """Validate CLI arguments and resolve the workspace root.
+
+    Parameters
+    ----------
+    argv
+        Raw command-line arguments.
+
+    Returns
+    -------
+    tuple[str, Path] | None
+        The requested version and repository root if arguments are valid;
+        ``None`` otherwise.
+
+    Examples
+    --------
+    >>> _validate_args_and_setup(["bump_version.py", "1.2.3"])  # doctest: +ELLIPSIS
+    ('1.2.3', Path(...))
+    """
+    if len(argv) != 2:
+        prog = Path(argv[0]).name
+        print(f"Usage: {prog} <version>", file=sys.stderr)
+        return None
+    version = argv[1]
+    root = Path(__file__).resolve().parent.parent
+    return version, root
+
+
+def _resolve_member_paths(root: Path, members: list[str]) -> list[Path]:
+    """Expand workspace member patterns to concrete paths.
+
+    Parameters
+    ----------
+    root
+        Workspace root directory.
+    members
+        Glob patterns for workspace members.
+
+    Returns
+    -------
+    list[Path]
+        Paths matched by the supplied patterns. Warnings are emitted for
+        patterns that match nothing.
+
+    Examples
+    --------
+    >>> _resolve_member_paths(Path('.'), ['scripts'])  # doctest: +ELLIPSIS
+    [Path('scripts')]
+    """
+    paths: list[Path] = []
+    for pattern in members:
+        matches = list(root.glob(pattern))
+        if not matches:
+            print(
+                f"Warning: No members matched pattern '{pattern}'",
+                file=sys.stderr,
+            )
+            continue
+        paths.extend(matches)
+    return paths
+
+
+def _update_member_version(member_path: Path, version: str) -> bool:
+    """Update a member Cargo.toml with the supplied version.
+
+    Parameters
+    ----------
+    member_path
+        Path to the member's ``Cargo.toml`` file.
+    version
+        Semantic version to apply.
+
+    Returns
+    -------
+    bool
+        ``True`` if an error occurred while updating; ``False`` otherwise.
+
+    Examples
+    --------
+    >>> _update_member_version(Path('Cargo.toml'), '1.2.3')
+    False
+    """
+    try:
+        _set_version(member_path, version)
+    except (
+        tomllib.TOMLDecodeError,
+        OSError,
+        TypeError,
+        ValueError,
+    ) as exc:  # pragma: no cover - defensive
+        print(
+            f"Error: Failed to set version for {member_path}: {exc}",
+            file=sys.stderr,
+        )
+        return True
+    return False
+
+
+def _process_single_member(member_root: Path, version: str) -> bool:
+    """Process a single workspace member.
+
+    Parameters
+    ----------
+    member_root
+        Directory or file matched from the workspace ``members`` patterns.
+    version
+        Semantic version to apply.
+
+    Returns
+    -------
+    bool
+        ``True`` if updating the member failed; ``False`` otherwise.
+
+    Examples
+    --------
+    >>> _process_single_member(Path('scripts'), '1.2.3')
+    False
+    """
+    member_path = (
+        member_root / "Cargo.toml"
+        if member_root.is_dir() or member_root.name != "Cargo.toml"
+        else member_root
+    )
+    if not member_path.exists():
+        print(
+            f"Warning: Skipping missing member Cargo.toml at {member_path}",
+            file=sys.stderr,
+        )
+        return False
+    return _update_member_version(member_path, version)
+
+
+def _process_members(root: Path, members: list[str], version: str) -> bool:
+    """Update all workspace members to the supplied version.
+
+    Parameters
+    ----------
+    root
+        Workspace root directory.
+    members
+        Glob patterns for workspace members.
+    version
+        Semantic version to apply.
+
+    Returns
+    -------
+    bool
+        ``True`` if any member failed to update; ``False`` otherwise.
+
+    Examples
+    --------
+    >>> _process_members(Path('.'), ['scripts'], '1.2.3')
+    False
+    """
+    had_error = False
+    for member_root in _resolve_member_paths(root, members):
+        if _process_single_member(member_root, version):
+            had_error = True
+    return had_error
+
+
 def main(argv: list[str]) -> int:
     """
     Update the workspace and member crate versions to the supplied value.
@@ -63,12 +224,10 @@ def main(argv: list[str]) -> int:
     >>> import sys
     >>> sys.exit(main(["bump_version.py", "1.2.3"]))
     """
-    if len(argv) != 2:
-        prog = Path(argv[0]).name
-        print(f"Usage: {prog} <version>", file=sys.stderr)
+    result = _validate_args_and_setup(argv)
+    if result is None:
         return 1
-    version = argv[1]
-    root = Path(__file__).resolve().parent.parent
+    version, root = result
     workspace = root / "Cargo.toml"
     try:
         with workspace.open("rb") as fh:
@@ -78,42 +237,7 @@ def main(argv: list[str]) -> int:
         return 1
     members = data.get("workspace", {}).get("members", [])
     _set_version(workspace, version)
-    had_error = False
-    for pattern in members:
-        matches = list(root.glob(pattern))
-        if not matches:
-            print(
-                f"Warning: No members matched pattern '{pattern}'",
-                file=sys.stderr,
-            )
-            continue
-        for member_root in matches:
-            member_path = (
-                member_root / "Cargo.toml"
-                if member_root.is_dir()
-                else member_root
-            )
-            if member_path.name != "Cargo.toml":
-                member_path = member_root / "Cargo.toml"
-            if not member_path.exists():
-                print(
-                    f"Warning: Skipping missing member Cargo.toml at {member_path}",
-                    file=sys.stderr,
-                )
-                continue
-            try:
-                _set_version(member_path, version)
-            except (
-                tomllib.TOMLDecodeError,
-                OSError,
-                TypeError,
-                ValueError,
-            ) as exc:  # pragma: no cover - defensive
-                had_error = True
-                print(
-                    f"Error: Failed to set version for {member_path}: {exc}",
-                    file=sys.stderr,
-                )
+    had_error = _process_members(root, members, version)
     return 0 if not had_error else 1
 
 if __name__ == "__main__":  # pragma: no cover

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env uv
+# /// script
+# dependencies = ["toml-w"]
+# ///
+"""Synchronise workspace and crate versions.
+
+This tool updates the top-level workspace version and each member crate's
+version to the supplied value. It exists to reduce the risk of publishing
+mismatched versions across the workspace.
+
+Examples
+--------
+Run with the desired semantic version:
+    ./scripts/bump_version.py 1.2.3
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import tomllib
+import toml_w
+
+def _set_version(toml_path: Path, version: str) -> None:
+    """Set the package or workspace version in a Cargo.toml file."""
+    with toml_path.open("rb") as fh:
+        data = tomllib.load(fh)
+    if "workspace" in data and "package" in data["workspace"]:
+        data["workspace"]["package"]["version"] = version
+    elif "package" in data:
+        data["package"]["version"] = version
+    toml_path.write_text(toml_w.dumps(data))
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        prog = Path(argv[0]).name
+        print(f"Usage: {prog} <version>")
+        return 1
+    version = argv[1]
+    root = Path(__file__).resolve().parent.parent
+    workspace = root / "Cargo.toml"
+    with workspace.open("rb") as fh:
+        data = tomllib.load(fh)
+    members = data.get("workspace", {}).get("members", [])
+    _set_version(workspace, version)
+    for member in members:
+        _set_version(root / member / "Cargo.toml", version)
+    return 0
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv))

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env uv
 # /// script
-# dependencies = ["toml-w"]
+# dependencies = ["tomli-w"]
 # ///
 """Synchronise workspace and crate versions.
 
@@ -18,7 +18,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 import tomllib
-import toml_w
+import tomli_w
 
 def _set_version(toml_path: Path, version: str) -> None:
     """Set the package or workspace version in a Cargo.toml file."""
@@ -28,7 +28,7 @@ def _set_version(toml_path: Path, version: str) -> None:
         data["workspace"]["package"]["version"] = version
     elif "package" in data:
         data["package"]["version"] = version
-    toml_path.write_text(toml_w.dumps(data))
+    toml_path.write_text(tomli_w.dumps(data))
 
 def main(argv: list[str]) -> int:
     if len(argv) != 2:


### PR DESCRIPTION
## Summary
- add `scripts/bump_version.py` to synchronise workspace and crate versions via `toml-w`
- document version bump helper in the README

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68ac019616ac8322be235cf58d5e68a5

## Summary by Sourcery

Add a new Python script to synchronise Cargo workspace and crate versions and document its usage

New Features:
- Introduce scripts/bump_version.py to update workspace and member crate versions in Cargo.toml

Documentation:
- Add README section describing the version bump helper and usage command