### PR TITLE
Re-export config dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Re-export `figment`, `uncased`, `xdg` and optional format parsers to simplify
-  dependency graphs for consumers.
-- Forward `json5`, `yaml` and `toml` feature flags to `ortho_config_macros` so
-  macros compile with matching support.
+- Re-export `figment`, `uncased`, `xdg`, and optional format parsers to
+  simplify dependency graphs for consumers.
+- Forward `json5`, `yaml`, and `toml` feature flags to
+  `ortho_config_macros`, so macros compile with matching support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### Added
+
+- Re-export `figment`, `uncased`, `xdg` and optional format parsers to simplify
+  dependency graphs for consumers.
+- Forward `json5`, `yaml` and `toml` feature flags to `ortho_config_macros` so
+  macros compile with matching support.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ ortho_config = "0.3.0" # Replace with the latest version
 serde = { version = "1.0", features = ["derive"] }
 ```
 
+`ortho_config` exposes its internal dependencies, letting applications import
+`figment`, `uncased`, `xdg` and the optional format parsers without declaring
+them separately.
+
 2. **Define the configuration struct:**
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ serde = { version = "1.0", features = ["derive"] }
 ```
 
 `ortho_config` re-exports its parsing dependencies, so applications can import
-`figment`, `uncased`, `xdg`, and the optional format parsers without declaring
-them directly.
+`figment`, `uncased`, `xdg`, and the optional format parsers (`figment_json5`,
+`json5`, `serde_yaml`, `toml`) without declaring them directly.
 
 2. **Define the configuration struct:**
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ ortho_config = "0.3.0" # Replace with the latest version
 serde = { version = "1.0", features = ["derive"] }
 ```
 
-`ortho_config` exposes its internal dependencies, letting applications import
-`figment`, `uncased`, `xdg` and the optional format parsers without declaring
-them separately.
+`ortho_config` re-exports its parsing dependencies, so applications can import
+`figment`, `uncased`, `xdg`, and the optional format parsers without declaring
+them directly.
 
 2. **Define the configuration struct:**
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ serde = { version = "1.0", features = ["derive"] }
 ```
 
 `ortho_config` re-exports its parsing dependencies, so applications can import
-`figment`, `uncased`, `xdg`, and the optional format parsers (`figment_json5`,
-`json5`, `serde_yaml`, `toml`) without declaring them directly.
+`figment`, `uncased`, `xdg` (on Unix-like and Redox targets), and the optional
+format parsers (`figment_json5`, `json5`, `serde_yaml`, `toml`) without
+declaring them directly.
 
 2. **Define the configuration struct:**
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -407,8 +407,9 @@ to rename the hidden `--config-path` flag by defining their own field with a
   - `thiserror`: For ergonomic error type definitions.
 
   The core crate re-exports `figment`, `uncased`, `xdg` (on Unix-like and
-  Redox targets), and the optional format parsers, so downstream libraries can
-  import them via `ortho_config::` without declaring separate dependencies.
+  Redox targets), and the optional format parsers (`figment_json5`, `json5`,
+  `serde_yaml`, `toml`), so downstream libraries can import them via
+  `ortho_config::` without declaring separate dependencies.
 
 ## 6. Implementation Roadmap
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -406,6 +406,10 @@ to rename the hidden `--config-path` flag by defining their own field with a
     users aren't surprised by silent TOML parsing.
   - `thiserror`: For ergonomic error type definitions.
 
+  The core crate re-exports `figment`, `uncased`, `xdg` and the optional
+  format parsers so downstream libraries can import them via `ortho_config::`
+  without declaring separate dependencies.
+
 ## 6. Implementation Roadmap
 
 1. **V0.1 (Scaffolding):**

--- a/docs/design.md
+++ b/docs/design.md
@@ -406,8 +406,8 @@ to rename the hidden `--config-path` flag by defining their own field with a
     users aren't surprised by silent TOML parsing.
   - `thiserror`: For ergonomic error type definitions.
 
-  The core crate re-exports `figment`, `uncased`, `xdg` and the optional
-  format parsers so downstream libraries can import them via `ortho_config::`
+  The core crate re-exports `figment`, `uncased`, `xdg`, and the optional
+  format parsers, so downstream libraries can import them via `ortho_config::`
   without declaring separate dependencies.
 
 ## 6. Implementation Roadmap

--- a/docs/design.md
+++ b/docs/design.md
@@ -406,9 +406,9 @@ to rename the hidden `--config-path` flag by defining their own field with a
     users aren't surprised by silent TOML parsing.
   - `thiserror`: For ergonomic error type definitions.
 
-  The core crate re-exports `figment`, `uncased`, `xdg`, and the optional
-  format parsers, so downstream libraries can import them via `ortho_config::`
-  without declaring separate dependencies.
+  The core crate re-exports `figment`, `uncased`, `xdg` (on Unix-like and
+  Redox targets), and the optional format parsers, so downstream libraries can
+  import them via `ortho_config::` without declaring separate dependencies.
 
 ## 6. Implementation Roadmap
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -65,9 +65,10 @@ during discovery and do not cause errors if present. The `yaml` feature
 similarly enables `.yaml` and `.yml` files; without it, such files are skipped
 during discovery and do not cause errors if present.
 
-`ortho_config` re-exports its parsing dependencies so consumers do not need to
-declare them directly. Access `figment`, `uncased`, `xdg` and the optional
-parsers (`figment_json5`, `serde_yaml`, `toml`) via `ortho_config::` paths.
+`ortho_config` re-exports its parsing dependencies, so consumers do not need to
+declare them directly. Access `figment`, `uncased`, `xdg`, and the optional
+parsers (`figment_json5`, `json5`, `serde_yaml`, `toml`) via `ortho_config::`
+paths.
 
 ## Migrating from earlier versions
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -65,6 +65,10 @@ during discovery and do not cause errors if present. The `yaml` feature
 similarly enables `.yaml` and `.yml` files; without it, such files are skipped
 during discovery and do not cause errors if present.
 
+`ortho_config` re-exports its parsing dependencies so consumers do not need to
+declare them directly. Access `figment`, `uncased`, `xdg` and the optional
+parsers (`figment_json5`, `serde_yaml`, `toml`) via `ortho_config::` paths.
+
 ## Migrating from earlier versions
 
 Projects using a pre‑0.5 release can upgrade with the following steps:

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -66,9 +66,9 @@ similarly enables `.yaml` and `.yml` files; without it, such files are skipped
 during discovery and do not cause errors if present.
 
 `ortho_config` re-exports its parsing dependencies, so consumers do not need to
-declare them directly. Access `figment`, `uncased`, `xdg`, and the optional
-parsers (`figment_json5`, `json5`, `serde_yaml`, `toml`) via `ortho_config::`
-paths.
+declare them directly. Access `figment`, `uncased`, `xdg` (on Unix-like and
+Redox targets), and the optional parsers (`figment_json5`, `json5`,
+`serde_yaml`, `toml`) via `ortho_config::` paths.
 
 ## Migrating from earlier versions
 

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -36,9 +36,9 @@ dunce = "1.0.0"
 
 [features]
 default = ["toml"]
-toml = ["figment/toml", "dep:toml"]
-json5 = ["dep:figment-json5", "dep:json5"]
-yaml = ["figment/yaml", "dep:serde_yaml"]
+toml = ["figment/toml", "dep:toml", "ortho_config_macros/toml"]
+json5 = ["dep:figment-json5", "dep:json5", "ortho_config_macros/json5"]
+yaml = ["figment/yaml", "dep:serde_yaml", "ortho_config_macros/yaml"]
 
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env"] }

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -9,6 +9,8 @@ pub use ortho_config_macros::OrthoConfig;
 pub use figment;
 #[cfg(feature = "json5")]
 pub use figment_json5;
+#[cfg(feature = "json5")]
+pub use json5;
 #[cfg(feature = "yaml")]
 pub use serde_yaml;
 #[cfg(feature = "toml")]

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -6,6 +6,17 @@
 
 pub use ortho_config_macros::OrthoConfig;
 
+pub use figment;
+#[cfg(feature = "json5")]
+pub use figment_json5;
+#[cfg(feature = "yaml")]
+pub use serde_yaml;
+#[cfg(feature = "toml")]
+pub use toml;
+pub use uncased;
+#[cfg(any(unix, target_os = "redox"))]
+pub use xdg;
+
 mod csv_env;
 mod error;
 mod file;

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -8,15 +8,20 @@ pub use ortho_config_macros::OrthoConfig;
 
 pub use figment;
 #[cfg(feature = "json5")]
+#[cfg_attr(docsrs, doc(cfg(feature = "json5")))]
 pub use figment_json5;
 #[cfg(feature = "json5")]
+#[cfg_attr(docsrs, doc(cfg(feature = "json5")))]
 pub use json5;
 #[cfg(feature = "yaml")]
+#[cfg_attr(docsrs, doc(cfg(feature = "yaml")))]
 pub use serde_yaml;
 #[cfg(feature = "toml")]
+#[cfg_attr(docsrs, doc(cfg(feature = "toml")))]
 pub use toml;
 pub use uncased;
 #[cfg(any(unix, target_os = "redox"))]
+#[cfg_attr(docsrs, doc(cfg(any(unix, target_os = "redox"))))]
 pub use xdg;
 
 mod csv_env;

--- a/ortho_config/tests/reexports.rs
+++ b/ortho_config/tests/reexports.rs
@@ -18,8 +18,9 @@ fn reexports_are_public() {
     }
     #[cfg(feature = "json5")]
     {
+        use ortho_config::figment::providers::Format as _;
         use ortho_config::{figment_json5::Json5, json5};
-        let _ = <Json5 as ortho_config::figment::providers::Format>::file("dummy.json5");
+        let _ = Json5::file("dummy.json5");
         let _: Result<serde_json::Value, _> = json5::from_str("{}");
     }
     #[cfg(any(unix, target_os = "redox"))]

--- a/ortho_config/tests/reexports.rs
+++ b/ortho_config/tests/reexports.rs
@@ -6,6 +6,22 @@ use ortho_config::{figment::Figment, uncased::UncasedStr};
 fn reexports_are_public() {
     let _figment = Figment::default();
     let _uncased = UncasedStr::new("key");
+    #[cfg(feature = "toml")]
+    {
+        use ortho_config::toml;
+        let _ = toml::Value::String("ok".to_string());
+    }
+    #[cfg(feature = "yaml")]
+    {
+        use ortho_config::serde_yaml;
+        let _ = serde_yaml::Value::Null;
+    }
+    #[cfg(feature = "json5")]
+    {
+        use ortho_config::{figment::providers::Format, figment_json5::Json5, json5};
+        let _ = Json5::file("dummy.json5");
+        let _: Result<serde_json::Value, _> = json5::from_str("{}");
+    }
     #[cfg(any(unix, target_os = "redox"))]
     {
         use ortho_config::xdg::BaseDirectories;

--- a/ortho_config/tests/reexports.rs
+++ b/ortho_config/tests/reexports.rs
@@ -1,0 +1,14 @@
+//! Ensures configuration helpers are accessible via re-exports.
+
+use ortho_config::{figment::Figment, uncased::UncasedStr};
+
+#[test]
+fn reexports_are_public() {
+    let _figment = Figment::default();
+    let _uncased = UncasedStr::new("key");
+    #[cfg(any(unix, target_os = "redox"))]
+    {
+        use ortho_config::xdg::BaseDirectories;
+        let _ = BaseDirectories::with_prefix("myapp");
+    }
+}

--- a/ortho_config/tests/reexports.rs
+++ b/ortho_config/tests/reexports.rs
@@ -18,8 +18,8 @@ fn reexports_are_public() {
     }
     #[cfg(feature = "json5")]
     {
-        use ortho_config::{figment::providers::Format, figment_json5::Json5, json5};
-        let _ = Json5::file("dummy.json5");
+        use ortho_config::{figment_json5::Json5, json5};
+        let _ = <Json5 as ortho_config::figment::providers::Format>::file("dummy.json5");
         let _: Result<serde_json::Value, _> = json5::from_str("{}");
     }
     #[cfg(any(unix, target_os = "redox"))]

--- a/ortho_config_macros/Cargo.toml
+++ b/ortho_config_macros/Cargo.toml
@@ -18,6 +18,8 @@ quote = "1"
 proc-macro2 = "1"
 
 [features]
+# Mirrors optional format parsers in `ortho_config` so
+# macro output enables them when selected.
 default = []
 json5 = []
 yaml = []

--- a/ortho_config_macros/src/derive/build.rs
+++ b/ortho_config_macros/src/derive/build.rs
@@ -285,7 +285,7 @@ fn build_xdg_config_discovery() -> proc_macro2::TokenStream {
     let yaml = build_discovery(["yaml", "yml"]);
     quote! {
         let try_load_config = |
-            fig: &mut Option<figment::Figment>,
+            fig: &mut Option<ortho_config::figment::Figment>,
             exts: &[&str],
             errors: &mut Vec<ortho_config::OrthoError>,
         | {
@@ -327,9 +327,9 @@ pub(crate) fn build_xdg_snippet(struct_attrs: &StructAttrs) -> proc_macro2::Toke
         if file_fig.is_none() {
             let xdg_base = ortho_config::normalize_prefix(#prefix_lit);
             let xdg_dirs = if xdg_base.is_empty() {
-                xdg::BaseDirectories::new()
+                ortho_config::xdg::BaseDirectories::new()
             } else {
-                xdg::BaseDirectories::with_prefix(&xdg_base)
+                ortho_config::xdg::BaseDirectories::with_prefix(&xdg_base)
             };
             #config_discovery
         }

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -98,7 +98,9 @@ pub(crate) fn build_env_section(tokens: &LoadImplTokens<'_>) -> proc_macro2::Tok
     quote! {
         let env_provider = {
             #env_provider
-                .map(|k| uncased::Uncased::new(k.as_str().to_ascii_uppercase()))
+                .map(|k| ortho_config::uncased::Uncased::new(
+                    k.as_str().to_ascii_uppercase(),
+                ))
                 .split("__")
         };
     }
@@ -216,13 +218,17 @@ pub(crate) fn build_load_impl(args: &LoadImplArgs<'_>) -> proc_macro2::TokenStre
                 T: Into<std::ffi::OsString> + Clone,
             {
                 use clap::Parser as _;
-                use figment::{Figment, providers::{Toml, Serialized}, Profile};
+                use ortho_config::figment::{
+                    providers::{Serialized, Toml},
+                    Figment,
+                    Profile,
+                };
                 use ortho_config::CsvEnv;
-                #[cfg(feature = "json5")] use figment_json5::Json5;
-                #[cfg(feature = "yaml")] use figment::providers::Yaml;
-                use uncased::Uncased;
-                #[cfg(feature = "yaml")] use serde_yaml;
-                #[cfg(feature = "toml")] use toml;
+                #[cfg(feature = "json5")] use ortho_config::figment_json5::Json5;
+                #[cfg(feature = "yaml")] use ortho_config::figment::providers::Yaml;
+                use ortho_config::uncased::Uncased;
+                #[cfg(feature = "yaml")] use ortho_config::serde_yaml;
+                #[cfg(feature = "toml")] use ortho_config::toml;
 
                 let mut errors: Vec<ortho_config::OrthoError> = Vec::new();
                 let cli = match Self::try_parse_from(iter) {

--- a/ortho_config_macros/src/derive/load_impl.rs
+++ b/ortho_config_macros/src/derive/load_impl.rs
@@ -218,17 +218,7 @@ pub(crate) fn build_load_impl(args: &LoadImplArgs<'_>) -> proc_macro2::TokenStre
                 T: Into<std::ffi::OsString> + Clone,
             {
                 use clap::Parser as _;
-                use ortho_config::figment::{
-                    providers::{Serialized, Toml},
-                    Figment,
-                    Profile,
-                };
-                use ortho_config::CsvEnv;
-                #[cfg(feature = "json5")] use ortho_config::figment_json5::Json5;
-                #[cfg(feature = "yaml")] use ortho_config::figment::providers::Yaml;
-                use ortho_config::uncased::Uncased;
-                #[cfg(feature = "yaml")] use ortho_config::serde_yaml;
-                #[cfg(feature = "toml")] use ortho_config::toml;
+                use ortho_config::figment::{providers::Serialized, Figment};
 
                 let mut errors: Vec<ortho_config::OrthoError> = Vec::new();
                 let cli = match Self::try_parse_from(iter) {


### PR DESCRIPTION
## Summary
- re-export figment, uncased, xdg and optional parsers so consumers need no extra dependencies
- use ortho_config's re-exports in macro output
- forward json5/yaml/toml features to macro crate and document re-exports

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68ad67eadc208322a3a7ead3e1d3e275

## Summary by Sourcery

Re-export key config dependencies from the core crate and update the macros and documentation to use these shared exports, removing the need for downstream crates to declare those dependencies separately.

New Features:
- Re-export figment, uncased, xdg, and optional format parsers (json5, yaml, toml) from the ortho_config core crate

Enhancements:
- Adapt procedural macro code to import dependencies via ortho_config’s re-exports
- Forward json5, yaml, and toml features to the macro crate

Build:
- Add parser feature flags to ortho_config_macros in ortho_config’s Cargo.toml

Documentation:
- Document the new dependency re-exports in README, design guide, and user guide