### PR TITLE
Normalise ortho_config prefix underscore handling

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -585,3 +585,11 @@ explicit.
 This design provides a clear path forward for implementing `OrthoConfig`. By
 building on a solid foundation of existing crates and focusing on the developer
 experience, we can create a highly valuable addition to the Rust ecosystem.
+
+## 9. Decision Log
+
+- **Prefix normalisation:** The `prefix` struct attribute now appends a trailing
+  underscore when callers omit it (unless the string is empty). This keeps
+  attribute usage ergonomic for API consumers—`#[ortho_config(prefix = "APP")]`
+  produces environment variables such as `APP_PORT`—whilst preserving existing
+  behaviour for code that already includes the delimiter.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -182,10 +182,11 @@ A configuration is represented by a plain Rust struct. To take advantage of
 
 Optionally, the struct can include a `#[ortho_config(prefix = "PREFIX")]`
 attribute. The prefix sets a common string for environment variables and
-configuration file names. Trailing underscores are trimmed and the prefix is
-lower‑cased when used to form file names. For example, a prefix of `APP_`
-results in environment variables like `APP_PORT` and file names such as
-`.app.toml`.
+configuration file names. When the attribute omits a trailing underscore,
+`ortho_config` appends one automatically so environment variables consistently
+use `<PREFIX>_`. Trailing underscores are trimmed and the prefix is lower‑cased
+when used to form file names. For example, a prefix of `APP` results in
+environment variables like `APP_PORT` and file names such as `.app.toml`.
 
 ### Field-level attributes
 
@@ -249,7 +250,8 @@ The following example illustrates many of these features:
   use serde::{Deserialize, Serialize};
 
   #[derive(Debug, Clone, Deserialize, Serialize, OrthoConfig)]
-  #[ortho_config(prefix = "APP")]                // environment variables start with APP_
+  // env vars use APP_ (the macro adds the underscore automatically)
+  #[ortho_config(prefix = "APP")]
   struct AppConfig {
       /// Logging verbosity
       log_level: String,

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -59,6 +59,9 @@ and `%APPDATA%`), and finally falls back to `$HOME/.hello_world.toml` and the
 working directory. The shipped overrides enable a `Layered hello` preamble and
 triple exclamation marks, so the behavioural suite and demo scripts assert the
 shouted output (`HEY CONFIG FRIENDS, EXCITED CREW!!!`) to guard the layering.
+The derive uses `#[ortho_config(prefix = "HELLO_WORLD")]`; the macro appends
+the trailing underscore automatically so environment variables continue to use
+the `HELLO_WORLD_` prefix.
 
 Once the workspace is built, `scripts/demo.sh` (or `scripts/demo.cmd` on
 Windows) can be executed. Each script creates an isolated temporary directory,

--- a/examples/hello_world/src/cli/mod.rs
+++ b/examples/hello_world/src/cli/mod.rs
@@ -44,7 +44,7 @@ pub struct CommandLine {
 
 /// CLI overrides for the global greeting options.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Args, Deserialize, Serialize, OrthoConfig)]
-#[ortho_config(prefix = "HELLO_WORLD_")]
+#[ortho_config(prefix = "HELLO_WORLD")]
 pub struct GlobalArgs {
     /// Recipient of the greeting when supplied on the CLI.
     #[arg(short = 'r', long = "recipient", value_name = "NAME", id = "recipient")]
@@ -82,7 +82,7 @@ pub enum Commands {
 
 /// Customisation options for the `greet` command.
 #[derive(Debug, Clone, PartialEq, Eq, Parser, Deserialize, Serialize, OrthoConfig)]
-#[ortho_config(prefix = "HELLO_WORLD_")]
+#[ortho_config(prefix = "HELLO_WORLD")]
 pub struct GreetCommand {
     /// Optional preamble printed before the greeting.
     #[arg(long, value_name = "PHRASE", id = "preamble")]
@@ -130,7 +130,7 @@ fn default_punctuation() -> String {
 
 /// Options controlling the `take-leave` workflow.
 #[derive(Debug, Clone, PartialEq, Eq, Parser, Deserialize, Serialize, OrthoConfig)]
-#[ortho_config(prefix = "HELLO_WORLD_")]
+#[ortho_config(prefix = "HELLO_WORLD")]
 pub struct TakeLeaveCommand {
     /// Parting phrase to use when saying goodbye.
     #[arg(
@@ -385,7 +385,7 @@ pub(crate) fn load_greet_defaults() -> Result<GreetCommand, HelloWorldError> {
 /// without extra accessor boilerplate.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, OrthoConfig)]
 #[ortho_config(
-    prefix = "HELLO_WORLD_",
+    prefix = "HELLO_WORLD",
     discovery(
         app_name = "hello_world",
         config_file_name = "hello_world.toml",


### PR DESCRIPTION
## Summary
- normalise the struct-level `prefix` attribute so missing trailing underscores are added automatically and cover the behaviour with rstest cases
- update the hello_world example and user-facing docs to demonstrate the implicit underscore handling
- run the workspace formatters, which reflowed existing Markdown as required

## Testing
- make fmt
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e7d13e10348322b3083966fa2c1eed