### PR TITLE
Add subcommand precedence tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +154,42 @@ name = "bytemuck"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+
+[[package]]
+name = "camino"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1e394ed14f39f8bc26f59d4c0c010dbe7f0a1b9bafff451b1f98b67c8af62a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c0355ca583dd58f176c3c12489d684163861ede3c9efa6fd8bba314c984189"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix",
+]
 
 [[package]]
 name = "cfg-if"
@@ -447,6 +489,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +752,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +777,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -809,6 +884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +973,8 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 name = "ortho_config"
 version = "0.5.0-beta1"
 dependencies = [
+ "camino",
+ "cap-std",
  "clap",
  "clap-dispatch",
  "cucumber",
@@ -905,6 +988,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "tempfile",
  "test_helpers",
  "thiserror 2.0.16",
@@ -1240,6 +1324,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,10 +1355,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sealed"
@@ -1345,6 +1454,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1845,6 +1979,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys",
 ]
 
 [[package]]

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -48,6 +48,9 @@ trybuild = "1"
 cucumber = "0.21.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 rstest = "0.26.1"
+serial_test = "3"
+cap-std = "3"
+camino = "1"
 tempfile = "3"
 test_helpers = { path = "../test_helpers" }
 

--- a/ortho_config/tests/subcommand_merge.rs
+++ b/ortho_config/tests/subcommand_merge.rs
@@ -1,4 +1,4 @@
-//! Tests subcommand configuration precedence (env > file > CLI defaults) for pr and issue.
+//! Tests subcommand configuration precedence (defaults < file < env < CLI) for pr and issue.
 use camino::Utf8PathBuf;
 use cap_std::{ambient_authority, fs::Dir};
 use clap::Parser;
@@ -78,12 +78,12 @@ fn config_dir(#[default("")] cfg: &str) -> (TempDir, DirGuard) {
     Some("file_ref"),
     vec!["file.txt".into()],
 )]
-#[case::cli_over_env_and_file(
+#[case::cli_over_env_with_file_fallback(
     "[cmds.pr]\nreference = \"file_ref\"\nfiles = [\"file.txt\"]\n",
     Some("env_ref"),
-    PrArgs { reference: Some("cli_ref".into()), files: vec!["cli.txt".into()] },
+    PrArgs { reference: Some("cli_ref".into()), files: vec![] },
     Some("cli_ref"),
-    vec!["cli.txt".into()],
+    vec!["file.txt".into()],
 )]
 #[allow(clippy::used_underscore_binding)]
 #[serial]
@@ -119,7 +119,7 @@ fn test_pr_precedence(
     IssueArgs { reference: None },
     Some("file_ref"),
 )]
-#[case::cli_over_env_and_file(
+#[case::cli_over_env(
     "[cmds.issue]\nreference = \"file_ref\"\n",
     Some("env_ref"),
     IssueArgs { reference: Some("cli_ref".into()) },

--- a/ortho_config/tests/subcommand_merge.rs
+++ b/ortho_config/tests/subcommand_merge.rs
@@ -1,0 +1,117 @@
+use camino::Utf8PathBuf;
+use cap_std::{ambient_authority, fs::Dir};
+use clap::Parser;
+use ortho_config::{OrthoConfig, load_and_merge_subcommand_for};
+use rstest::rstest;
+use serde::{Deserialize, Serialize};
+use serial_test::serial;
+use tempfile::TempDir;
+
+#[derive(Debug, Parser, Serialize, Deserialize, OrthoConfig, Default, PartialEq)]
+#[command(name = "pr")]
+#[ortho_config(prefix = "VK_")]
+struct PrArgs {
+    #[arg(long)]
+    reference: Option<String>,
+    #[arg(long)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    files: Vec<String>,
+}
+
+#[derive(Debug, Parser, Serialize, Deserialize, OrthoConfig, Default, PartialEq)]
+#[command(name = "issue")]
+#[ortho_config(prefix = "VK_")]
+struct IssueArgs {
+    #[arg(long)]
+    reference: Option<String>,
+}
+
+fn write_config(cfg: &str) -> TempDir {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let cap = Dir::open_ambient_dir(dir.path(), ambient_authority()).expect("open temp dir");
+    cap.write(".vk.toml", cfg).expect("write config");
+    dir
+}
+
+struct DirGuard {
+    old: Utf8PathBuf,
+}
+
+fn set_dir(dir: &TempDir) -> DirGuard {
+    let old = std::env::current_dir().expect("read current dir");
+    std::env::set_current_dir(dir.path()).expect("set current dir");
+    DirGuard {
+        old: Utf8PathBuf::from_path_buf(old).expect("utf8"),
+    }
+}
+
+impl Drop for DirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.old).expect("restore current dir");
+    }
+}
+
+fn set_env(key: &str, val: Option<&str>) {
+    unsafe {
+        match val {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+}
+
+#[rstest]
+#[serial]
+fn pr_env_over_file_when_cli_absent() {
+    let cfg = "[cmds.pr]\nreference = \"file_ref\"\nfiles = [\"file.txt\"]\n";
+    let dir = write_config(cfg);
+    let _guard = set_dir(&dir);
+    set_env("VK_CMDS_PR_REFERENCE", Some("env_ref"));
+    let cli = PrArgs {
+        reference: None,
+        files: vec![],
+    };
+    let merged = load_and_merge_subcommand_for(&cli).expect("merge pr args");
+    assert_eq!(merged.reference.as_deref(), Some("env_ref"));
+    assert_eq!(merged.files, ["file.txt"]);
+    set_env("VK_CMDS_PR_REFERENCE", None);
+}
+
+#[rstest]
+#[serial]
+fn pr_file_over_defaults_when_env_and_cli_absent() {
+    let cfg = "[cmds.pr]\nreference = \"file_ref\"\nfiles = [\"file.txt\"]\n";
+    let dir = write_config(cfg);
+    let _guard = set_dir(&dir);
+    let cli = PrArgs {
+        reference: None,
+        files: vec![],
+    };
+    let merged = load_and_merge_subcommand_for(&cli).expect("merge pr args");
+    assert_eq!(merged.reference.as_deref(), Some("file_ref"));
+    assert_eq!(merged.files, ["file.txt"]);
+}
+
+#[rstest]
+#[serial]
+fn issue_env_over_file_when_cli_absent() {
+    let cfg = "[cmds.issue]\nreference = \"file_ref\"\n";
+    let dir = write_config(cfg);
+    let _guard = set_dir(&dir);
+    set_env("VK_CMDS_ISSUE_REFERENCE", Some("env_ref"));
+    let cli = IssueArgs { reference: None };
+    let merged = load_and_merge_subcommand_for(&cli).expect("merge issue args");
+    assert_eq!(merged.reference.as_deref(), Some("env_ref"));
+    set_env("VK_CMDS_ISSUE_REFERENCE", None);
+}
+
+#[rstest]
+#[serial]
+fn issue_file_over_defaults_when_env_and_cli_absent() {
+    let cfg = "[cmds.issue]\nreference = \"file_ref\"\n";
+    let dir = write_config(cfg);
+    let _guard = set_dir(&dir);
+    let cli = IssueArgs { reference: None };
+    let merged = load_and_merge_subcommand_for(&cli).expect("merge issue args");
+    assert_eq!(merged.reference.as_deref(), Some("file_ref"));
+}


### PR DESCRIPTION
## Summary
- test subcommand config precedence for env and file fallbacks
- add serial test and capability-based fs deps for tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c74b6f322c832281612096eb203abc

## Summary by Sourcery

Add tests and supporting utilities to validate that subcommand configuration loading honors the correct precedence of CLI arguments, environment variables, and file-based settings using sequential execution and capability-based filesystem operations.

Enhancements:
- Use serial_test to ensure sequential execution of filesystem-dependent tests
- Use cap-std and camino for capability-based filesystem operations in tests

Build:
- Add serial_test, cap-std, and camino dependencies to Cargo.toml

Tests:
- Add integration tests to verify that pr and issue subcommands load configuration with precedence: environment variables over file settings and file settings over defaults