### PR TITLE
Remove thematic breaks before H2 headings in docs

### DIFF
--- a/docs/reliable-testing-in-rust-via-dependency-injection.md
+++ b/docs/reliable-testing-in-rust-via-dependency-injection.md
@@ -23,8 +23,6 @@ dependencies are provided as arguments. The
 set of traits (`Env`, `Clock`, etc.) to implement this pattern for common
 system interactions in Rust.
 
-______________________________________________________________________
-
 ## ✨ Mocking Environment Variables
 
 ### 1. Add `mockable`
@@ -122,8 +120,6 @@ fn main() {
 }
 ```
 
-______________________________________________________________________
-
 ## 🔩 Handling Other Non-Deterministic Dependencies
 
 This dependency injection pattern also applies to other non-deterministic
@@ -187,8 +183,6 @@ mod tests {
 ```
 
 In production, an instance of `RealClock::new()` would be used.
-
-______________________________________________________________________
 
 ## 📌 Key Takeaways
 


### PR DESCRIPTION
## Summary
- Remove extraneous thematic breaks (underscore lines) that appear before level 2 headings in docs/reliable-testing-in-rust-via-dependency-injection.md
- Improves readability and consistency with other docs

## Changes
- **Docs cleanup**: Deleted stray lines consisting of underscores used as thematic breaks before H2 headings
- No content changes to the actual documentation, only formatting cleanup

## Rationale
- The thematic breaks were decorative only and caused unnecessary visual gaps; removing them aligns with project docs style

## Files touched
- docs/reliable-testing-in-rust-via-dependency-injection.md

## Testing
- [x] Open the docs file and verify no stray underline lines precede H2 headings
- [x] Render the markdown to confirm clean headings formatting

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/582cf762-25f0-4968-8ba8-93d972f27d4a

📝 Closes #158

## Summary by Sourcery

Documentation:
- Remove extraneous underscore-based thematic breaks preceding H2 headings in reliable-testing-in-rust-via-dependency-injection.md to improve readability and consistency with other docs.