### PR TITLE
Add reusable config discovery helper

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -148,6 +148,22 @@ directories over local files. Additional unit tests ensure
 produced from the sample configuration shout with the layered punctuation and
 preamble documented in the behavioural scenarios.
 
+### 4.5. Configuration discovery helper
+
+`ConfigDiscovery` now wraps the path search order previously hand-written in
+the example. A builder customises the environment variable, dotfile name and
+project roots without duplicating the discovery routine. The helper maintains
+the precedence from the example: explicit overrides via `<PREFIX>_CONFIG_PATH`,
+then XDG locations (including `/etc/xdg` when `XDG_CONFIG_DIRS` is unset),
+Windows application data directories, the user's home directory, and finally
+project roots. Candidates are deduplicated as they are gathered so different
+sources referencing the same file do not perform duplicate I/O.
+
+`ConfigDiscovery::load_first` delegates to `load_config_file`, short-circuiting
+once a readable file is found. Returning `OrthoResult` keeps the API aligned
+with the rest of the crate and allows downstream binaries to continue using
+their existing `From<Arc<OrthoError>>` implementations.
+
 ### Aggregated errors
 
 To surface multiple failures at once, `OrthoError::aggregate<I, E>(errors)`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -151,11 +151,10 @@ references the relevant design guidance.
 
 - [ ] **Abstract configuration discovery**
 
-  - [ ] Provide a cross-platform discovery helper that surfaces the same
+  - [x] Provide a cross-platform discovery helper that surfaces the same
     search order currently hand-coded in `hello_world`, consolidating explicit
     paths, XDG directories, Windows locations and project roots into a single
-    call.
-    [[Feedback](feedback-from-hello-world-example.md)]
+    call. [[Feedback](feedback-from-hello-world-example.md)]
 
   - [ ] Integrate the helper with the derive macro so applications can opt in
     via attributes to customise config file names and generated CLI flags
@@ -166,8 +165,7 @@ references the relevant design guidance.
 
   - [ ] Design a library-level merging trait or API that composes layered
     configuration structs without the ad hoc Figment plumbing required in the
-    example crate.
-    [[Feedback](feedback-from-hello-world-example.md)]
+    example crate. [[Feedback](feedback-from-hello-world-example.md)]
 
   - [ ] Ensure merge failures map to `OrthoError` consistently so downstream
     binaries no longer need bespoke error conversion when combining loaders.
@@ -186,13 +184,11 @@ references the relevant design guidance.
 
   - [ ] Provide an attribute- or trait-based hook for bespoke subcommand merge
     logic so advanced cases can adjust the merged struct without manual glue
-    code.
-    [[Feedback](feedback-from-hello-world-example.md)]
+    code. [[Feedback](feedback-from-hello-world-example.md)]
 
   - [ ] Offer a unified API that returns merged global and selected subcommand
     configuration in one call, eliminating the repetitive `match` scaffolding
-    in `hello_world`.
-    [[Feedback](feedback-from-hello-world-example.md)]
+    in `hello_world`. [[Feedback](feedback-from-hello-world-example.md)]
 
 - [ ] **Address future enhancements**
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -54,15 +54,31 @@ working directory, layers `.hello_world.toml` defaults via `cap-std`, and sets
 `HELLO_WORLD_*` environment variables per scenario to demonstrate precedence:
 configuration files < environment variables < CLI arguments.
 
-The runtime discovers `.hello_world.toml` in several locations so local
-overrides apply without additional flags. `HELLO_WORLD_CONFIG_PATH` wins when
-set; otherwise the loader searches `$XDG_CONFIG_HOME/hello_world/config.toml`,
-every directory listed in `$XDG_CONFIG_DIRS`, `%APPDATA%` on Windows,
-`$HOME/.config/hello_world/config.toml`, `$HOME/.hello_world.toml`, and finally
-the working directory. The repository ships `config/overrides.toml`, which
-extends `config/baseline.toml` to set `is_excited = true`, provide a
-`Layered hello` preamble, and swap the greet punctuation for `!!!`. Behavioural
-tests and demo scripts assert the uppercase output to guard this layering.
+`ConfigDiscovery` exposes the same search order used by the example so
+applications can replace bespoke path juggling with a single call. By default
+the helper honours `HELLO_WORLD_CONFIG_PATH`, then searches
+`$XDG_CONFIG_HOME/hello_world`, each entry in `$XDG_CONFIG_DIRS` (falling back
+to `/etc/xdg` on Unix-like targets), Windows application data directories,
+`$HOME/.config/hello_world`, `$HOME/.hello_world.toml`, and finally the project
+root. Candidates are deduplicated and returned in precedence order:
+
+```rust,no_run
+use ortho_config::ConfigDiscovery;
+
+# fn load() -> ortho_config::OrthoResult<()> {
+let figment = ConfigDiscovery::builder("hello_world")
+    .env_var("HELLO_WORLD_CONFIG_PATH")
+    .build()
+    .load_first()?;
+# let _ = figment;
+# Ok(())
+# }
+```
+
+The repository ships `config/overrides.toml`, which extends
+`config/baseline.toml` to set `is_excited = true`, provide a `Layered hello`
+preamble, and swap the greet punctuation for `!!!`. Behavioural tests and demo
+scripts assert the uppercase output to guard this layering.
 
 ## Installation and dependencies
 

--- a/examples/hello_world/src/cli/discovery.rs
+++ b/examples/hello_world/src/cli/discovery.rs
@@ -1,123 +1,28 @@
-use std::ffi::OsString;
-
+#[cfg(test)]
 use camino::Utf8PathBuf;
 
 use crate::error::HelloWorldError;
 
-pub(super) fn push_unique_candidate(candidates: &mut Vec<Utf8PathBuf>, path: Utf8PathBuf) {
-    if path.as_str().is_empty() || candidates.contains(&path) {
-        return;
-    }
-    candidates.push(path);
+fn discovery() -> ortho_config::ConfigDiscovery {
+    ortho_config::ConfigDiscovery::builder("hello_world")
+        .env_var("HELLO_WORLD_CONFIG_PATH")
+        .build()
 }
 
+#[cfg(test)]
+fn convert_candidates(paths: Vec<std::path::PathBuf>) -> Vec<Utf8PathBuf> {
+    paths
+        .into_iter()
+        .filter_map(|path| Utf8PathBuf::from_path_buf(path).ok())
+        .collect()
+}
+
+#[cfg(test)]
 pub(super) fn collect_config_candidates() -> Vec<Utf8PathBuf> {
-    let mut candidates = Vec::new();
-
-    {
-        let mut push = |path: Utf8PathBuf| push_unique_candidate(&mut candidates, path);
-        add_explicit_config_path(&mut push);
-        add_xdg_config_paths(&mut push);
-        add_windows_config_paths(&mut push);
-        add_home_config_paths(&mut push);
-    }
-    push_unique_candidate(&mut candidates, Utf8PathBuf::from(".hello_world.toml"));
-
-    candidates
-}
-
-pub(super) fn add_explicit_config_path<F>(push_candidate: &mut F)
-where
-    F: FnMut(Utf8PathBuf),
-{
-    if let Ok(path) = std::env::var("HELLO_WORLD_CONFIG_PATH") {
-        push_candidate(Utf8PathBuf::from(path));
-    }
-}
-
-pub(super) fn add_xdg_config_paths<F>(push_candidate: &mut F)
-where
-    F: FnMut(Utf8PathBuf),
-{
-    let config_basename = ".hello_world.toml";
-
-    if let Ok(dir) = std::env::var("XDG_CONFIG_HOME") {
-        let dir = Utf8PathBuf::from(dir);
-        push_candidate(dir.join("hello_world").join("config.toml"));
-        push_candidate(dir.join(config_basename));
-    }
-
-    if let Ok(dirs) = std::env::var("XDG_CONFIG_DIRS") {
-        let os_dirs = OsString::from(&dirs);
-        for dir in std::env::split_paths(&os_dirs) {
-            if let Ok(dir) = Utf8PathBuf::from_path_buf(dir) {
-                push_candidate(dir.join("hello_world").join("config.toml"));
-                push_candidate(dir.join(config_basename));
-            }
-        }
-    } else {
-        #[cfg(unix)]
-        {
-            let dir = Utf8PathBuf::from("/etc/xdg");
-            push_candidate(dir.join("hello_world").join("config.toml"));
-            push_candidate(dir.join(config_basename));
-        }
-    }
-}
-
-pub(super) fn add_windows_config_paths<F>(push_candidate: &mut F)
-where
-    F: FnMut(Utf8PathBuf),
-{
-    let config_basename = ".hello_world.toml";
-
-    if let Ok(appdata) = std::env::var("APPDATA") {
-        let dir = Utf8PathBuf::from(appdata);
-        push_candidate(dir.join("hello_world").join("config.toml"));
-        push_candidate(dir.join(config_basename));
-    }
-
-    if let Ok(local_appdata) = std::env::var("LOCALAPPDATA") {
-        let dir = Utf8PathBuf::from(local_appdata);
-        push_candidate(dir.join("hello_world").join("config.toml"));
-        push_candidate(dir.join(config_basename));
-    }
-}
-
-pub(super) fn add_home_config_paths<F>(push_candidate: &mut F)
-where
-    F: FnMut(Utf8PathBuf),
-{
-    let config_basename = ".hello_world.toml";
-
-    let home = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE"));
-    if let Ok(home) = home {
-        let home_path = Utf8PathBuf::from(home);
-        push_candidate(
-            home_path
-                .join(".config")
-                .join("hello_world")
-                .join("config.toml"),
-        );
-        push_candidate(home_path.join(config_basename));
-    }
-}
-
-pub(super) fn load_first_available_config(
-    candidates: Vec<Utf8PathBuf>,
-) -> Result<Option<ortho_config::figment::Figment>, HelloWorldError> {
-    for path in candidates {
-        match ortho_config::load_config_file(path.as_std_path()) {
-            Ok(Some(figment)) => return Ok(Some(figment)),
-            Ok(None) => {}
-            Err(err) => return Err(HelloWorldError::Configuration(err)),
-        }
-    }
-    Ok(None)
+    convert_candidates(discovery().candidates())
 }
 
 pub(super) fn discover_config_figment()
 -> Result<Option<ortho_config::figment::Figment>, HelloWorldError> {
-    let candidates = collect_config_candidates();
-    load_first_available_config(candidates)
+    discovery().load_first().map_err(HelloWorldError::from)
 }

--- a/examples/hello_world/tests/cucumber.rs
+++ b/examples/hello_world/tests/cucumber.rs
@@ -145,6 +145,21 @@ impl World {
             .expect("write hello_world config");
     }
 
+    /// Writes an arbitrary configuration file into the scenario directory.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `name` is not a simple filename or when writing fails.
+    pub fn write_named_file(&self, name: &str, contents: &str) {
+        assert!(
+            is_simple_filename(name),
+            "custom config filename must not contain path separators: {name}"
+        );
+        let dir = self.scenario_dir();
+        dir.write(name, contents)
+            .expect("write hello_world named config");
+    }
+
     /// Copies a repository sample configuration into the scenario directory.
     ///
     /// # Panics

--- a/examples/hello_world/tests/features/global_parameters.feature
+++ b/examples/hello_world/tests/features/global_parameters.feature
@@ -56,6 +56,16 @@ Feature: Global parameters govern greetings
     Then the command succeeds
     And stdout contains "EnvOne EnvTwo, Cli!"
 
+  Scenario: Explicit config path overrides discovery order
+    Given the file "custom.toml" contains:
+      """
+      recipient = "Explicit path"
+      """
+    And the environment contains "HELLO_WORLD_CONFIG_PATH" = "custom.toml"
+    When I run the hello world example with arguments "greet"
+    Then the command succeeds
+    And stdout contains "Explicit path"
+
   Scenario: Sample configuration files drive the demo scripts
     Given I start from the sample hello world config "overrides.toml"
     When I run the hello world example with arguments "greet"

--- a/examples/hello_world/tests/steps/global.rs
+++ b/examples/hello_world/tests/steps/global.rs
@@ -116,6 +116,18 @@ pub fn config_file(world: &mut World, step: &GherkinStep) {
     world.write_config(contents);
 }
 
+#[given(expr = "the file {string} contains:")]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber step signature requires owned capture values"
+)]
+pub fn named_file_contains(world: &mut World, name: CapturedString, step: &GherkinStep) {
+    let contents = step
+        .docstring()
+        .expect("config docstring provided for hello world example");
+    world.write_named_file(name.as_str(), contents);
+}
+
 /// Initialises the scenario using a repository sample configuration.
 #[given(expr = "I start from the sample hello world config {string}")]
 #[expect(

--- a/ortho_config/src/discovery.rs
+++ b/ortho_config/src/discovery.rs
@@ -1,0 +1,374 @@
+//! Cross-platform configuration file discovery helpers.
+//!
+//! Applications can use [`ConfigDiscovery`] to enumerate configuration file
+//! candidates in the same order exercised by the `hello_world` example. The
+//! helper inspects explicit paths, XDG directories, Windows application data
+//! folders, the user's home directory and project roots.
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::{OrthoResult, load_config_file};
+
+/// Builder for [`ConfigDiscovery`].
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use ortho_config::discovery::ConfigDiscovery;
+///
+/// # fn run() -> ortho_config::OrthoResult<()> {
+/// let discovery = ConfigDiscovery::builder("hello_world")
+///     .env_var("HELLO_WORLD_CONFIG_PATH")
+///     .build();
+///
+/// if let Some(figment) = discovery.load_first()? {
+///     #[derive(serde::Deserialize)]
+///     struct Greeting { recipient: String }
+///     let config: Greeting = figment.extract()?;
+///     println!("Loaded greeting for {}", config.recipient);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct ConfigDiscoveryBuilder {
+    env_var: Option<String>,
+    app_name: String,
+    config_file_name: String,
+    custom_dotfile_name: Option<String>,
+    custom_project_file_name: Option<String>,
+    project_roots: Vec<PathBuf>,
+    explicit_paths: Vec<PathBuf>,
+}
+
+impl ConfigDiscoveryBuilder {
+    /// Creates a builder initialised for `app_name`.
+    ///
+    /// The `app_name` populates platform directories such as
+    /// `$XDG_CONFIG_HOME/<app_name>/config.toml` and
+    /// `%APPDATA%\<app_name>\config.toml`.
+    #[must_use]
+    pub fn new(app_name: impl Into<String>) -> Self {
+        Self {
+            env_var: None,
+            app_name: app_name.into(),
+            config_file_name: String::from("config.toml"),
+            custom_dotfile_name: None,
+            custom_project_file_name: None,
+            project_roots: vec![PathBuf::new()],
+            explicit_paths: Vec::new(),
+        }
+    }
+
+    /// Sets the environment variable consulted for an explicit configuration path.
+    #[must_use]
+    pub fn env_var(mut self, env_var: impl Into<String>) -> Self {
+        self.env_var = Some(env_var.into());
+        self
+    }
+
+    /// Overrides the canonical configuration file name searched under platform directories.
+    #[must_use]
+    pub fn config_file_name(mut self, name: impl Into<String>) -> Self {
+        self.config_file_name = name.into();
+        self
+    }
+
+    /// Sets a custom dotfile name used in directories that search for hidden files.
+    #[must_use]
+    pub fn dotfile_name(mut self, name: impl Into<String>) -> Self {
+        self.custom_dotfile_name = Some(name.into());
+        self
+    }
+
+    /// Overrides the filename searched within project roots.
+    #[must_use]
+    pub fn project_file_name(mut self, name: impl Into<String>) -> Self {
+        self.custom_project_file_name = Some(name.into());
+        self
+    }
+
+    /// Removes all project roots from the builder.
+    #[must_use]
+    pub fn clear_project_roots(mut self) -> Self {
+        self.project_roots.clear();
+        self
+    }
+
+    /// Adds an additional project root searched for configuration files.
+    #[must_use]
+    pub fn add_project_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.project_roots.push(root.into());
+        self
+    }
+
+    /// Adds an explicit candidate path that precedes platform discovery.
+    #[must_use]
+    pub fn add_explicit_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.explicit_paths.push(path.into());
+        self
+    }
+
+    fn default_dotfile(&self) -> String {
+        let stem = self.app_name.trim();
+        let extension = Path::new(&self.config_file_name)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+
+        if stem.is_empty() {
+            match extension {
+                "" => String::from(".config"),
+                ext => format!(".{ext}"),
+            }
+        } else if extension.is_empty() {
+            format!(".{stem}")
+        } else {
+            format!(".{stem}.{extension}")
+        }
+    }
+
+    /// Finalises the builder and returns a [`ConfigDiscovery`].
+    #[must_use]
+    pub fn build(self) -> ConfigDiscovery {
+        let default_dotfile = self.default_dotfile();
+        let dotfile_name = self.custom_dotfile_name.unwrap_or(default_dotfile);
+        let project_file_name = self
+            .custom_project_file_name
+            .unwrap_or_else(|| dotfile_name.clone());
+
+        ConfigDiscovery {
+            env_var: self.env_var,
+            explicit_paths: self.explicit_paths,
+            app_name: self.app_name,
+            config_file_name: self.config_file_name,
+            dotfile_name,
+            project_file_name,
+            project_roots: self.project_roots,
+        }
+    }
+}
+
+/// Cross-platform configuration discovery helper mirroring the `hello_world` example.
+#[derive(Debug, Clone)]
+pub struct ConfigDiscovery {
+    env_var: Option<String>,
+    explicit_paths: Vec<PathBuf>,
+    app_name: String,
+    config_file_name: String,
+    dotfile_name: String,
+    project_file_name: String,
+    project_roots: Vec<PathBuf>,
+}
+
+impl ConfigDiscovery {
+    /// Creates a new builder initialised for `app_name`.
+    #[must_use]
+    pub fn builder(app_name: impl Into<String>) -> ConfigDiscoveryBuilder {
+        ConfigDiscoveryBuilder::new(app_name)
+    }
+
+    fn push_unique(paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, candidate: PathBuf) {
+        if candidate.as_os_str().is_empty() {
+            return;
+        }
+        if seen.insert(candidate.clone()) {
+            paths.push(candidate);
+        }
+    }
+
+    fn push_explicit(&self, paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+        if let Some(env_var) = &self.env_var {
+            if let Some(value) = std::env::var_os(env_var) {
+                if !value.is_empty() {
+                    Self::push_unique(paths, seen, PathBuf::from(value));
+                }
+            }
+        }
+
+        for path in &self.explicit_paths {
+            Self::push_unique(paths, seen, path.clone());
+        }
+    }
+
+    fn push_nested(&self, base: &Path, paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+        let dir = if self.app_name.is_empty() {
+            base.to_path_buf()
+        } else {
+            base.join(&self.app_name)
+        };
+        Self::push_unique(paths, seen, dir.join(&self.config_file_name));
+    }
+
+    fn push_dotfile(&self, base: &Path, paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+        Self::push_unique(paths, seen, base.join(&self.dotfile_name));
+    }
+
+    fn push_xdg(&self, paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+        if let Some(dir) = std::env::var_os("XDG_CONFIG_HOME") {
+            let dir = PathBuf::from(dir);
+            self.push_nested(&dir, paths, seen);
+            self.push_dotfile(&dir, paths, seen);
+        }
+
+        if let Some(dirs) = std::env::var_os("XDG_CONFIG_DIRS") {
+            for dir in std::env::split_paths(&dirs) {
+                self.push_nested(&dir, paths, seen);
+                self.push_dotfile(&dir, paths, seen);
+            }
+        } else if cfg!(any(unix, target_os = "redox")) {
+            let dir = Path::new("/etc/xdg");
+            self.push_nested(dir, paths, seen);
+            self.push_dotfile(dir, paths, seen);
+        }
+    }
+
+    fn push_windows(&self, paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+        for key in ["APPDATA", "LOCALAPPDATA"] {
+            if let Some(dir) = std::env::var_os(key) {
+                let dir = PathBuf::from(dir);
+                self.push_nested(&dir, paths, seen);
+                self.push_dotfile(&dir, paths, seen);
+            }
+        }
+    }
+
+    fn push_home(&self, paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+        let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"));
+        if let Some(home) = home {
+            let home_path = PathBuf::from(&home);
+            let config_dir = home_path.join(".config");
+            self.push_nested(&config_dir, paths, seen);
+            Self::push_unique(paths, seen, home_path.join(&self.dotfile_name));
+        }
+    }
+
+    fn push_projects(&self, paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+        for root in &self.project_roots {
+            Self::push_unique(paths, seen, root.join(&self.project_file_name));
+        }
+    }
+
+    /// Returns the ordered configuration candidates.
+    #[must_use]
+    pub fn candidates(&self) -> Vec<PathBuf> {
+        let mut seen = HashSet::new();
+        let mut paths = Vec::new();
+
+        self.push_explicit(&mut paths, &mut seen);
+        self.push_xdg(&mut paths, &mut seen);
+        self.push_windows(&mut paths, &mut seen);
+        self.push_home(&mut paths, &mut seen);
+        self.push_projects(&mut paths, &mut seen);
+
+        paths
+    }
+
+    /// Loads the first available configuration file using [`load_config_file`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OrthoError`](crate::OrthoError) if reading a candidate fails.
+    pub fn load_first(&self) -> OrthoResult<Option<figment::Figment>> {
+        for path in self.candidates() {
+            match load_config_file(&path) {
+                Ok(Some(figment)) => return Ok(Some(figment)),
+                Ok(None) => {}
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde::Deserialize;
+    use tempfile::TempDir;
+    use test_helpers::env as test_env;
+
+    fn clear_common_env() -> Vec<test_env::EnvVarGuard> {
+        let mut guards = Vec::new();
+        for key in [
+            "HELLO_WORLD_CONFIG_PATH",
+            "XDG_CONFIG_HOME",
+            "XDG_CONFIG_DIRS",
+            "APPDATA",
+            "LOCALAPPDATA",
+            "HOME",
+            "USERPROFILE",
+        ] {
+            guards.push(test_env::remove_var(key));
+        }
+        guards
+    }
+
+    #[rstest]
+    fn env_override_precedes_other_candidates() {
+        let _guards = clear_common_env();
+        let path = std::env::temp_dir().join("explicit.toml");
+        let _env = test_env::set_var("HELLO_WORLD_CONFIG_PATH", &path);
+
+        let discovery = ConfigDiscovery::builder("hello_world")
+            .env_var("HELLO_WORLD_CONFIG_PATH")
+            .build();
+        let candidates = discovery.candidates();
+        assert_eq!(candidates.first(), Some(&path));
+    }
+
+    #[rstest]
+    fn xdg_candidates_follow_explicit_paths() {
+        let _guards = clear_common_env();
+        let dir = TempDir::new().expect("xdg");
+        let xdg_path = dir.path().join("hello_world");
+        std::fs::create_dir_all(&xdg_path).expect("create xdg dir");
+        let _home = test_env::set_var("XDG_CONFIG_HOME", dir.path());
+
+        let discovery = ConfigDiscovery::builder("hello_world").build();
+        let candidates = discovery.candidates();
+        let expected_first = xdg_path.join("config.toml");
+        let expected_second = dir.path().join(".hello_world.toml");
+        assert_eq!(candidates.first(), Some(&expected_first));
+        assert_eq!(candidates.get(1), Some(&expected_second));
+    }
+
+    #[rstest]
+    fn project_roots_append_last() {
+        let _guards = clear_common_env();
+        let discovery = ConfigDiscovery::builder("hello_world")
+            .clear_project_roots()
+            .add_project_root("proj")
+            .build();
+        let candidates = discovery.candidates();
+        assert_eq!(
+            candidates.last(),
+            Some(&PathBuf::from("proj/.hello_world.toml"))
+        );
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct SampleConfig {
+        value: bool,
+    }
+
+    #[rstest]
+    fn load_first_reads_first_existing_file() {
+        let _guards = clear_common_env();
+        let dir = TempDir::new().expect("config dir");
+        let file_dir = dir.path().join("hello_world");
+        std::fs::create_dir_all(&file_dir).expect("create hello_world dir");
+        let file = file_dir.join("config.toml");
+        std::fs::write(&file, "value = true").expect("write config");
+        let _xdg = test_env::set_var("XDG_CONFIG_HOME", dir.path());
+
+        let discovery = ConfigDiscovery::builder("hello_world").build();
+        let figment = discovery
+            .load_first()
+            .expect("load figment")
+            .expect("figment present");
+        let config: SampleConfig = figment.extract().expect("extract sample config");
+        assert!(config.value);
+    }
+}

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -25,6 +25,7 @@ pub use uncased;
 pub use xdg;
 
 mod csv_env;
+pub mod discovery;
 mod error;
 pub mod file;
 mod merge;
@@ -54,6 +55,7 @@ pub fn normalize_prefix(prefix: &str) -> String {
 }
 
 pub use csv_env::CsvEnv;
+pub use discovery::{ConfigDiscovery, ConfigDiscoveryBuilder};
 pub use error::OrthoError;
 pub use file::load_config_file;
 /// Re-export sanitization helpers used to strip `None` fields and produce a


### PR DESCRIPTION
## Summary
- add a reusable `ConfigDiscovery` helper with a builder, candidate enumeration, and unit tests to mirror the hello_world search order
- switch the hello_world example to the shared helper and extend the cucumber suite with an explicit path scenario and step support
- document the helper in the design and user guide and mark the roadmap entry complete

## Testing
- make fmt
- make check-fmt
- make lint
- make test
- make markdownlint

------
https://chatgpt.com/codex/tasks/task_e_68e060e921bc832282896ad7e1b51fd9