### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
       - name: Lint
         run: make lint
 
+      - name: Workflow contract tests
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: make test-workflow-contracts
+
       - name: Test and Measure Coverage (with serde_saphyr)
         uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,40 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+# Scheduled runs mutate only files changed within the detection window;
+# manual dispatch runs mutate everything, fanned out across shards. To
+# test a branch, select it in the Actions "Run workflow" control.
+
+on:
+  schedule:
+    - cron: "5 5 * * *" # Daily, 05:05 UTC
+  workflow_dispatch:
+
+# Default the token to no scopes; the job opts in explicitly.
+permissions: {}
+
+# Serialize runs per ref: a dispatch during a scheduled run (or vice
+# versa) queues rather than racing. Runs are informational, so queued
+# runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    with:
+      # Virtual workspace: the library, derive macro, orthohelp cargo
+      # subcommand, and example crates all live in subdirectories, so
+      # the default src/ prefix would miss every workspace member.
+      paths: "cargo-orthohelp/,examples/,ortho_config/,ortho_config_macros/"
+      # Test-support crate and the orthohelp test fixture crate exist
+      # only to exercise other crates' tests; their survivors are noise.
+      exclude-globs: "test_helpers/**,tests/fixtures/**"
+      # Mirror the CI coverage baseline's feature set (serde_json toml
+      # json5 yaml) so feature-gated parsers are tested against mutants.
+      extra-args: "--features serde_json,toml,json5,yaml"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie typecheck python-test-deps publish-check powershell-wrapper-validate FORCE
+.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie typecheck python-test-deps publish-check powershell-wrapper-validate test-workflow-contracts FORCE
 
 CRATE ?= ortho_config
 CARGO ?= cargo
@@ -39,6 +39,9 @@ test: python-test-deps ## Run tests with warnings treated as errors
 
 python-test-deps: ## Ensure Python test dependencies are provisioned
 	$(PYTEST) --version > $(NULL_DEVICE)
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	$(UV) run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 # will match target/debug/libmy_library.rlib and target/release/libmy_library.rlib
 target/%/lib$(CRATE).rlib: FORCE ## Build library in debug or release

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,145 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests;
+ortho-config's caller is declarative configuration. These tests parse
+the caller with PyYAML and pin the contract it must uphold, so drift
+(repointing the pin at a branch, widening permissions, or losing the
+workspace paths, scaffolding excludes, or feature configuration) fails
+CI on the pull request rather than surfacing in a scheduled or manual
+run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The merge commit of leynos/shared-actions PR #319, matching the
+#: estate template (leynos/wireframe#572). Bump the workflow and this
+#: test together.
+PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: The exact caller configuration: workspace member paths (virtual
+#: workspace, so the default src/ prefix covers nothing), test-support
+#: and fixture-crate excludes, and the CI coverage feature set.
+EXPECTED_WITH = {
+    "paths": "cargo-orthohelp/,examples/,ortho_config/,ortho_config_macros/",
+    "exclude-globs": "test_helpers/**,tests/fixtures/**",
+    "extra-args": "--features serde_json,toml,json5,yaml",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; the execution plan documents {PINNED_SHA!r} — "
+        "bump the plan and this test together with the workflow"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "5 5 * * *"}], (
+        f"on.schedule must be the daily 05:05 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes the workspace paths, excludes, and feature args."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert with_block == EXPECTED_WITH, (
+        "jobs.mutation.with must be exactly the documented configuration "
+        f"(workspace paths, scaffolding excludes, CI feature set); expected "
+        f"{EXPECTED_WITH!r}, got {with_block!r}"
+    )


### PR DESCRIPTION
## Summary

This pull request adopts the shared mutation-testing reusable workflow from [leynos/shared-actions](https://github.com/leynos/shared-actions) as a thin caller, pinned to commit `47aea18960d24f33aedc4782ec6b73e365418313`. Runs are informational only: a daily change-detection guard (05:05 UTC) mutates only recently changed files and makes quiet days a cheap no-op, while manual dispatch performs a full run fanned out across shards. Nothing gates pull requests.

## Configuration for this repository

- **`paths: "cargo-orthohelp/,examples/,ortho_config/,ortho_config_macros/"`** — the root manifest is a virtual workspace, so the default `src/` prefix would match nothing; these prefixes cover every mutable workspace member (the library, the derive-macro crate, the `cargo orthohelp` subcommand, and the example crate).
- **`exclude-globs: "test_helpers/**,tests/fixtures/**"`** — the `test_helpers` support crate and the `tests/fixtures/orthohelp_fixture` crate exist only to exercise other crates' tests, so their survivors would be noise.
- **`extra-args: "--features serde_json,toml,json5,yaml"`** — mirrors the union of the CI coverage baseline's feature sets so feature-gated parsers are tested against mutants.

No `extra-crate-dirs` are needed: every crate is a workspace member.

A contract test suite (`tests/workflow_contracts/mutation_testing_test.py`, run via `make test-workflow-contracts`) pins the caller's shape — the SHA pin, least-privilege permissions, per-ref concurrency, the schedule, and the exact `with:` block — so drift fails CI on the pull request rather than surfacing in a scheduled run. The suite is wired into the CI `build-test` job's Ubuntu leg after Lint.

## Validation

- Both workflows parse with PyYAML.
- `actionlint` passes on `mutation-testing.yml`; `ci.yml` carries one pre-existing, unrelated finding (`matrix.coverage` is referenced but never defined in the matrix).
- `make test-workflow-contracts`: 6 passed, including a negative test (repointing the pin at `@v1` fails the SHA assertion; restored to green).

## References

- Caller guide: <https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md>
- Estate template: leynos/wireframe#572
