### PR TITLE
Handle platform-specific XDG discovery lint

### DIFF
--- a/ortho_config/tests/subcommand.rs
+++ b/ortho_config/tests/subcommand.rs
@@ -5,6 +5,7 @@ use anyhow::{Result, anyhow, ensure};
 mod util;
 
 use clap::Parser;
+#[cfg(any(unix, target_os = "redox"))]
 use figment::Error as FigmentError;
 use ortho_config::OrthoConfig;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary
- split `push_default_xdg` into Unix/Redox and non-Unix variants so we can appease Clippy without sacrificing behaviour
- keep the Unix helper delegating to `push_for_bases` while providing a const stub for platforms that do not use XDG defaults

## Testing
- make check-fmt
- make lint
- make test *(fails: known hello_world message plan expectations due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcf39598608322bed860398cd86ff1

## Summary by Sourcery

Enhancements:
- Split push_default_xdg into Unix/Redox and non-Unix variants, adding a const no-op stub on non-Unix platforms to satisfy Clippy lints