### PR TITLE
Pin shared-actions SHAs and add coverage artefact suffix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@ebbaaa0d7a776ec3187f3940667e5c7c9379cdf5
+        uses: leynos/shared-actions/.github/actions/setup-rust@b3003053406da454154ac87c5c5f487fe5ff8cd8
 
       - name: Install bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76  # v2
@@ -65,25 +65,27 @@ jobs:
         run: make lint
 
       - name: Test and Measure Coverage (with serde_saphyr)
-        uses: leynos/shared-actions/.github/actions/generate-coverage@ebbaaa0d7a776ec3187f3940667e5c7c9379cdf5
+        uses: leynos/shared-actions/.github/actions/generate-coverage@b3003053406da454154ac87c5c5f487fe5ff8cd8
         with:
           output-path: lcov.info
           format: lcov
           features: serde_json toml json5 yaml
+          artefact-name-suffix: serde-saphyr
 
       - name: Test and Measure Coverage (without serde_saphyr)
-        uses: leynos/shared-actions/.github/actions/generate-coverage@ebbaaa0d7a776ec3187f3940667e5c7c9379cdf5
+        uses: leynos/shared-actions/.github/actions/generate-coverage@b3003053406da454154ac87c5c5f487fe5ff8cd8
         with:
           output-path: lcov.info
           format: lcov
           features: serde_json toml json5
+          artefact-name-suffix: no-serde-saphyr
 
       - name: Publish dry run
         run: make publish-check
 
       - name: Upload coverage data to CodeScene
         if: ${{ matrix.coverage && env.CS_ACCESS_TOKEN && vars.CODESCENE_CLI_SHA256 }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@ebbaaa0d7a776ec3187f3940667e5c7c9379cdf5
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@b3003053406da454154ac87c5c5f487fe5ff8cd8
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump shared-actions SHAs in CI workflow to latest
- Add unique artefact suffixes for coverage reports to differentiate serde_saphyr variants

## Changes
### CI Workflow Updates
- Update Setup Rust action SHA from the previous commit to the latest: leynos/shared-actions/.github/actions/setup-rust@b3003053406da454154ac87c5c5f487fe5ff8cd8
- Update Generate Coverage action SHA to the latest: leynos/shared-actions/.github/actions/generate-coverage@b3003053406da454154ac87c5c5f487fe5ff8cd8
- Update Upload CodeScene Coverage action SHA to the latest: leynos/shared-actions/.github/actions/upload-codescene-coverage@b3003053406da454154ac87c5c5f487fe5ff8cd8

### Artefact Suffixes for Coverage
- Test and Measure Coverage (with serde_saphyr): add artefact-name-suffix: serde-saphyr
- Test and Measure Coverage (without serde_saphyr): add artefact-name-suffix: no-serde-saphyr

## Rationale
- Align CI with the latest shared-actions SHAs to pick up recent fixes and improvements.
- Introduce distinct artefact suffixes for coverage runs to uniquely identify results for serde-enabled vs. non-serde variants, preventing artefact name collisions.

## Testing Plan
- Push branch terragon/update-sha-and-artefact-name-suffix-ml0ky8 and monitor CI:
  - Ensure all steps run with the updated SHAs.
  - Verify coverage artefacts are generated with suffixes: serde-saphyr and no-serde-saphyr.
  - Confirm CodeScene coverage upload uses the updated action SHA.

## Notes
- No functional changes to code; CI configuration updates only.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b2777352-4346-46b2-b83b-6eecc4ffb0bb

## Summary by Sourcery

Update CI workflows to use the latest shared-actions SHAs and introduce unique artefact suffixes for serde-enabled and non-serde coverage reports

Enhancements:
- Add distinct artefact-name-suffix values for serde_saphyr and non-serde coverage runs

CI:
- Pin setup-rust, generate-coverage, and upload-codescene-coverage shared-actions to their latest SHAs