### PR TITLE
Document serde-saphyr migration roadmap tasks

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -251,6 +251,32 @@ references the relevant design guidance.
     configuration in one call, eliminating the repetitive `match` scaffolding
     in `hello_world`. [[Feedback](feedback-from-hello-world-example.md)]
 
+- [ ] **Replace `serde_yaml` with `serde-saphyr` for YAML parsing**
+  [[ADR-001](adr-001-replace-serde-yaml-with-serde-saphyr.md)]
+
+  - [ ] Update `ortho_config/Cargo.toml` features to remove the indirect
+    `figment/yaml` dependency, add optional `serde_saphyr` and `serde_json`
+    entries, and wire the YAML feature to these crates.
+    [[ADR-001](adr-001-replace-serde-yaml-with-serde-saphyr.md)]
+
+  - [ ] Implement the `SaphyrYaml` provider in `ortho_config/src/file.rs` that
+    reads YAML files, deserialises them with `serde-saphyr`, and converts the
+    output into `figment::value::Dict`.
+    [[ADR-001](adr-001-replace-serde-yaml-with-serde-saphyr.md)]
+
+  - [ ] Switch `parse_config_by_format` to use the new provider for `.yaml` and
+    `.yml` files, ensuring feature-gated builds continue to compile.
+    [[ADR-001](adr-001-replace-serde-yaml-with-serde-saphyr.md)]
+
+  - [ ] Extend `ortho_config/src/file/file_tests.rs` with YAML 1.2 compliance
+    coverage (`key: yes` remains a string, duplicates are rejected) and add
+    failure-path tests for malformed YAML inputs.
+    [[ADR-001](adr-001-replace-serde-yaml-with-serde-saphyr.md)]
+
+  - [ ] Document the migration in `CHANGELOG.md`, update user guides to call out
+    YAML 1.2 compliance, and plan a minor version bump for the release.
+    [[ADR-001](adr-001-replace-serde-yaml-with-serde-saphyr.md)]
+
 - [ ] **Address future enhancements**
 
   - [ ] Explore asynchronous loading of configuration files and environment


### PR DESCRIPTION
## Summary
- add roadmap tasks covering the serde-saphyr migration plan
- outline dependency, provider, testing, and documentation updates linked to ADR-001

## Testing
- make fmt
- make markdownlint

------
https://chatgpt.com/codex/tasks/task_e_68fd56a923b483228de24220ae4d6ded

## Summary by Sourcery

Documentation:
- Add detailed roadmap tasks for migrating YAML parsing from serde_yaml to serde-saphyr under ADR-001, covering dependency configuration, provider implementation, parser switch, compliance tests, documentation updates, and version bump planning.