### PR TITLE
Fix SubcmdConfigMerge imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ to `.config.toml`. These values are then merged beneath the CLI arguments.
 ```rust
 use clap::{Args, Parser};
 use serde::Deserialize;
-use ortho_config::{OrthoConfig, SubcmdConfigMerge};
+use ortho_config::OrthoConfig;
+use ortho_config::subcommand::SubcmdConfigMerge;
 
 #[derive(Debug, Deserialize, Args, OrthoConfig)]
 #[ortho_config(prefix = "APP_")]

--- a/docs/design.md
+++ b/docs/design.md
@@ -336,7 +336,7 @@ the need for repetitive implementation blocks across subcommands.
 Import it with:
 
 ```rust
-use ortho_config::SubcmdConfigMerge;
+use ortho_config::subcommand::SubcmdConfigMerge;
 ```
 
 The sequence below shows how subcommand defaults are gathered and how gathering

--- a/docs/subcommand-refinements.md
+++ b/docs/subcommand-refinements.md
@@ -66,7 +66,7 @@ self, enabling each subcommand to invoke configuration merging without extra
 code. Import it with:
 
 ```rust
-use ortho_config::SubcmdConfigMerge;
+use ortho_config::subcommand::SubcmdConfigMerge;
 ```
 
 ## How this Simplifies `vk`

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -75,19 +75,21 @@ Projects using a pre‑0.5 release can upgrade with the following steps:
   `load_and_merge_subcommand_for` supersedes this workaround.
 - Replace calls to deprecated helpers such as `load_subcommand_config_for` with
   `ortho_config::subcommand::load_and_merge_subcommand_for` or import
-  SubcmdConfigMerge to call load_and_merge directly.
+  `ortho_config::subcommand::SubcmdConfigMerge` to call `load_and_merge`
+  directly.
 
 Import it with:
 
 ```rust
-use ortho_config::SubcmdConfigMerge;
+use ortho_config::subcommand::SubcmdConfigMerge;
 ```
 
 Subcommand structs can leverage the `SubcmdConfigMerge` trait to expose a
 `load_and_merge` method automatically:
 
 ```rust
-use ortho_config::{OrthoConfig, OrthoError, SubcmdConfigMerge};
+use ortho_config::{OrthoConfig, OrthoError};
+use ortho_config::subcommand::SubcmdConfigMerge;
 use serde::Deserialize;
 
 #[derive(Deserialize, OrthoConfig)]
@@ -378,7 +380,8 @@ might be defined as follows:
 
 ```rust
 use clap::Parser;
-use ortho_config::{OrthoConfig, SubcmdConfigMerge};
+use ortho_config::OrthoConfig;
+use ortho_config::subcommand::SubcmdConfigMerge;
 use serde::{Deserialize, Serialize};
 
 #[derive(Parser, Deserialize, Serialize, Debug, OrthoConfig, Clone, Default)]

--- a/examples/registry_ctl.rs
+++ b/examples/registry_ctl.rs
@@ -3,7 +3,8 @@
 use clap::Parser;
 use clap_dispatch::clap_dispatch;
 use serde::Deserialize;
-use ortho_config::{OrthoConfig, SubcmdConfigMerge};
+use ortho_config::OrthoConfig;
+use ortho_config::subcommand::SubcmdConfigMerge;
 
 #[derive(Parser, Deserialize, Default, Debug, Clone, OrthoConfig)]
 #[ortho_config(prefix = "REGCTL_")]

--- a/ortho_config/src/subcommand/mod.rs
+++ b/ortho_config/src/subcommand/mod.rs
@@ -143,7 +143,8 @@ where
 ///
 /// ```rust,no_run
 /// use clap::Parser;
-/// use ortho_config::{OrthoConfig, SubcmdConfigMerge};
+/// use ortho_config::OrthoConfig;
+/// use ortho_config::subcommand::SubcmdConfigMerge;
 /// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Parser, Deserialize, Serialize, OrthoConfig, Default)]

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -17,7 +17,8 @@
 //!   - no CLI, no environment  => `option = "file"` (file wins)
 
 use clap::{Parser, Subcommand};
-use ortho_config::{OrthoConfig, SubcmdConfigMerge};
+use ortho_config::OrthoConfig;
+use ortho_config::subcommand::SubcmdConfigMerge;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Parser)]

--- a/ortho_config/tests/steps/subcommand_steps.rs
+++ b/ortho_config/tests/steps/subcommand_steps.rs
@@ -8,7 +8,7 @@
 use crate::{PrArgs, World};
 use clap::Parser;
 use cucumber::{given, then, when};
-use ortho_config::SubcmdConfigMerge;
+use ortho_config::subcommand::SubcmdConfigMerge;
 
 /// Check if all configuration sources are absent.
 fn has_no_config_sources(world: &World) -> bool {

--- a/ortho_config/tests/util.rs
+++ b/ortho_config/tests/util.rs
@@ -5,8 +5,8 @@
 //! tests by encapsulating the jail creation and configuration loading.
 
 use clap::CommandFactory;
-use ortho_config::subcommand::{CmdName, Prefix};
-use ortho_config::{OrthoConfig, OrthoError, SubcmdConfigMerge, load_and_merge_subcommand};
+use ortho_config::subcommand::{Prefix, SubcmdConfigMerge};
+use ortho_config::{OrthoConfig, OrthoError, load_and_merge_subcommand};
 use serde::de::DeserializeOwned;
 
 fn with_jail<F, L, T>(setup: F, loader: L) -> Result<T, OrthoError>


### PR DESCRIPTION
## Summary
- import `SubcmdConfigMerge` from the `subcommand` module in tests and examples
- remove unused `CmdName` and align documentation with the new import path

## Testing
- `make fmt`
- `make markdownlint`
- `make nixie`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4f5abe9483228aa1a13b4bde2070