### PR TITLE
Add hello world example outline

### DIFF
--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -48,10 +48,10 @@ production-ready complexity.
 - Prerequisites: Rust toolchain (via rustup), Cargo, make, and
   markdownlint-cli2.
 - Build: `cargo build`.
-- Run formatting and lint checks: `make fmt && make markdownlint`.
-- Run static analysis: `make lint` (wraps `cargo clippy -D warnings`).
+- Run formatting and Markdown lint checks: `make fmt && make markdownlint`.
 - Validate Mermaid diagrams (if present): `make nixie`.
-- Execute tests (unit and behavioural): `cargo test`.
+- Run static analysis: `cargo clippy -D warnings` (or `make lint`).
+- Execute tests (unit and behavioural): `make test`.
 
 ## Implementation checklist
 


### PR DESCRIPTION
## Summary
- add an `examples/hello_world` crate directory with an overview README
- document the intended configuration, testing, and scripting coverage for the example

## Testing
- make fmt
- make markdownlint

------
https://chatgpt.com/codex/tasks/task_e_68cacaa510fc8322805a6899f436c475

## Summary by Sourcery

Add a new hello_world example crate outline with a detailed README

New Features:
- Introduce the examples/hello_world crate with an overview README

Documentation:
- Document the example’s capabilities, project layout, testing disciplines, automation scripts, and implementation considerations