### PR TITLE
CI: Bump shared-actions SHA references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@b3003053406da454154ac87c5c5f487fe5ff8cd8
+        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
 
       - name: Install bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76  # v2
@@ -65,7 +65,7 @@ jobs:
         run: make lint
 
       - name: Test and Measure Coverage (with serde_saphyr)
-        uses: leynos/shared-actions/.github/actions/generate-coverage@b3003053406da454154ac87c5c5f487fe5ff8cd8
+        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           output-path: lcov.info
           format: lcov
@@ -73,7 +73,7 @@ jobs:
           artefact-name-suffix: serde-saphyr
 
       - name: Test and Measure Coverage (without serde_saphyr)
-        uses: leynos/shared-actions/.github/actions/generate-coverage@b3003053406da454154ac87c5c5f487fe5ff8cd8
+        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           output-path: lcov.info
           format: lcov
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload coverage data to CodeScene
         if: ${{ matrix.coverage && env.CS_ACCESS_TOKEN && vars.CODESCENE_CLI_SHA256 }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@b3003053406da454154ac87c5c5f487fe5ff8cd8
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Update SHA references for shared-actions in CI workflows to the latest revision (aebb3f5b831102e2a10ef909c83d7d50ea86c332).
- Affects: setup-rust, generate-coverage (with and without serde_saphyr), and upload-codescene-coverage.

## Changes
- .github/workflows/ci.yml:
  - Update SHA for setup-rust from b3003053406da454154ac87c5c5f487fe5ff8cd8 to aebb3f5b831102e2a10ef909c83d7d50ea86c332
  - Update SHA for generate-coverage (serde_saphyr) from b3003053406da454154ac87c5c5f487fe5ff8cd8 to aebb3f5b831102e2a10ef909c83d7d50ea86c332
  - Update SHA for generate-coverage (without serde_saphyr) from b3003053406da454154ac87c5c5f487fe5ff8cd8 to aebb3f5b831102e2a10ef909c83d7d50ea86c332
  - Update SHA for upload-codescene-coverage from b3003053406da454154ac87c5c5f487fe5ff8cd8 to aebb3f5b831102e2a10ef909c83d7d50ea86c332

## Rationale
- Align CI with the latest shared-actions updates to ensure compatibility and receive the newest fixes.

## Test plan
- CI will run on PRs; verify that the workflow logs show the new SHAs being fetched and used.
- After merge, monitor CI runs to confirm all jobs complete successfully.

## Notes
- No code changes were made; this is a maintenance update to CI workflow action references.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/398293f0-eef7-45c5-a439-00d1f066f117

## Summary by Sourcery

Build:
- Refresh pinned SHAs for shared-actions in the main CI workflow to the latest shared-actions commit.