### PR TITLE
Remove srgn documentation reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,8 +244,7 @@ The following tooling is available in this environment:
 - `checkmake` – Linter for `Makefile`s, ensuring they follow best practices and
   conventions.
 - `srgn` – [Structural grep](https://github.com/alexpovel/srgn), searches code
-  and enables editing by syntax tree patterns (see `docs/srgn.md` for a
-  complete guide).
+  and enables editing by syntax tree patterns.
 - `difft` **(Difftastic)** – Semantic diff tool that compares code structure
   rather than just text differences.
 


### PR DESCRIPTION
## Summary
- remove obsolete srgn documentation reference

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68c1c85de544832285390b1be6e7c8e8

## Summary by Sourcery

Documentation:
- Removed link to the srgn guide in AGENTS.md