### PR TITLE
Streamline subcommand overrides and unify merge errors

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -153,6 +153,10 @@ This design removes Figment from the public API. Applications call the new
 disappear; their functionality is subsumed by `MergeLayer`. Failures inside
 `merge_layer` immediately map to `OrthoError::Merge`, so downstream binaries no
 longer wrap Figment errors by hand.[^hello-world-feedback]
+`declarative::from_value` now wraps `serde_json::Error` instances in
+lightweight `figment::Error` values before constructing `OrthoError::Merge`,
+keeping merge-time failures aligned with the CLI merge helpers even when
+configuration layers are supplied by bespoke loaders.
 
 Deriving `DeclarativeMerge` keeps configuration structs declarative. Each field
 expands to a match arm that decides how to overlay the incoming value. Scalars

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -234,7 +234,7 @@ references the relevant design guidance.
 
 - [ ] **Streamline subcommand configuration overrides**
 
-  - [ ] Route merge failures through `OrthoError::Merge` so binaries rely on a
+  - [x] Route merge failures through `OrthoError::Merge` so binaries rely on a
     single shared error surface when combining loaders.
     [[Feedback](feedback-from-hello-world-example.md)]
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -857,6 +857,9 @@ small extension traits:
   `OrthoResult<T>` when `E: Into<OrthoError>` (e.g., `serde_json::Error`).
 - `OrthoMergeExt::into_ortho_merge()` converts `Result<T, figment::Error>`
   into `OrthoResult<T>` as `OrthoError::Merge`.
+- `declarative::from_value` wraps `serde_json::Error` values in
+  `OrthoError::Merge`, keeping `merge_from_layers` failures aligned with
+  subcommand merge helpers.
 - `IntoFigmentError::into_figment()` converts `Arc<OrthoError>` (or
   `&Arc<OrthoError>`) into `figment::Error` for interop in tests or adapters,
   cloning the inner error to preserve structured details where possible.

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -40,6 +40,10 @@ production-ready complexity.
   driving a behavioural scenario that composes JSON-described layers into
   `GlobalArgs`, asserting that default salutations are preserved when
   environment layers append new values.
+- **Unified merge errors**: both the derive-generated loaders and the
+  subcommand helpers now surface merge-time failures as `OrthoError::Merge`, so
+  the binary reports a single variant when globals and subcommands disagree
+  during configuration composition.
 - **Localized help text**: ship a `DemoLocalizer` backed by
 `FluentLocalizer`, layer the example’s bundled catalogue over `ortho_config`’s
 defaults, and thread it through `CommandLine::command().localize(&localizer)`

--- a/examples/hello_world/src/cli/config_loading.rs
+++ b/examples/hello_world/src/cli/config_loading.rs
@@ -1,7 +1,5 @@
 //! Helpers that expose configuration file overrides for subcommands.
 
-use std::sync::Arc;
-
 use camino::Utf8PathBuf;
 use ortho_config::MergeLayer;
 
@@ -18,8 +16,8 @@ pub(crate) fn load_config_overrides_with_layer(
 
     let path = layer.path().map(camino::Utf8PathBuf::from);
     let value = layer.into_value();
-    let overrides: FileOverrides = ortho_config::serde_json::from_value(value)
-        .map_err(|err| HelloWorldError::Configuration(Arc::new(err.into())))?;
+    let overrides =
+        ortho_config::declarative::from_value(value).map_err(HelloWorldError::Configuration)?;
     Ok(Some((overrides, path)))
 }
 

--- a/ortho_config/tests/features/merge_errors.feature
+++ b/ortho_config/tests/features/merge_errors.feature
@@ -1,0 +1,5 @@
+Feature: Merge errors surface consistently
+  Scenario: Merge failures use the shared merge error surface
+    Given an invalid CLI merge layer for rules
+    When the rules configuration is merged
+    Then a merge error is returned

--- a/ortho_config/tests/merge_error_variants.rs
+++ b/ortho_config/tests/merge_error_variants.rs
@@ -1,0 +1,38 @@
+//! Verifies merge-time failures surface as `OrthoError::Merge`.
+
+use ortho_config::{MergeComposer, OrthoConfig, OrthoError, declarative::LayerComposition};
+use rstest::rstest;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, OrthoConfig, Default, PartialEq, Eq)]
+#[ortho_config(prefix = "FAIL_")]
+struct MergeFailureConfig {
+    #[ortho_config(default = 7)]
+    level: u8,
+}
+
+#[rstest]
+fn merge_from_layers_reports_merge_error() {
+    let mut composer = MergeComposer::new();
+    composer.push_defaults(ortho_config::serde_json::json!({ "level": 1 }));
+    composer.push_cli(ortho_config::serde_json::json!({ "level": "loud" }));
+
+    let err = MergeFailureConfig::merge_from_layers(composer.layers())
+        .expect_err("expected merge to fail");
+
+    assert!(matches!(err.as_ref(), OrthoError::Merge { .. }));
+}
+
+#[rstest]
+fn layer_composition_propagates_merge_error() {
+    let mut composer = MergeComposer::new();
+    composer.push_defaults(ortho_config::serde_json::json!({ "level": 1 }));
+    composer.push_cli(ortho_config::serde_json::json!({ "level": "loud" }));
+
+    let composition = LayerComposition::new(composer.layers(), Vec::new());
+    let err = composition
+        .into_merge_result(MergeFailureConfig::merge_from_layers)
+        .expect_err("expected composed merge to fail");
+
+    assert!(matches!(err.as_ref(), OrthoError::Merge { .. }));
+}

--- a/ortho_config/tests/rstest_bdd/behaviour/scenarios.rs
+++ b/ortho_config/tests/rstest_bdd/behaviour/scenarios.rs
@@ -13,3 +13,4 @@ scenarios!("tests/features/ignore_patterns.feature");
 scenarios!("tests/features/subcommand.feature");
 scenarios!("tests/features/localizer.feature");
 scenarios!("tests/features/merge_composer.feature");
+scenarios!("tests/features/merge_errors.feature");

--- a/ortho_config/tests/rstest_bdd/behaviour/steps/merge_error_steps.rs
+++ b/ortho_config/tests/rstest_bdd/behaviour/steps/merge_error_steps.rs
@@ -1,0 +1,40 @@
+//! Steps asserting merge failures surface as `OrthoError::Merge`.
+
+use crate::fixtures::{MergeErrorContext, RulesConfig};
+use anyhow::{Result, anyhow, ensure};
+use ortho_config::{MergeComposer, OrthoError};
+use rstest_bdd_macros::{given, then, when};
+
+#[given("an invalid CLI merge layer for rules")]
+fn invalid_cli_layer(merge_error_context: &MergeErrorContext) -> Result<()> {
+    let mut composer = MergeComposer::new();
+    composer.push_defaults(ortho_config::serde_json::json!({ "rules": ["ok"] }));
+    composer.push_cli(ortho_config::serde_json::json!({ "rules": { "broken": true } }));
+    merge_error_context.layers.set(composer.layers());
+    Ok(())
+}
+
+#[when("the rules configuration is merged")]
+fn merge_rules(merge_error_context: &MergeErrorContext) -> Result<()> {
+    let layers = merge_error_context
+        .layers
+        .with_ref(|layers| layers.clone())
+        .ok_or_else(|| anyhow!("merge layers missing"))?;
+    let result = RulesConfig::merge_from_layers(layers);
+    merge_error_context.result.set(result);
+    Ok(())
+}
+
+#[then("a merge error is returned")]
+fn assert_merge_error(merge_error_context: &MergeErrorContext) -> Result<()> {
+    let err = merge_error_context
+        .result
+        .take()
+        .ok_or_else(|| anyhow!("merge result missing"))?
+        .expect_err("expected merge to fail");
+    ensure!(
+        matches!(err.as_ref(), OrthoError::Merge { .. }),
+        "unexpected error variant: {err:?}"
+    );
+    Ok(())
+}

--- a/ortho_config/tests/rstest_bdd/behaviour/steps/mod.rs
+++ b/ortho_config/tests/rstest_bdd/behaviour/steps/mod.rs
@@ -9,5 +9,6 @@ pub mod extends_steps;
 pub mod flatten_steps;
 pub mod ignore_steps;
 pub mod localizer_steps;
+pub mod merge_error_steps;
 pub mod merge_composer_steps;
 pub mod subcommand_steps;

--- a/ortho_config/tests/rstest_bdd/fixtures.rs
+++ b/ortho_config/tests/rstest_bdd/fixtures.rs
@@ -51,6 +51,13 @@ pub struct ErrorContext {
     pub agg_result: Slot<ortho_config::OrthoResult<ErrorConfig>>,
 }
 
+/// Scenario state for merge error surface scenarios.
+#[derive(Debug, Default, ScenarioState)]
+pub struct MergeErrorContext {
+    pub layers: Slot<Vec<MergeLayer<'static>>>,
+    pub result: Slot<ortho_config::OrthoResult<RulesConfig>>,
+}
+
 /// Scenario state for flattened CLI merging scenarios.
 #[derive(Debug, Default, ScenarioState)]
 pub struct FlattenContext {
@@ -154,6 +161,12 @@ pub fn composer_context() -> ComposerContext {
 #[fixture]
 pub fn error_context() -> ErrorContext {
     ErrorContext::default()
+}
+
+/// Provides a clean merge error context so merge surface steps can share state.
+#[fixture]
+pub fn merge_error_context() -> MergeErrorContext {
+    MergeErrorContext::default()
 }
 
 /// Provides a clean flatten context for flattened CLI scenarios.

--- a/ortho_config_macros/src/derive/generate/declarative/mod.rs
+++ b/ortho_config_macros/src/derive/generate/declarative/mod.rs
@@ -68,7 +68,7 @@ fn append_collection_tokens(strategies: &CollectionStrategies) -> CollectionToke
                             other => ortho_config::serde_json::Value::Array(vec![other]),
                         };
                         let incoming: Vec<_> =
-                            ortho_config::serde_json::from_value(normalised).into_ortho()?;
+                            ortho_config::declarative::from_value(normalised)?;
                         let acc = self
                             .#state_field_ident
                             .get_or_insert_with(Default::default);


### PR DESCRIPTION
## Summary
- Unifies how configuration merge failures surface across loaders by routing through a single `OrthoError::Merge` surface.
- Switches to declarative-based value loading for subcommand overrides to align with merge-time error handling.
- Introduces tests and docs updates to reflect the unified error surface.

## Changes
### Core functionality
- Route merge failures through `OrthoError::Merge` for binaries to share a single error surface when combining loaders.
- Replace ad-hoc serde_json error handling in subcommand override loading with `declarative::from_value` to standardize error shaping.
- Update error construction to wrap serde_json errors into a descriptive `figment::Error` and then into `OrthoError::Merge`.

### CLI loading path
- `examples/hello_world/src/cli/config_loading.rs` now uses `ortho_config::declarative::from_value(value)` when loading overrides, instead of manual serde_json error wrapping.

### Declarative/macros
- `ortho_config/src/declarative.rs`: `from_value` now converts JSON deserialization errors into a unified `OrthoError::Merge` with a clear message, preserving line/column information when available.
- `ortho_config_macros/src/derive/generate/declarative/mod.rs`: updated to invoke `declarative::from_value(...)` instead of converting to an intermediate `into_ortho()` path.

### Tests and fixtures
- New tests to verify the unified merge error surface:
  - `ortho_config/tests/features/merge_errors.feature`
  - `ortho_config/tests/merge_error_variants.rs`
  - BDD-style steps: `ortho_config/tests/rstest_bdd/behaviour/steps/merge_error_steps.rs`
  - BDD test scaffolding: `ortho_config/tests/rstest_bdd/fixtures.rs` (merge error context)
- Extend scenarios to include merge error surface checks.

### Documentation
- `docs/design.md`: document that `declarative::from_value` wraps `serde_json::Error` into lightweight `figment::Error` before constructing `OrthoError::Merge`.
- `docs/roadmap.md`: mark the subcommand overrides streamline item as completed.
- `docs/users-guide.md`: note that `declarative::from_value` aligns merge failures with the merge helpers; subcommand and loader failures share the same surface.
- `examples/hello_world/README.md`: describe unified merge error surface for subcommands and globals.

### Examples
- `examples/hello_world/README.md` updated with a note about unified merge errors across loaders and subcommands.

## Test plan
- [x] Run unit tests for `ortho_config` and the declarative merge paths.
- [x] Run new merge error surface tests:
  - Feature: Merge errors surface consistently
  - Variants asserting that errors are of `OrthoError::Merge` type
- [x] Execute the RSTest BDD suite including new merge error scenarios:
  - Load invalid CLI merge layers and verify a merge error is produced
  - Ensure error propagation through layered composition surfaces `OrthoError::Merge`
- [x] Validate example workload in `hello_world` continues to surface a single merge error variant when conflicts occur.

## Migration and compatibility
- No public API removal; error surface behavior is unified for merge failures. Existing code that relied on `serde_json` error handling paths will now route through `declarative::from_value`, yielding a consistent `OrthoError::Merge` for deserialization failures during merges.

## How to test locally
- cargo test -p ortho_config
- Run the BDD tests suite under `ortho_config/tests/rstest_bdd` to verify the merge error surface remains consistent across scenarios.

If you want me to tailor the body further (e.g., add a short “Why this change” section or include a quick step-by-step test guide), I can adjust accordingly.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/13cca4af-2f57-42c3-847e-619fa64c7808

## Summary by Sourcery

Unify merge-time error handling for declarative configuration loading and subcommand overrides so all merge failures surface as `OrthoError::Merge`.

Enhancements:
- Route `declarative::from_value` and macro-generated loaders through a shared `OrthoError::Merge` error surface, preserving JSON location details.
- Align the hello_world example’s subcommand override loading with declarative merge error handling for consistent CLI error reporting.

Documentation:
- Document the unified merge error surface and updated `declarative::from_value` behavior in the design, user guide, roadmap, and hello_world example README.

Tests:
- Add unit and BDD-style tests to verify merge failures are reported as `OrthoError::Merge` across direct merges and layered compositions, including a new merge_errors.feature and supporting fixtures.