### PR TITLE
Add hello world rstest and cucumber coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,13 +746,16 @@ name = "hello_world"
 version = "0.5.0-beta2"
 dependencies = [
  "camino",
+ "cap-std",
  "clap",
  "color-eyre",
  "cucumber",
+ "gherkin",
  "ortho_config",
  "rstest",
  "serde",
  "shlex",
+ "tempfile",
  "thiserror 2.0.16",
  "tokio",
 ]

--- a/docs/design.md
+++ b/docs/design.md
@@ -114,6 +114,20 @@ and explicit:
 These helpers are intentionally small and composable so call‑sites remain easy
 to read without hiding the semantics of error mapping.
 
+### 4.3. Hello world example testing strategy
+
+The `examples/hello_world` crate now anchors both unit and behavioural testing
+for the workspace. Deterministic components such as CLI parsing, validation,
+and plan construction are covered with `rstest` parameterisations; fixtures
+expose pre-populated `HelloWorldCli`, `GreetCommand`, and `TakeLeaveCommand`
+values to exercise edge-cases like conflicting modes, blank input, and
+punctuation overrides. End-to-end workflows are expressed with `cucumber-rs`
+scenarios that invoke the compiled binary. The Cucumber world initialises a
+temporary working directory (`tempfile::TempDir`) per scenario, writes
+`.hello-world.toml` snapshots via `cap_std::fs_utf8`, and layers environment
+overrides before spawning the command. This isolates precedence checks (file →
+environment → CLI) while keeping the operating system environment pristine.
+
 ### Aggregated errors
 
 To surface multiple failures at once, `OrthoError::aggregate<I, E>(errors)`

--- a/docs/design.md
+++ b/docs/design.md
@@ -122,7 +122,7 @@ and plan construction are covered with `rstest` parameterisations; fixtures
 expose pre-populated `HelloWorldCli`, `GreetCommand`, and `TakeLeaveCommand`
 values to exercise edge-cases like conflicting modes, blank input, and
 punctuation overrides. End-to-end workflows are expressed with `cucumber-rs`
-scenarios that invoke the compiled binary. The Cucumber world initialises a
+scenarios that invoke the compiled binary. The Cucumber world initializes a
 temporary working directory (`tempfile::TempDir`) per scenario, writes
 `.hello-world.toml` snapshots via `cap_std::fs_utf8`, and layers environment
 overrides before spawning the command. This isolates precedence checks (file →

--- a/docs/design.md
+++ b/docs/design.md
@@ -114,7 +114,7 @@ and explicit:
 These helpers are intentionally small and composable so call‑sites remain easy
 to read without hiding the semantics of error mapping.
 
-### 4.3. Hello world example testing strategy
+### 4.4. Hello world example testing strategy
 
 The `examples/hello_world` crate now anchors both unit and behavioural testing
 for the workspace. Deterministic components such as CLI parsing, validation,
@@ -225,7 +225,7 @@ This is the most complex component. It needs to perform the following using
      For example, it uses the `prefix` attribute for
      `figment::providers::Env::prefixed(…)`.
 
-### 4.3. Orthographic Name Mapping
+### 4.5. Orthographic Name Mapping
 
 The macro must enforce naming conventions automatically.
 
@@ -244,7 +244,7 @@ The macro must enforce naming conventions automatically.
   `#[ortho_config(rename_all = "kebab-case")]` which would pass the
   corresponding `#[serde(rename_all = "…")]` attribute to the user's struct.
 
-### 4.4. Array (`Vec<T>`) Merging
+### 4.6. Array (`Vec<T>`) Merging
 
 This is a key user-experience feature.
 
@@ -260,7 +260,7 @@ This is a key user-experience feature.
      calling `extract()` on the final result. This ensures the combined `Vec`
      is present for deserialization.
 
-### 4.5. Error Handling
+### 4.7. Error Handling
 
 A custom, comprehensive error enum is non-negotiable for a good user experience.
 
@@ -320,7 +320,7 @@ possible. `Gathering` covers failures while sourcing defaults from files or the
 environment. When CLI values are overlaid onto those defaults, any merge or
 deserialization failures map to `Merge`.
 
-### 4.6. Configuration File Discovery
+### 4.8. Configuration File Discovery
 
 On Unix-like systems and Redox, the crate uses the `xdg` crate to locate
 configuration directories. It respects `XDG_CONFIG_HOME` and falls back to
@@ -334,7 +334,7 @@ resolves to `%APPDATA%` (a.k.a. `FOLDERID_RoamingAppData`) and `%LOCALAPPDATA%`
 Support for `XDG_CONFIG_HOME` on Windows could be added later using
 `directories` to mimic the XDG specification.
 
-### 4.7. Comma-Separated Environment Lists
+### 4.9. Comma-Separated Environment Lists
 
 Environment variables often provide simple comma-separated strings for lists.
 The crate introduces a `CsvEnv` provider that wraps `figment::providers::Env`
@@ -345,7 +345,7 @@ containing literal commas must be wrapped in quotes or brackets to avoid being
 split. The derive macro now uses `CsvEnv` instead of `Env` so list handling is
 consistent across files, environment, and CLI inputs.
 
-### 4.8. Configuration Inheritance
+### 4.10. Configuration Inheritance
 
 Some projects require a base configuration that can be extended by other files.
 A configuration file may specify an `extends` key whose value is a relative or
@@ -364,7 +364,7 @@ Precedence across all sources becomes:
 Prefixes and subcommand namespaces are applied at each layer just as they would
 be without inheritance.
 
-### 4.9. Improved Subcommand Merging
+### 4.11. Improved Subcommand Merging
 
 Earlier versions extracted subcommand defaults before applying CLI overrides.
 Missing required fields in `[cmds.<name>]` caused deserialization failures even
@@ -408,7 +408,7 @@ sequenceDiagram
     SC-->>CLI: Err(OrthoError::Gathering)
   end
 
-### 4.10. Dynamic rule tables
+### 4.12. Dynamic rule tables
 
 Configuration structures may include map fields such as
 `BTreeMap<String, RuleCfg>` to support dynamic tables where the keys are not
@@ -418,7 +418,7 @@ arbitrary rule configurations like `[rules.consistent-casing]` without
 additional code. Entries may originate from files, environment variables or CLI
 flags and follow the usual precedence rules.
 
-### 4.11. Ignore pattern lists
+### 4.13. Ignore pattern lists
 
 Vector fields such as `ignore_patterns` can be populated from comma-separated
 environment variables and CLI flags. Values are merged using the `append` merge
@@ -426,7 +426,7 @@ strategy so that patterns from configuration files are extended by environment
 variables and finally CLI arguments. Whitespace is trimmed and duplicates are
 preserved.
 
-### 4.12. Renaming the configuration path flag
+### 4.14. Renaming the configuration path flag
 
 The derive macro exposes the generated `config_path` field, allowing projects
 to rename the hidden `--config-path` flag by defining their own field with a

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -45,6 +45,15 @@ flags via the derive macro; see its [README](../examples/hello_world/README.md)
 for a step-by-step walkthrough and the Cucumber scenarios that validate
 behaviour end-to-end.
 
+Run `make test` to execute the example’s coverage. The unit suite uses `rstest`
+fixtures to exercise parsing, validation, and command planning across
+parameterised edge-cases (conflicting delivery modes, blank salutations, and
+custom punctuation). Behavioural coverage comes from the `cucumber-rs` runner
+in `tests/cucumber.rs`, which spawns the compiled binary inside a temporary
+working directory, layers `.hello-world.toml` defaults via `cap-std`, and sets
+`HELLO_WORLD_*` environment variables per scenario to demonstrate precedence:
+configuration files < environment variables < CLI arguments.
+
 ## Installation and dependencies
 
 Add `ortho_config` as a dependency in `Cargo.toml` along with `serde`:

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -20,6 +20,9 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "ti
 rstest = "0.26.1"
 shlex = "1.3.0"
 camino = "1"
+tempfile = "3"
+cap-std = "3"
+gherkin = "0.14"
 
 [features]
 default = []

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -62,8 +62,8 @@ production-ready complexity.
       with defaults and validation.
 - [x] Implement the `greet` subcommand with its arguments and options.
 - [x] Implement the `take-leave` subcommand with its arguments and options.
-- [ ] Add `rstest` unit tests covering parsing, validation, and command logic.
-- [ ] Add `cucumber-rs` behavioural tests covering end-to-end workflows and
+- [x] Add `rstest` unit tests covering parsing, validation, and command logic.
+- [x] Add `cucumber-rs` behavioural tests covering end-to-end workflows and
       configuration precedence.
 - [ ] Create shell and Windows `.cmd` scripts showcasing configuration file
       usage and overrides.

--- a/examples/hello_world/src/cli.rs
+++ b/examples/hello_world/src/cli.rs
@@ -583,9 +583,7 @@ mod tests {
     fn load_global_config_applies_overrides() {
         ortho_config::figment::Jail::expect_with(|jail| {
             jail.clear_env();
-            let cli =
-                CommandLine::try_parse_from(["hello-world", "-r", "Team", "-s", "Hi", "greet"])
-                    .expect("parse CLI");
+            let cli = parse_command_line(&["-r", "Team", "-s", "Hi", "greet"]);
             let config = load_global_config(&cli.globals).expect("load config");
             assert_eq!(config.recipient, "Team");
             assert_eq!(config.trimmed_salutations(), vec![String::from("Hi")]);
@@ -599,7 +597,7 @@ mod tests {
         ortho_config::figment::Jail::expect_with(|jail| {
             jail.clear_env();
             jail.set_env("HELLO_WORLD_RECIPIENT", "Library");
-            let cli = CommandLine::try_parse_from(["hello-world", "greet"]).expect("parse CLI");
+            let cli = parse_command_line(&["greet"]);
             let config = load_global_config(&cli.globals).expect("load config");
             assert_eq!(config.recipient, "Library");
             Ok(())

--- a/examples/hello_world/tests/cucumber.rs
+++ b/examples/hello_world/tests/cucumber.rs
@@ -66,11 +66,11 @@ impl World {
     }
 
     /// Removes an environment variable override for the next command.
+    ///
+    /// This only updates the world-scoped overrides map so the process
+    /// environment remains untouched during the scenario.
     pub fn remove_env(&mut self, key: &str) {
         self.env.remove(key);
-        // Removing environment variables mutates global process state.
-        // Limit scope to keys managed by the world to avoid surprises.
-        unsafe { std::env::remove_var(key) };
     }
 
     /// Writes a configuration file into the scenario work directory.

--- a/examples/hello_world/tests/cucumber.rs
+++ b/examples/hello_world/tests/cucumber.rs
@@ -63,7 +63,7 @@ impl From<std::process::Output> for CommandResult {
 }
 
 impl World {
-    /// Records an environment variable to be injected for the next command.
+    /// Records an environment variable override scoped to the scenario.
     pub fn set_env<K, V>(&mut self, key: K, value: V)
     where
         K: Into<String>,
@@ -72,7 +72,7 @@ impl World {
         self.env.insert(key.into(), value.into());
     }
 
-    /// Removes an environment variable override for the next command.
+    /// Removes a scenario-scoped environment variable override.
     ///
     /// This only updates the world-scoped overrides map so the process
     /// environment remains untouched during the scenario.

--- a/examples/hello_world/tests/features/global_parameters.feature
+++ b/examples/hello_world/tests/features/global_parameters.feature
@@ -43,3 +43,11 @@ Feature: Global parameters govern greetings
     Then the command succeeds
     And stdout contains "Until next time"
     And stdout contains "Hello, World?"
+
+  Scenario: CLI overrides environment overrides configuration files
+    Given the hello world config file sets file defaults
+    And the environment contains "HELLO_WORLD_RECIPIENT" = "Env"
+    And the environment contains "HELLO_WORLD_SALUTATIONS" = "EnvOne,EnvTwo"
+    When I run the hello world example with arguments "-r Cli greet"
+    Then the command succeeds
+    And stdout contains "EnvOne EnvTwo, Cli!"

--- a/examples/hello_world/tests/features/global_parameters.feature
+++ b/examples/hello_world/tests/features/global_parameters.feature
@@ -45,7 +45,11 @@ Feature: Global parameters govern greetings
     And stdout contains "Hello, World?"
 
   Scenario: CLI overrides environment overrides configuration files
-    Given the hello world config file sets file defaults
+    Given the hello world config file contains:
+      """
+      recipient = "File"
+      salutations = ["File hello"]
+      """
     And the environment contains "HELLO_WORLD_RECIPIENT" = "Env"
     And the environment contains "HELLO_WORLD_SALUTATIONS" = "EnvOne,EnvTwo"
     When I run the hello world example with arguments "-r Cli greet"

--- a/examples/hello_world/tests/steps/global.rs
+++ b/examples/hello_world/tests/steps/global.rs
@@ -5,7 +5,7 @@
 //! Step definitions for the `hello_world` example.
 //! Drive the binary and assert its outputs.
 use crate::World;
-use cucumber::{then, when};
+use cucumber::{given, then, when};
 
 /// Runs the binary without additional arguments.
 #[when("I run the hello world example")]
@@ -54,4 +54,22 @@ pub fn stdout_contains(world: &mut World, expected: String) {
 // for assertions so the captured text remains available.
 pub fn stderr_contains(world: &mut World, expected: String) {
     world.assert_stderr_contains(&expected);
+}
+
+#[given(expr = "the environment contains {string} = {string}")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step signature requires owned String"
+)]
+pub fn environment_contains(world: &mut World, key: String, value: String) {
+    world.set_env(key, value);
+}
+
+#[given("the hello world config file sets file defaults")]
+pub fn config_file(world: &mut World) {
+    world.write_config(
+        r#"recipient = "File"
+salutations = ["File hello"]
+"#,
+    );
 }

--- a/examples/hello_world/tests/steps/global.rs
+++ b/examples/hello_world/tests/steps/global.rs
@@ -5,6 +5,7 @@
 //! Step definitions for the `hello_world` example.
 //! Drive the binary and assert its outputs.
 use crate::World;
+use cucumber::gherkin::Step as GherkinStep;
 use cucumber::{given, then, when};
 
 /// Runs the binary without additional arguments.
@@ -65,11 +66,19 @@ pub fn environment_contains(world: &mut World, key: String, value: String) {
     world.set_env(key, value);
 }
 
-#[given("the hello world config file sets file defaults")]
-pub fn config_file(world: &mut World) {
-    world.write_config(
-        r#"recipient = "File"
-salutations = ["File hello"]
-"#,
-    );
+#[given(expr = "the environment does not contain {string}")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step signature requires owned String"
+)]
+pub fn environment_does_not_contain(world: &mut World, key: String) {
+    world.remove_env(&key);
+}
+
+#[given("the hello world config file contains:")]
+pub fn config_file(world: &mut World, step: &GherkinStep) {
+    let contents = step
+        .docstring()
+        .expect("config docstring provided for hello world example");
+    world.write_config(contents);
 }


### PR DESCRIPTION
## Summary
- add rstest fixtures covering hello world CLI parsing, validation, and command helpers
- extend the cucumber world with temp-dir config helpers and an environment precedence scenario
- document the testing approach and update the example checklist

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d7c8ad90e8832294eb8ba9295d70f4

## Summary by Sourcery

Add comprehensive rstest unit tests and enhance cucumber-based behavioural tests for the `hello_world` example, introduce working-directory and env/config-file helpers, update documentation, and bump test-related dependencies.

New Features:
- Add parameterized rstest fixtures for CLI parsing, validation, delivery-mode logic, and edge-cases in the `hello_world` example
- Introduce Cucumber-world helpers for temporary working directories, configuration file writing, and environment variable injection
- Add a Cucumber scenario to verify configuration file < environment variable < CLI argument precedence

Enhancements:
- Replace legacy build_plan and build_take_leave_plan tests with structured rstest cases covering validation errors, delivery modes, and trimming logic

Build:
- Add `tempfile`, `cap-std`, and `gherkin` dependencies to the example’s Cargo.toml for test support

Documentation:
- Document the combined rstest and cucumber testing approach in design.md and user-guide, and update the example README checklist

Tests:
- Extend Cucumber steps and feature files to leverage new helpers and cover environment/config-file scenarios