### PR TITLE
Introduce declarative configuration merging

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -179,7 +179,7 @@ references the relevant design guidance.
       without additional boilerplate. Mirror the trait signatures from the
       declarative design doc before implementing. [[Design](design.md)]
 
-    - [ ] Generate merge arms for each field, respecting existing
+    - [x] Generate merge arms for each field, respecting existing
       `#[ortho_config(...)]` metadata so nested structures, optional values,
       and enums flow through consistently. Use the dependency injection
       patterns documented for testing to keep fixtures focused on precedence

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -41,7 +41,9 @@ values from multiple sources. The core features are:
 - **Declarative merge tooling** – Every configuration struct exposes a
   `merge_from_layers` helper along with `MergeComposer`, making it simple to
   compose defaults, files, environment captures, and CLI values in unit tests
-  or bespoke loaders without instantiating the CLI parser.
+  or bespoke loaders without instantiating the CLI parser. Vector fields honour
+  the append strategy by default, so defaults flow through alongside
+  environment and CLI additions.
 
 The workspace bundles an executable Hello World example under
 `examples/hello_world`. It layers defaults, environment variables, and CLI
@@ -119,14 +121,18 @@ composer.push_cli(json!({"recipient": "Cli" }));
 
 let merged = AppConfig::merge_from_layers(composer.layers())?;
 assert_eq!(merged.recipient, "Cli");
-assert_eq!(merged.salutations, vec![String::from("Env")]);
+assert_eq!(
+    merged.salutations,
+    vec![String::from("Hi"), String::from("Env")]
+);
 ```
 
 This API surfaces the same precedence as the generated `load()` method while
 making it trivial to drive unit and behavioural tests with hand-crafted layers.
-The Hello World example’s behavioural suite includes a dedicated scenario that
-parses JSON descriptors into `MergeLayer` values and asserts the merged
-configuration via these helpers.
+`Vec<_>` fields accumulate values from each layer in order, so defaults can
+coexist with environment or CLI extensions. The Hello World example’s
+behavioural suite includes a dedicated scenario that parses JSON descriptors
+into `MergeLayer` values and asserts the merged configuration via these helpers.
 
 ## Installation and dependencies
 
@@ -240,6 +246,11 @@ Field attributes modify how a field is sourced or merged:
 Unrecognized keys are ignored by the derive macro for forwards compatibility.
 Unknown keys will therefore silently do nothing. Developers who require
 stricter validation may add manual `compile_error!` guards.
+
+Vector append buffers operate on raw JSON values, so element types only need to
+implement `serde::Deserialize`. Deriving `serde::Serialize` remains useful when
+applications serialise configuration back out (for example, to emit defaults),
+but it is no longer required merely to opt into the append strategy.
 
 By default, each field receives a long flag derived from its name in kebab‑case
 and a short flag. The macro chooses the short flag using these rules:

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -22,7 +22,8 @@ production-ready complexity.
 - **Declarative merging**: demonstrate how `MergeComposer` and
   `merge_from_layers` build layered configuration without invoking the CLI by
   driving a behavioural scenario that composes JSON-described layers into
-  `GlobalArgs`.
+  `GlobalArgs`, asserting that default salutations are preserved when
+  environment layers append new values.
 - **Shell and Windows automation**: provide paired `.sh` and `.cmd` scripts
   highlighting how environment variables, configuration files, and command-line
   overrides interact. Include examples covering default configuration,

--- a/examples/hello_world/tests/features/global_parameters.feature
+++ b/examples/hello_world/tests/features/global_parameters.feature
@@ -109,5 +109,6 @@ Feature: Global parameters govern greetings
     Then the declarative globals recipient is "Cli"
     And the declarative globals salutations are:
       """
+      Hi
       Env
       """

--- a/ortho_config/tests/declarative_merge.rs
+++ b/ortho_config/tests/declarative_merge.rs
@@ -13,6 +13,16 @@ struct DeclarativeSample {
     flag: bool,
 }
 
+#[derive(Debug, Deserialize, OrthoConfig)]
+struct AppendSample {
+    values: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, OrthoConfig)]
+struct OptionalSample {
+    flag: Option<String>,
+}
+
 fn compose_layers(
     defaults: serde_json::Value,
     environment: serde_json::Value,
@@ -92,6 +102,35 @@ fn merge_value_merges_absent_target_key() {
     merge_value(&mut target, layer);
     assert_eq!(target, json!({ "new_key": "new_value", "another": 123 }));
 }
+
+#[rstest]
+fn merge_layers_append_vectors() {
+    let mut composer = MergeComposer::new();
+    composer.push_defaults(json!({ "values": ["default"] }));
+    composer.push_environment(json!({ "values": ["env"] }));
+    composer.push_cli(json!({ "values": ["cli"] }));
+
+    let config = AppendSample::merge_from_layers(composer.layers()).expect("merge succeeds");
+    assert_eq!(
+        config.values,
+        vec![
+            String::from("default"),
+            String::from("env"),
+            String::from("cli"),
+        ]
+    ); // order reflects precedence layering
+}
+
+#[rstest]
+fn merge_layers_respect_option_nulls() {
+    let mut composer = MergeComposer::new();
+    composer.push_defaults(json!({ "flag": "present" }));
+    composer.push_environment(json!({ "flag": null }));
+
+    let config = OptionalSample::merge_from_layers(composer.layers()).expect("merge succeeds");
+    assert!(config.flag.is_none());
+}
+
 
 #[rstest]
 fn merge_from_layers_accepts_file_layers() {

--- a/ortho_config_macros/src/derive/build/override.rs
+++ b/ortho_config_macros/src/derive/build/override.rs
@@ -8,10 +8,10 @@ use syn::{Ident, Type};
 
 use crate::derive::parse::{FieldAttrs, MergeStrategy, vec_inner};
 
-pub(crate) fn collect_append_fields<'a>(
-    fields: &'a [syn::Field],
-    field_attrs: &'a [FieldAttrs],
-) -> syn::Result<Vec<(Ident, &'a Type)>> {
+pub(crate) fn collect_append_fields(
+    fields: &[syn::Field],
+    field_attrs: &[FieldAttrs],
+) -> syn::Result<Vec<(Ident, Type)>> {
     let mut append_fields = Vec::new();
     for (field, attrs) in fields.iter().zip(field_attrs) {
         let Some(name) = field.ident.clone() else {
@@ -31,7 +31,7 @@ pub(crate) fn collect_append_fields<'a>(
             continue;
         };
         if strategy == MergeStrategy::Append {
-            append_fields.push((name, vec_ty));
+            append_fields.push((name, (*vec_ty).clone()));
         }
     }
     Ok(append_fields)
@@ -39,7 +39,7 @@ pub(crate) fn collect_append_fields<'a>(
 
 pub(crate) fn build_override_struct(
     base: &Ident,
-    fields: &[(Ident, &Type)],
+    fields: &[(Ident, Type)],
 ) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
     let ident = format_ident!("__{}VecOverride", base);
     let struct_fields = fields.iter().map(|(name, ty)| {
@@ -59,7 +59,7 @@ pub(crate) fn build_override_struct(
     (ts, init_ts)
 }
 
-pub(crate) fn build_append_logic(fields: &[(Ident, &Type)]) -> proc_macro2::TokenStream {
+pub(crate) fn build_append_logic(fields: &[(Ident, Type)]) -> proc_macro2::TokenStream {
     if fields.is_empty() {
         return quote! {};
     }

--- a/ortho_config_macros/src/lib.rs
+++ b/ortho_config_macros/src/lib.rs
@@ -60,6 +60,7 @@ struct MacroComponents {
     override_struct_ts: proc_macro2::TokenStream,
     load_impl: proc_macro2::TokenStream,
     prefix_fn: Option<proc_macro2::TokenStream>,
+    append_fields: Vec<(syn::Ident, syn::Type)>,
 }
 
 #[derive(Clone, Copy)]
@@ -271,6 +272,7 @@ fn build_macro_components(
         override_struct_ts,
         load_impl,
         prefix_fn,
+        append_fields,
     })
 }
 
@@ -398,11 +400,22 @@ fn generate_ortho_impl(
     }
 }
 
-fn generate_declarative_state_struct(state_ident: &syn::Ident) -> proc_macro2::TokenStream {
+fn generate_declarative_state_struct(
+    state_ident: &syn::Ident,
+    append_fields: &[(syn::Ident, syn::Type)],
+) -> proc_macro2::TokenStream {
+    let append_state_fields = append_fields.iter().map(|(name, _ty)| {
+        let state_field_ident = format_ident!("append_{}", name);
+        quote! {
+            #state_field_ident: Option<Vec<ortho_config::serde_json::Value>>
+        }
+    });
+
     quote! {
         #[derive(Default)]
         struct #state_ident {
             value: ortho_config::serde_json::Value,
+            #( #append_state_fields, )*
         }
     }
 }
@@ -410,13 +423,55 @@ fn generate_declarative_state_struct(state_ident: &syn::Ident) -> proc_macro2::T
 fn generate_declarative_merge_impl(
     state_ident: &syn::Ident,
     config_ident: &syn::Ident,
+    append_fields: &[(syn::Ident, syn::Type)],
 ) -> proc_macro2::TokenStream {
+    let append_logic = append_fields.iter().map(|(field_ident, _ty)| {
+        let state_field_ident = format_ident!("append_{}", field_ident);
+        let field_name = field_ident.to_string();
+        quote! {
+            if let Some(value) = map.remove(#field_name) {
+                let mut incoming: Vec<ortho_config::serde_json::Value> =
+                    ortho_config::serde_json::from_value(value).into_ortho()?;
+                let acc = self.#state_field_ident.get_or_insert_with(Vec::new);
+                acc.append(&mut incoming);
+                let aggregated = ortho_config::serde_json::Value::Array(acc.clone());
+                let mut object = ortho_config::serde_json::Map::new();
+                object.insert(String::from(#field_name), aggregated);
+                ortho_config::declarative::merge_value(
+                    &mut self.value,
+                    ortho_config::serde_json::Value::Object(object),
+                );
+            }
+        }
+    });
+
+    let append_logic_tokens: Vec<_> = append_logic.collect();
+    let use_result_ext = if append_fields.is_empty() {
+        quote! {}
+    } else {
+        quote! { use ortho_config::OrthoResultExt as _; }
+    };
+
     quote! {
         impl ortho_config::DeclarativeMerge for #state_ident {
             type Output = #config_ident;
 
             fn merge_layer(&mut self, layer: ortho_config::MergeLayer<'_>) -> ortho_config::OrthoResult<()> {
-                ortho_config::declarative::merge_value(&mut self.value, layer.into_value());
+                #use_result_ext
+                match layer.into_value() {
+                    ortho_config::serde_json::Value::Object(mut map) => {
+                        #( #append_logic_tokens )*
+                        if !map.is_empty() {
+                            ortho_config::declarative::merge_value(
+                                &mut self.value,
+                                ortho_config::serde_json::Value::Object(map),
+                            );
+                        }
+                    }
+                    other => {
+                        ortho_config::declarative::merge_value(&mut self.value, other);
+                    }
+                }
                 Ok(())
             }
 
@@ -475,10 +530,13 @@ fn generate_declarative_merge_from_layers_fn(
     }
 }
 
-fn generate_declarative_impl(config_ident: &syn::Ident) -> proc_macro2::TokenStream {
+fn generate_declarative_impl(
+    config_ident: &syn::Ident,
+    append_fields: &[(syn::Ident, syn::Type)],
+) -> proc_macro2::TokenStream {
     let state_ident = format_ident!("__{}DeclarativeMergeState", config_ident);
-    let state_struct = generate_declarative_state_struct(&state_ident);
-    let merge_impl = generate_declarative_merge_impl(&state_ident, config_ident);
+    let state_struct = generate_declarative_state_struct(&state_ident, append_fields);
+    let merge_impl = generate_declarative_merge_impl(&state_ident, config_ident, append_fields);
     let merge_fn = generate_declarative_merge_from_layers_fn(&state_ident, config_ident);
 
     quote! {
@@ -495,7 +553,7 @@ fn generate_trait_implementation(
     let cli_struct = generate_cli_struct(components);
     let defaults_struct = generate_defaults_struct(components);
     let ortho_impl = generate_ortho_impl(config_ident, components);
-    let declarative_impl = generate_declarative_impl(config_ident);
+    let declarative_impl = generate_declarative_impl(config_ident, &components.append_fields);
     quote! {
         #cli_struct
         #defaults_struct
@@ -530,6 +588,7 @@ mod tests {
             override_struct_ts: quote! {},
             load_impl: quote! {},
             prefix_fn: None,
+            append_fields: Vec::new(),
         }
     }
 
@@ -595,7 +654,7 @@ mod tests {
     #[rstest]
     fn generate_declarative_state_struct_emits_storage() {
         let state_ident = parse_str("__SampleDeclarativeMergeState").expect("state ident");
-        let tokens = generate_declarative_state_struct(&state_ident);
+        let tokens = generate_declarative_state_struct(&state_ident, &[]);
         let expected = quote! {
             #[derive(Default)]
             struct __SampleDeclarativeMergeState {
@@ -606,10 +665,28 @@ mod tests {
     }
 
     #[rstest]
+    fn generate_declarative_state_struct_includes_append_fields() {
+        let state_ident = parse_str("__SampleDeclarativeMergeState").expect("state ident");
+        let append_fields = vec![(
+            parse_str("items").expect("field ident"),
+            parse_str("String").expect("field type"),
+        )];
+        let tokens = generate_declarative_state_struct(&state_ident, &append_fields);
+        let expected = quote! {
+            #[derive(Default)]
+            struct __SampleDeclarativeMergeState {
+                value: ortho_config::serde_json::Value,
+                append_items: Option<Vec<ortho_config::serde_json::Value>>,
+            }
+        };
+        assert_eq!(tokens.to_string(), expected.to_string());
+    }
+
+    #[rstest]
     fn generate_declarative_merge_impl_emits_trait_impl() {
         let state_ident = parse_str("__SampleDeclarativeMergeState").expect("state ident");
         let config_ident = parse_str("Sample").expect("config ident");
-        let tokens = generate_declarative_merge_impl(&state_ident, &config_ident);
+        let tokens = generate_declarative_merge_impl(&state_ident, &config_ident, &[]);
         let expected = quote! {
             impl ortho_config::DeclarativeMerge for __SampleDeclarativeMergeState {
                 type Output = Sample;
@@ -618,7 +695,19 @@ mod tests {
                     &mut self,
                     layer: ortho_config::MergeLayer<'_>
                 ) -> ortho_config::OrthoResult<()> {
-                    ortho_config::declarative::merge_value(&mut self.value, layer.into_value());
+                    match layer.into_value() {
+                        ortho_config::serde_json::Value::Object(mut map) => {
+                            if !map.is_empty() {
+                                ortho_config::declarative::merge_value(
+                                    &mut self.value,
+                                    ortho_config::serde_json::Value::Object(map),
+                                );
+                            }
+                        }
+                        other => {
+                            ortho_config::declarative::merge_value(&mut self.value, other);
+                        }
+                    }
                     Ok(())
                 }
 
@@ -628,6 +717,22 @@ mod tests {
             }
         };
         assert_eq!(tokens.to_string(), expected.to_string());
+    }
+
+    #[rstest]
+    fn generate_declarative_merge_impl_handles_append_fields() {
+        let state_ident = parse_str("__SampleDeclarativeMergeState").expect("state ident");
+        let config_ident = parse_str("Sample").expect("config ident");
+        let append_fields = vec![(
+            parse_str("items").expect("field ident"),
+            parse_str("String").expect("field type"),
+        )];
+        let tokens = generate_declarative_merge_impl(&state_ident, &config_ident, &append_fields);
+        let rendered = tokens.to_string();
+        assert!(rendered.contains("append_items"));
+        assert!(rendered.contains("OrthoResultExt"));
+        assert!(rendered.contains("serde_json :: Map"));
+        assert!(rendered.contains("Value :: Array"));
     }
 
     #[rstest]
@@ -685,7 +790,7 @@ mod tests {
     #[rstest]
     fn generate_declarative_impl_composes_helpers() {
         let config_ident = parse_str("Sample").expect("config ident");
-        let tokens = generate_declarative_impl(&config_ident);
+        let tokens = generate_declarative_impl(&config_ident, &[]);
         let expected = quote! {
             #[derive(Default)]
             struct __SampleDeclarativeMergeState {
@@ -699,7 +804,19 @@ mod tests {
                     &mut self,
                     layer: ortho_config::MergeLayer<'_>
                 ) -> ortho_config::OrthoResult<()> {
-                    ortho_config::declarative::merge_value(&mut self.value, layer.into_value());
+                    match layer.into_value() {
+                        ortho_config::serde_json::Value::Object(mut map) => {
+                            if !map.is_empty() {
+                                ortho_config::declarative::merge_value(
+                                    &mut self.value,
+                                    ortho_config::serde_json::Value::Object(map),
+                                );
+                            }
+                        }
+                        other => {
+                            ortho_config::declarative::merge_value(&mut self.value, other);
+                        }
+                    }
                     Ok(())
                 }
 


### PR DESCRIPTION
## Summary
- clarify the MergeLayer description in `docs/design.md` with improved grammar and wrapping for readability
- fix user guide sentences that join independent clauses with "so" by adding the required commas in both affected sections

## Testing
- make fmt
- make check-fmt
- make lint
- make test
- make markdownlint
- make nixie

------
https://chatgpt.com/codex/tasks/task_e_68f4384479908322a3f664e4a42bed86

## Summary by Sourcery

Support append merge strategy for vector fields by capturing JSON arrays in per-field buffers and generating merge logic, update macro code, tests, examples, and documentation, and polish grammar in docs

New Features:
- Introduce vector-append merge strategy in the declarative-merge derive macro, generating per-field append buffers for Vec<T> fields
- Generate merge logic that accumulates JSON array values across layers for fields marked with the append strategy

Bug Fixes:
- Fix missing commas in user guide sentences joining independent clauses

Enhancements:
- Extend declarative merge code generation to pass `append_fields` through state struct, merge impl, and trait implementation
- Adjust override builder to clone vector element types instead of referencing them

Documentation:
- Clarify design documentation around `MergeLayer` and append buffers with improved grammar and wrapping
- Update user guide, example README, and roadmap to describe vector append semantics and correct punctuation

Tests:
- Add unit tests for vector append behavior and optional-field null merging in declarative merges