### PR TITLE
Expose SubcmdConfigMerge and fix example serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ to `.config.toml`. These values are then merged beneath the CLI arguments.
 use clap::{Args, Parser};
 use serde::Deserialize;
 use ortho_config::OrthoConfig;
-use ortho_config::subcommand::SubcmdConfigMerge;
+use ortho_config::SubcmdConfigMerge;
 
 #[derive(Debug, Deserialize, Args, OrthoConfig)]
 #[ortho_config(prefix = "APP_")]

--- a/docs/design.md
+++ b/docs/design.md
@@ -336,7 +336,7 @@ the need for repetitive implementation blocks across subcommands.
 Import it with:
 
 ```rust
-use ortho_config::subcommand::SubcmdConfigMerge;
+use ortho_config::SubcmdConfigMerge;
 ```
 
 The sequence below shows how subcommand defaults are gathered and how gathering

--- a/docs/subcommand-refinements.md
+++ b/docs/subcommand-refinements.md
@@ -66,7 +66,7 @@ self, enabling each subcommand to invoke configuration merging without extra
 code. Import it with:
 
 ```rust
-use ortho_config::subcommand::SubcmdConfigMerge;
+use ortho_config::SubcmdConfigMerge;
 ```
 
 ## How this Simplifies `vk`

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -75,13 +75,12 @@ Projects using a pre‑0.5 release can upgrade with the following steps:
   `load_and_merge_subcommand_for` supersedes this workaround.
 - Replace calls to deprecated helpers such as `load_subcommand_config_for` with
   `ortho_config::subcommand::load_and_merge_subcommand_for` or import
-  `ortho_config::subcommand::SubcmdConfigMerge` to call `load_and_merge`
-  directly.
+  `ortho_config::SubcmdConfigMerge` to call `load_and_merge` directly.
 
 Import it with:
 
 ```rust
-use ortho_config::subcommand::SubcmdConfigMerge;
+use ortho_config::SubcmdConfigMerge;
 ```
 
 Subcommand structs can leverage the `SubcmdConfigMerge` trait to expose a
@@ -89,7 +88,7 @@ Subcommand structs can leverage the `SubcmdConfigMerge` trait to expose a
 
 ```rust
 use ortho_config::{OrthoConfig, OrthoError};
-use ortho_config::subcommand::SubcmdConfigMerge;
+use ortho_config::SubcmdConfigMerge;
 use serde::Deserialize;
 
 #[derive(Deserialize, OrthoConfig)]
@@ -381,7 +380,7 @@ might be defined as follows:
 ```rust
 use clap::Parser;
 use ortho_config::OrthoConfig;
-use ortho_config::subcommand::SubcmdConfigMerge;
+use ortho_config::SubcmdConfigMerge;
 use serde::{Deserialize, Serialize};
 
 #[derive(Parser, Deserialize, Serialize, Debug, OrthoConfig, Clone, Default)]

--- a/examples/registry_ctl.rs
+++ b/examples/registry_ctl.rs
@@ -2,9 +2,9 @@
 
 use clap::Parser;
 use clap_dispatch::clap_dispatch;
-use serde::{Deserialize, Serialize};
 use ortho_config::OrthoConfig;
 use ortho_config::subcommand::SubcmdConfigMerge;
+use serde::{Deserialize, Serialize};
 
 #[derive(Parser, Deserialize, Serialize, Default, Debug, Clone, OrthoConfig)]
 #[ortho_config(prefix = "REGCTL_")]
@@ -24,12 +24,8 @@ pub struct ListItemsArgs {
     all: Option<bool>,
 }
 
-trait Run {
-    fn run(&self, db_url: &str) -> Result<(), String>;
-}
-
 impl Run for AddUserArgs {
-    fn run(&self, db_url: &str) -> Result<(), String> {
+    fn run(self, db_url: &str) -> Result<(), String> {
         println!("Connecting to database at: {db_url}");
         println!("Adding user: {:?}, Admin: {:?}", self.username, self.admin);
         Ok(())
@@ -37,12 +33,11 @@ impl Run for AddUserArgs {
 }
 
 impl Run for ListItemsArgs {
-    fn run(&self, db_url: &str) -> Result<(), String> {
+    fn run(self, db_url: &str) -> Result<(), String> {
         println!("Connecting to database at: {db_url}");
         println!(
             "Listing items in category {:?}, All: {:?}",
-            self.category,
-            self.all
+            self.category, self.all
         );
         Ok(())
     }
@@ -70,4 +65,33 @@ fn main() -> Result<(), String> {
         }
     };
     final_cmd.run(db_url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_user_args_roundtrip() {
+        let args = AddUserArgs {
+            username: Some(String::from("alice")),
+            admin: Some(true),
+        };
+        let json = serde_json::to_string(&args).expect("serialise");
+        let de: AddUserArgs = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(de.username, args.username);
+        assert_eq!(de.admin, args.admin);
+    }
+
+    #[test]
+    fn list_items_args_roundtrip() {
+        let args = ListItemsArgs {
+            category: Some(String::from("tools")),
+            all: Some(false),
+        };
+        let json = serde_json::to_string(&args).expect("serialise");
+        let de: ListItemsArgs = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(de.category, args.category);
+        assert_eq!(de.all, args.all);
+    }
 }

--- a/examples/registry_ctl.rs
+++ b/examples/registry_ctl.rs
@@ -2,11 +2,11 @@
 
 use clap::Parser;
 use clap_dispatch::clap_dispatch;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use ortho_config::OrthoConfig;
 use ortho_config::subcommand::SubcmdConfigMerge;
 
-#[derive(Parser, Deserialize, Default, Debug, Clone, OrthoConfig)]
+#[derive(Parser, Deserialize, Serialize, Default, Debug, Clone, OrthoConfig)]
 #[ortho_config(prefix = "REGCTL_")]
 pub struct AddUserArgs {
     #[arg(long)]
@@ -15,7 +15,7 @@ pub struct AddUserArgs {
     admin: Option<bool>,
 }
 
-#[derive(Parser, Deserialize, Default, Debug, Clone, OrthoConfig)]
+#[derive(Parser, Deserialize, Serialize, Default, Debug, Clone, OrthoConfig)]
 #[ortho_config(prefix = "REGCTL_")]
 pub struct ListItemsArgs {
     #[arg(long)]

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -56,4 +56,5 @@ harness = false
 
 [[example]]
 name = "registry_ctl"
-path = "../examples/registry_ctl.rs"
+path = "examples/registry_ctl.rs"
+test = true

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -53,3 +53,7 @@ test_helpers = { path = "../test_helpers" }
 [[test]]
 name = "cucumber"
 harness = false
+
+[[example]]
+name = "registry_ctl"
+path = "../examples/registry_ctl.rs"

--- a/ortho_config/examples/registry_ctl.rs
+++ b/ortho_config/examples/registry_ctl.rs
@@ -3,7 +3,7 @@
 use clap::Parser;
 use clap_dispatch::clap_dispatch;
 use ortho_config::OrthoConfig;
-use ortho_config::subcommand::SubcmdConfigMerge;
+use ortho_config::SubcmdConfigMerge;
 use serde::{Deserialize, Serialize};
 
 #[derive(Parser, Deserialize, Serialize, Default, Debug, Clone, PartialEq, OrthoConfig)]

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -11,6 +11,7 @@ mod error;
 mod file;
 mod merge;
 pub mod subcommand;
+pub use crate::subcommand::SubcmdConfigMerge;
 pub use subcommand::{load_and_merge_subcommand, load_and_merge_subcommand_for};
 
 /// Normalize a prefix by trimming trailing underscores and converting

--- a/ortho_config/src/subcommand/mod.rs
+++ b/ortho_config/src/subcommand/mod.rs
@@ -144,7 +144,7 @@ where
 /// ```rust,no_run
 /// use clap::Parser;
 /// use ortho_config::OrthoConfig;
-/// use ortho_config::subcommand::SubcmdConfigMerge;
+/// use ortho_config::SubcmdConfigMerge;
 /// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Parser, Deserialize, Serialize, OrthoConfig, Default)]

--- a/ortho_config/tests/clap_subcommand.rs
+++ b/ortho_config/tests/clap_subcommand.rs
@@ -17,8 +17,7 @@
 //!   - no CLI, no environment  => `option = "file"` (file wins)
 
 use clap::{Parser, Subcommand};
-use ortho_config::OrthoConfig;
-use ortho_config::subcommand::SubcmdConfigMerge;
+use ortho_config::{OrthoConfig, SubcmdConfigMerge};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Parser)]

--- a/ortho_config/tests/steps/subcommand_steps.rs
+++ b/ortho_config/tests/steps/subcommand_steps.rs
@@ -8,7 +8,7 @@
 use crate::{PrArgs, World};
 use clap::Parser;
 use cucumber::{given, then, when};
-use ortho_config::subcommand::SubcmdConfigMerge;
+use ortho_config::SubcmdConfigMerge;
 
 /// Check if all configuration sources are absent.
 fn has_no_config_sources(world: &World) -> bool {

--- a/ortho_config/tests/util.rs
+++ b/ortho_config/tests/util.rs
@@ -5,8 +5,8 @@
 //! tests by encapsulating the jail creation and configuration loading.
 
 use clap::CommandFactory;
-use ortho_config::subcommand::{Prefix, SubcmdConfigMerge};
-use ortho_config::{OrthoConfig, OrthoError, load_and_merge_subcommand};
+use ortho_config::subcommand::Prefix;
+use ortho_config::{OrthoConfig, OrthoError, SubcmdConfigMerge, load_and_merge_subcommand};
 use serde::de::DeserializeOwned;
 
 fn with_jail<F, L, T>(setup: F, loader: L) -> Result<T, OrthoError>


### PR DESCRIPTION
## Summary
- derive `Serialize` for registry control example subcommands
- re-export `SubcmdConfigMerge` at crate root and update tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac53f765c4832280a39880265eb3f5

## Summary by Sourcery

Expose SubcmdConfigMerge at the crate root, derive Serialize for registry control example subcommands, and update imports in tests and examples accordingly.

Enhancements:
- Derive Serialize for example subcommands in registry_ctl
- Re-export SubcmdConfigMerge at the crate root
- Update tests and example imports to use the new SubcmdConfigMerge path