### PR TITLE
Use tomlkit for version bumps

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -2,7 +2,7 @@
 # /// script
 # dependencies = ["tomlkit==0.13.*", "markdown-it-py>=3,<4"]
 # ///
-"""Synchronise workspace and crate versions.
+"""Synchronize workspace and crate versions.
 
 This tool updates the top-level workspace version and each member crate's
 version to the supplied value, keeping documentation snippets in sync. It

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -176,7 +176,10 @@ def _update_dict_dependency(
     prefix = _extract_version_prefix(entry)
     existing = entry.get("version")
     if isinstance(existing, tomlkit.items.String):
-        existing._original = prefix + version  # value is read-only in tomlkit 0.13
+        try:
+            setattr(existing, "value", prefix + version)
+        except AttributeError:  # tomlkit <0.14 lacks a value setter
+            existing._original = prefix + version
     else:
         entry["version"] = prefix + version
 
@@ -199,7 +202,10 @@ def _update_string_dependency(
     """
     prefix = _extract_version_prefix(entry)
     if isinstance(entry, tomlkit.items.String):
-        entry._original = prefix + version  # preserve comments/formatting
+        try:
+            setattr(entry, "value", prefix + version)
+        except AttributeError:  # tomlkit <0.14 lacks a value setter
+            entry._original = prefix + version
     else:
         deps[dependency] = prefix + version
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -171,12 +171,12 @@ def _update_dict_dependency(
     >>> entry["version"].value
     '^1.2.3'
     """
-    if entry.get("workspace") is True:
+    if bool(entry.get("workspace")) is True:
         return
     prefix = _extract_version_prefix(entry)
     existing = entry.get("version")
     if isinstance(existing, tomlkit.items.String):
-        existing._original = prefix + version
+        existing._original = prefix + version  # value is read-only in tomlkit 0.13
     else:
         entry["version"] = prefix + version
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S uv run
 # /// script
-# dependencies = ["tomlkit==0.13.*", "markdown-it-py"]
+# dependencies = ["tomlkit==0.13.*", "markdown-it-py>=3,<4"]
 # ///
 """Synchronise workspace and crate versions.
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -21,7 +21,7 @@ import sys
 import tempfile
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 import tomlkit
 from markdown_it import MarkdownIt
@@ -139,7 +139,7 @@ def _update_dict_dependency(
 def _update_string_dependency(
     deps: MutableMapping[str, object],
     dependency: str,
-    entry: tomlkit.items.String | str,
+    entry: Any,
     version: str,
 ) -> None:
     """Update string-style dependency ``dependency`` in ``deps``.

--- a/scripts/tests/test_bump_version.py
+++ b/scripts/tests/test_bump_version.py
@@ -1,35 +1,39 @@
+from pathlib import Path
+
+import pytest
 import tomlkit
+
 from scripts.bump_version import (
     _update_dependency_version,
     _update_markdown_versions,
+    replace_fences,
 )
 
 
-def test_updates_string_dependency_preserving_prefix() -> None:
-    doc = tomlkit.parse('[dependencies]\nfoo = "^0.1"')
-    _update_dependency_version(doc, 'foo', '1.2.3')
-    assert 'foo = "^1.2.3"' in tomlkit.dumps(doc), "should update caret string dependency"
-
-
-def test_updates_dict_dependency_preserving_prefix() -> None:
-    snippet = '[dependencies]\nfoo = { version = "~0.1", features = ["a"] }'
-    doc = tomlkit.parse(snippet)
-    _update_dependency_version(doc, 'foo', '1.2.3')
+@pytest.mark.parametrize(
+    "section",
+    ["dependencies", "dev-dependencies", "build-dependencies"],
+)
+@pytest.mark.parametrize(
+    "body, expected, extra",
+    [
+        ("foo = \"^0.1\"", "foo = \"^1.2.3\"", None),
+        (
+            'foo = { version = "~0.1", features = ["a"] }',
+            'version = "~1.2.3"',
+            'features = ["a"]',
+        ),
+    ],
+)
+def test_updates_dependency_version(
+    section: str, body: str, expected: str, extra: str | None
+) -> None:
+    doc = tomlkit.parse(f"[{section}]\n{body}")
+    _update_dependency_version(doc, "foo", "1.2.3")
     dumped = tomlkit.dumps(doc)
-    assert 'version = "~1.2.3"' in dumped, "should update dict dependency version"
-    assert 'features = ["a"]' in dumped, "should preserve other fields"
-
-
-def test_updates_dev_dependency_table() -> None:
-    doc = tomlkit.parse('[dev-dependencies]\nfoo = "0.1"')
-    _update_dependency_version(doc, 'foo', '1.2.3')
-    assert 'foo = "1.2.3"' in tomlkit.dumps(doc), "should update dev-dependencies table"
-
-
-def test_updates_build_dependency_table() -> None:
-    doc = tomlkit.parse('[build-dependencies]\nfoo = "^0.1"')
-    _update_dependency_version(doc, 'foo', '1.2.3')
-    assert 'foo = "^1.2.3"' in tomlkit.dumps(doc), "should update build-dependencies table"
+    assert expected in dumped
+    if extra:
+        assert extra in dumped
 
 
 def test_preserves_trailing_comment_on_string_dependency() -> None:
@@ -39,6 +43,15 @@ def test_preserves_trailing_comment_on_string_dependency() -> None:
     assert '# pinned for CI' in dumped, "must preserve trailing comment on value node"
 
 
+def test_preserves_quote_style_on_string_dependency() -> None:
+    doc = tomlkit.parse("[dependencies]\nfoo = '0.1'  # single quoted\n")
+    _update_dependency_version(doc, "foo", "1.2.3")
+    dumped = tomlkit.dumps(doc)
+    assert "foo = '1.2.3'" in dumped, (
+        f"expected single quotes preserved, got:\n{dumped}"
+    )
+
+
 def test_missing_dependency_no_change() -> None:
     snippet = '[dependencies]\nbar = "0.1"'
     doc = tomlkit.parse(snippet)
@@ -46,10 +59,14 @@ def test_missing_dependency_no_change() -> None:
     assert tomlkit.dumps(doc).strip() == snippet, "should be a no-op when dependency is absent"
 
 
-def test_update_markdown_versions_updates_toml_fences(tmp_path) -> None:
-    md_text = (
-        "pre\n" "```toml\n" "[dependencies]\n" 'ortho_config = "0"\n' "```\n" "post\n"
-    )
+def test_update_markdown_versions_updates_toml_fences(tmp_path: Path) -> None:
+    md_text = """pre
+```toml
+[dependencies]
+ortho_config = "0"
+```
+post
+"""
     for rel in ("README.md", "docs/users-guide.md"):
         md_path = tmp_path / rel
         md_path.parent.mkdir(parents=True, exist_ok=True)
@@ -59,7 +76,7 @@ def test_update_markdown_versions_updates_toml_fences(tmp_path) -> None:
         assert 'ortho_config = "1"' in updated, "must update TOML fences"
 
 
-def test_update_markdown_versions_ignores_non_toml_fences(tmp_path) -> None:
+def test_update_markdown_versions_ignores_non_toml_fences(tmp_path: Path) -> None:
     md_text = "pre\n```bash\necho hi\n```\npost\n"
     for rel in ("README.md", "docs/users-guide.md"):
         md_path = tmp_path / rel
@@ -67,3 +84,22 @@ def test_update_markdown_versions_ignores_non_toml_fences(tmp_path) -> None:
         md_path.write_text(md_text)
         _update_markdown_versions(md_path, "1")
         assert md_path.read_text() == md_text, "must leave non-TOML fences unchanged"
+
+
+def test_replace_fences_preserves_indentation() -> None:
+    md_text = (
+        "1. item\n\n"
+        "    ```toml\n"
+        "    [dependencies]\n"
+        '    foo = "0"\n'
+        "    ```\n"
+    )
+    replaced = replace_fences(md_text, "toml", lambda body: body.replace("0", "1"))
+    expected = (
+        "1. item\n\n"
+        "    ```toml\n"
+        "    [dependencies]\n"
+        '    foo = "1"\n'
+        "    ```\n"
+    )
+    assert replaced == expected

--- a/scripts/tests/test_bump_version.py
+++ b/scripts/tests/test_bump_version.py
@@ -59,6 +59,13 @@ def test_missing_dependency_no_change() -> None:
     assert tomlkit.dumps(doc).strip() == snippet, "should be a no-op when dependency is absent"
 
 
+def test_workspace_dependency_no_version_written() -> None:
+    doc = tomlkit.parse('[dependencies]\nfoo = { workspace = true }\n')
+    _update_dependency_version(doc, 'foo', '1.2.3')
+    deps = doc['dependencies']['foo']
+    assert 'version' not in deps, 'must not add version when workspace is true'
+
+
 @pytest.mark.parametrize(
     "md_text, should_change, description",
     [

--- a/scripts/tests/test_bump_version.py
+++ b/scripts/tests/test_bump_version.py
@@ -1,0 +1,30 @@
+import tomlkit
+from scripts.bump_version import _update_dependency_version
+
+
+def test_updates_string_dependency_preserving_prefix():
+    doc = tomlkit.parse('[dependencies]\nfoo = "^0.1"')
+    _update_dependency_version(doc, 'foo', '1.2.3')
+    assert 'foo = "^1.2.3"' in tomlkit.dumps(doc)
+
+
+def test_updates_dict_dependency_preserving_prefix():
+    snippet = '[dependencies]\nfoo = { version = "~0.1", features = ["a"] }'
+    doc = tomlkit.parse(snippet)
+    _update_dependency_version(doc, 'foo', '1.2.3')
+    dumped = tomlkit.dumps(doc)
+    assert 'version = "~1.2.3"' in dumped
+    assert 'features = ["a"]' in dumped
+
+
+def test_updates_dev_dependency_table():
+    doc = tomlkit.parse('[dev-dependencies]\nfoo = "0.1"')
+    _update_dependency_version(doc, 'foo', '1.2.3')
+    assert 'foo = "1.2.3"' in tomlkit.dumps(doc)
+
+
+def test_missing_dependency_no_change():
+    snippet = '[dependencies]\nbar = "0.1"'
+    doc = tomlkit.parse(snippet)
+    _update_dependency_version(doc, 'foo', '1.2.3')
+    assert tomlkit.dumps(doc).strip() == snippet

--- a/scripts/tests/test_bump_version.py
+++ b/scripts/tests/test_bump_version.py
@@ -81,7 +81,12 @@ post
             "must update TOML fences",
         ),
         (
-            "pre\n```bash\necho hi\n```\npost\n",
+            """pre
+```bash
+echo hi
+```
+post
+""",
             False,
             "must leave non-TOML fences unchanged",
         ),

--- a/scripts/tests/test_bump_version.py
+++ b/scripts/tests/test_bump_version.py
@@ -103,19 +103,19 @@ def test_update_markdown_versions_behavior(
 
 
 def test_replace_fences_preserves_indentation() -> None:
-    md_text = (
-        "1. item\n\n"
-        "    ```toml\n"
-        "    [dependencies]\n"
-        '    foo = "0"\n'
-        "    ```\n"
-    )
+    md_text = """1. item
+
+    ```toml
+    [dependencies]
+    foo = "0"
+    ```
+"""
     replaced = replace_fences(md_text, "toml", lambda body: body.replace("0", "1"))
-    expected = (
-        "1. item\n\n"
-        "    ```toml\n"
-        "    [dependencies]\n"
-        '    foo = "1"\n'
-        "    ```\n"
-    )
+    expected = """1. item
+
+    ```toml
+    [dependencies]
+    foo = "1"
+    ```
+"""
     assert replaced == expected

--- a/scripts/tests/test_bump_version.py
+++ b/scripts/tests/test_bump_version.py
@@ -2,29 +2,42 @@ import tomlkit
 from scripts.bump_version import _update_dependency_version
 
 
-def test_updates_string_dependency_preserving_prefix():
+def test_updates_string_dependency_preserving_prefix() -> None:
     doc = tomlkit.parse('[dependencies]\nfoo = "^0.1"')
     _update_dependency_version(doc, 'foo', '1.2.3')
-    assert 'foo = "^1.2.3"' in tomlkit.dumps(doc)
+    assert 'foo = "^1.2.3"' in tomlkit.dumps(doc), "should update caret string dependency"
 
 
-def test_updates_dict_dependency_preserving_prefix():
+def test_updates_dict_dependency_preserving_prefix() -> None:
     snippet = '[dependencies]\nfoo = { version = "~0.1", features = ["a"] }'
     doc = tomlkit.parse(snippet)
     _update_dependency_version(doc, 'foo', '1.2.3')
     dumped = tomlkit.dumps(doc)
-    assert 'version = "~1.2.3"' in dumped
-    assert 'features = ["a"]' in dumped
+    assert 'version = "~1.2.3"' in dumped, "should update dict dependency version"
+    assert 'features = ["a"]' in dumped, "should preserve other fields"
 
 
-def test_updates_dev_dependency_table():
+def test_updates_dev_dependency_table() -> None:
     doc = tomlkit.parse('[dev-dependencies]\nfoo = "0.1"')
     _update_dependency_version(doc, 'foo', '1.2.3')
-    assert 'foo = "1.2.3"' in tomlkit.dumps(doc)
+    assert 'foo = "1.2.3"' in tomlkit.dumps(doc), "should update dev-dependencies table"
 
 
-def test_missing_dependency_no_change():
+def test_updates_build_dependency_table() -> None:
+    doc = tomlkit.parse('[build-dependencies]\nfoo = "^0.1"')
+    _update_dependency_version(doc, 'foo', '1.2.3')
+    assert 'foo = "^1.2.3"' in tomlkit.dumps(doc), "should update build-dependencies table"
+
+
+def test_preserves_trailing_comment_on_string_dependency() -> None:
+    doc = tomlkit.parse('[dependencies]\nfoo = "^0.1"  # pinned for CI\n')
+    _update_dependency_version(doc, 'foo', '1.2.3')
+    dumped = tomlkit.dumps(doc)
+    assert '# pinned for CI' in dumped, "must preserve trailing comment on value node"
+
+
+def test_missing_dependency_no_change() -> None:
     snippet = '[dependencies]\nbar = "0.1"'
     doc = tomlkit.parse(snippet)
     _update_dependency_version(doc, 'foo', '1.2.3')
-    assert tomlkit.dumps(doc).strip() == snippet
+    assert tomlkit.dumps(doc).strip() == snippet, "should be a no-op when dependency is absent"


### PR DESCRIPTION
## Summary
- preserve Cargo.toml formatting and comments during version bumps
- update ortho_config crate's ortho_config_macros dependency when bumping versions

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ad64a5f790832283d93418713d8f29

## Summary by Sourcery

Use tomlkit in the version bump script to maintain Cargo.toml formatting and comments and add support for synchronising internal dependency versions when bumping crate versions

Enhancements:
- Switch bump_version.py to tomlkit for parsing and writing Cargo.toml to preserve formatting and comments
- Add optional dependency parameter to synchronise internal crate dependency versions (used for ortho_config_macros)