### PR TITLE
Add declarative merge scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,9 +382,8 @@ Version v0.5.0 introduces a small API refinement:
 - Types deriving `OrthoConfig` expose an associated `prefix()` function. Use
   this if you need the configured prefix directly.
 
-Update the `Cargo.toml` to depend on `ortho_config = "0.5.0"` and adjust
-code to call `load_and_merge_subcommand_for` instead of manually merging
-defaults.
+Update the `Cargo.toml` to depend on `ortho_config = "0.5.0"` and adjust code
+to call `load_and_merge_subcommand_for` instead of manually merging defaults.
 
 ## Version management
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -158,6 +158,17 @@ their own `DeclarativeMerge` implementation, ensuring subcommand namespaces are
 merged consistently without the manual `apply_greet_overrides` helper
 highlighted in the example feedback.
 
+The initial implementation materialises merge state as a JSON object using
+`serde_json::Map<String, Value>`. Each layer is validated to ensure it contains
+an object payload; the helper maps violations to `OrthoError::Merge` using a
+`figment::Error` wrapper so downstream callers observe a consistent error
+surface. Overlays perform a simple "last write wins" merge for scalars and
+arrays while recursing into nested objects. This keeps precedence semantics
+predictable whilst allowing follow-on work to introduce richer strategies for
+collections without changing the surrounding API. `merge_from_layers` exposes
+the state machine so unit tests and doctests can compose deterministic layers
+without invoking CLI parsing or file discovery.
+
 The derive macro also emits a helper named `merge_from_layers` that accepts any
 iterator of `MergeLayer<'static>` and returns `OrthoResult<Self>` for tests.
 Developers can construct deterministic `MergeLayer` fixtures (for example,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -167,14 +167,14 @@ references the relevant design guidance.
     that replaces hand-written Figment wiring in the hello_world example and
     future clients. [[Feedback](feedback-from-hello-world-example.md)]
 
-  - [ ] Document declarative merging with examples covering defaults, file
+  - [x] Document declarative merging with examples covering defaults, file
     overrides, environment variables, and CLI adjustments to codify expected
     behaviour. [[Feedback](feedback-from-hello-world-example.md)]
 
   - [ ] Derive `DeclarativeMerge` alongside `OrthoConfig`, generating
     field-level merge arms and attribute-driven strategies for collections.
 
-    - [ ] Sketch the derive macro surfaces, ensuring every struct that
+    - [x] Sketch the derive macro surfaces, ensuring every struct that
       already implements `OrthoConfig` can auto-derive `DeclarativeMerge`
       without additional boilerplate. Mirror the trait signatures from the
       declarative design doc before implementing. [[Design](design.md)]

--- a/ortho_config/README.md
+++ b/ortho_config/README.md
@@ -382,9 +382,8 @@ Version v0.5.0 introduces a small API refinement:
 - Types deriving `OrthoConfig` expose an associated `prefix()` function. Use
   this if you need the configured prefix directly.
 
-Update the `Cargo.toml` to depend on `ortho_config = "0.5.0"` and adjust
-code to call `load_and_merge_subcommand_for` instead of manually merging
-defaults.
+Update the `Cargo.toml` to depend on `ortho_config = "0.5.0"` and adjust code
+to call `load_and_merge_subcommand_for` instead of manually merging defaults.
 
 ## Version management
 

--- a/ortho_config/src/declarative.rs
+++ b/ortho_config/src/declarative.rs
@@ -1,0 +1,182 @@
+use crate::{OrthoError, OrthoResult};
+use figment::Error as FigmentError;
+use serde::de::DeserializeOwned;
+use serde_json::{Map, Value};
+use std::borrow::Cow;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Trait implemented by generated merge state machines.
+pub trait DeclarativeMerge: Sized {
+    /// Final configuration type produced after merging all layers.
+    type Output;
+
+    /// Merge a single configuration layer into the accumulated state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OrthoError`] when the layer payload is invalid.
+    fn merge_layer(&mut self, layer: MergeLayer<'_>) -> OrthoResult<()>;
+
+    /// Finalise the merge, producing the concrete configuration type.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OrthoError`] when deserialisation of the merged value fails.
+    fn finish(self) -> OrthoResult<Self::Output>;
+}
+
+/// Describes the source of a configuration layer.
+#[derive(Clone, Debug)]
+pub enum MergeSource<'a> {
+    /// Default values generated from struct attributes.
+    Defaults,
+    /// Configuration parsed from a file discovered on disk.
+    File { path: Cow<'a, Path> },
+    /// Environment variable overrides.
+    Environment,
+    /// Command-line overrides.
+    Cli,
+}
+
+impl<'a> MergeSource<'a> {
+    /// Builds a file layer reference from any path-like value.
+    pub fn file<P>(path: P) -> Self
+    where
+        P: Into<Cow<'a, Path>>,
+    {
+        MergeSource::File { path: path.into() }
+    }
+}
+
+impl fmt::Display for MergeSource<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MergeSource::Defaults => write!(f, "defaults"),
+            MergeSource::Environment => write!(f, "environment"),
+            MergeSource::Cli => write!(f, "CLI"),
+            MergeSource::File { path } => write!(f, "file '{}'", path.display()),
+        }
+    }
+}
+
+/// Borrowed or owned JSON value describing a configuration layer.
+#[derive(Clone, Debug)]
+pub struct MergeLayer<'a> {
+    source: MergeSource<'a>,
+    value: Cow<'a, Value>,
+}
+
+impl<'a> MergeLayer<'a> {
+    /// Creates a new layer from the provided source and JSON payload.
+    #[must_use]
+    pub fn new(source: MergeSource<'a>, value: Cow<'a, Value>) -> Self {
+        Self { source, value }
+    }
+
+    /// Creates a defaults layer from an owned value.
+    #[must_use]
+    pub fn defaults(value: Value) -> Self {
+        Self::new(MergeSource::Defaults, Cow::Owned(value))
+    }
+
+    /// Creates a file layer from an owned value and path.
+    #[must_use]
+    pub fn file(path: PathBuf, value: Value) -> Self {
+        Self::new(MergeSource::file(path), Cow::Owned(value))
+    }
+
+    /// Creates an environment layer from an owned value.
+    #[must_use]
+    pub fn environment(value: Value) -> Self {
+        Self::new(MergeSource::Environment, Cow::Owned(value))
+    }
+
+    /// Creates a CLI layer from an owned value.
+    #[must_use]
+    pub fn cli(value: Value) -> Self {
+        Self::new(MergeSource::Cli, Cow::Owned(value))
+    }
+
+    /// Returns the layer source.
+    #[must_use]
+    pub fn source(&self) -> &MergeSource<'a> {
+        &self.source
+    }
+
+    /// Returns the underlying JSON payload.
+    #[must_use]
+    pub fn value(&self) -> &Value {
+        self.value.as_ref()
+    }
+}
+
+fn make_merge_error(msg: String) -> Arc<OrthoError> {
+    Arc::new(OrthoError::merge(FigmentError::from(msg)))
+}
+
+fn expect_object<'a>(
+    value: &'a Value,
+    source: &MergeSource<'_>,
+) -> OrthoResult<&'a Map<String, Value>> {
+    match value {
+        Value::Object(map) => Ok(map),
+        _ => Err(make_merge_error(format!(
+            "{source} layer must be a JSON object to support declarative merging"
+        ))),
+    }
+}
+
+fn merge_value(
+    target: &mut Map<String, Value>,
+    value: &Value,
+    source: &MergeSource<'_>,
+) -> OrthoResult<()> {
+    let map = expect_object(value, source)?;
+    merge_map(target, map);
+    Ok(())
+}
+
+fn merge_map(target: &mut Map<String, Value>, overlay: &Map<String, Value>) {
+    for (key, value) in overlay {
+        match value {
+            Value::Object(child) => match target.get_mut(key) {
+                Some(Value::Object(existing)) => merge_map(existing, child),
+                _ => {
+                    target.insert(key.clone(), Value::Object(child.clone()));
+                }
+            },
+            _ => {
+                target.insert(key.clone(), value.clone());
+            }
+        }
+    }
+}
+
+fn json_to_config<T: DeserializeOwned>(map: Map<String, Value>) -> OrthoResult<T> {
+    serde_json::from_value(Value::Object(map)).map_err(|err| {
+        make_merge_error(format!("failed to deserialize merged configuration: {err}"))
+    })
+}
+
+/// Merge the provided layer into the accumulator map.
+///
+/// # Errors
+///
+/// Returns an [`OrthoError`] if the layer payload cannot be merged.
+pub fn merge_layer_into_map(
+    accumulator: &mut Map<String, Value>,
+    layer: &MergeLayer<'_>,
+) -> OrthoResult<()> {
+    merge_value(accumulator, layer.value(), layer.source())
+}
+
+/// Convert an accumulated JSON map into the desired configuration type.
+///
+/// # Errors
+///
+/// Returns an [`OrthoError`] when the merged payload cannot be deserialised.
+pub fn merged_map_into<T: DeserializeOwned>(map: Map<String, Value>) -> OrthoResult<T> {
+    json_to_config(map)
+}

--- a/ortho_config/src/lib.rs
+++ b/ortho_config/src/lib.rs
@@ -13,6 +13,7 @@ pub use figment_json5;
 #[cfg(feature = "json5")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json5")))]
 pub use json5;
+pub use serde_json;
 #[cfg(feature = "yaml")]
 #[cfg_attr(docsrs, doc(cfg(feature = "yaml")))]
 pub use serde_yaml;
@@ -25,6 +26,7 @@ pub use uncased;
 pub use xdg;
 
 mod csv_env;
+mod declarative;
 pub mod discovery;
 mod error;
 pub mod file;
@@ -32,6 +34,9 @@ mod merge;
 mod result_ext;
 pub mod subcommand;
 pub use crate::subcommand::SubcmdConfigMerge;
+pub use declarative::{
+    DeclarativeMerge, MergeLayer, MergeSource, merge_layer_into_map, merged_map_into,
+};
 pub use result_ext::{IntoFigmentError, OrthoMergeExt, OrthoResultExt, ResultIntoFigment};
 pub use subcommand::{load_and_merge_subcommand, load_and_merge_subcommand_for};
 

--- a/ortho_config/tests/declarative_merge.rs
+++ b/ortho_config/tests/declarative_merge.rs
@@ -1,0 +1,69 @@
+use ortho_config::{MergeLayer, OrthoConfig};
+use rstest::rstest;
+use serde::Deserialize;
+use serde_json::json;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize, OrthoConfig, PartialEq, Eq)]
+struct DeclarativeConfig {
+    recipient: String,
+    salutations: Vec<String>,
+    #[serde(default)]
+    is_excited: bool,
+}
+
+#[rstest]
+fn merge_layers_respects_precedence() {
+    let defaults = MergeLayer::defaults(json!({
+        "recipient": "World",
+        "salutations": ["Hello"],
+        "is_excited": false,
+    }));
+    let file = MergeLayer::file(
+        PathBuf::from("config.toml"),
+        json!({
+            "salutations": ["Hey", "there"],
+        }),
+    );
+    let env = MergeLayer::environment(json!({ "recipient": "Env" }));
+    let cli = MergeLayer::cli(json!({
+        "recipient": "Cli",
+        "is_excited": true,
+    }));
+
+    let merged = DeclarativeConfig::merge_from_layers([defaults, file, env, cli])
+        .expect("expected declarative merge to succeed");
+
+    assert_eq!(merged.recipient, "Cli");
+    assert_eq!(
+        merged.salutations,
+        vec!["Hey".to_string(), "there".to_string()]
+    );
+    assert!(merged.is_excited);
+}
+
+#[rstest]
+fn merge_layer_requires_object_payload() {
+    let result = DeclarativeConfig::merge_from_layers([MergeLayer::defaults(json!("not object"))]);
+    let err = result.expect_err("non-object layer must fail");
+    assert!(
+        err.to_string()
+            .contains("defaults layer must be a JSON object"),
+        "unexpected error message: {err}"
+    );
+}
+
+#[rstest]
+fn merge_layers_supports_partial_overrides() {
+    let defaults = MergeLayer::defaults(json!({
+        "recipient": "World",
+        "salutations": ["Hello"],
+    }));
+    let cli = MergeLayer::cli(json!({ "recipient": "Cli" }));
+
+    let merged = DeclarativeConfig::merge_from_layers([defaults, cli])
+        .expect("expected partial overrides to succeed");
+
+    assert_eq!(merged.recipient, "Cli");
+    assert_eq!(merged.salutations, vec!["Hello".to_string()]);
+}

--- a/ortho_config_macros/README.md
+++ b/ortho_config_macros/README.md
@@ -382,9 +382,8 @@ Version v0.5.0 introduces a small API refinement:
 - Types deriving `OrthoConfig` expose an associated `prefix()` function. Use
   this if you need the configured prefix directly.
 
-Update the `Cargo.toml` to depend on `ortho_config = "0.5.0"` and adjust
-code to call `load_and_merge_subcommand_for` instead of manually merging
-defaults.
+Update the `Cargo.toml` to depend on `ortho_config = "0.5.0"` and adjust code
+to call `load_and_merge_subcommand_for` instead of manually merging defaults.
 
 ## Version management
 


### PR DESCRIPTION
## Summary
- add a declarative merge trait with JSON layer helpers that can be generated alongside OrthoConfig
- update the derive macro to emit hidden merge state plus a merge_from_layers helper and expose the new API via re-exports
- document declarative merging, update the hello_world example tests, and cover the new helpers with rstest fixtures while ticking the roadmap task

## Testing
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint`

------
https://chatgpt.com/codex/tasks/task_e_68e972d57a3883228987bb8b9b5952a7