### PR TITLE
Test the whole workspace against mutants and bump the workflow pin

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2b09d10192627fd6e1034e7c12625dd266b45503
     with:
       # Virtual workspace: the library, derive macro, orthohelp cargo
       # subcommand, and example crates all live in subdirectories, so
@@ -36,5 +36,8 @@ jobs:
       # only to exercise other crates' tests; their survivors are noise.
       exclude-globs: "test_helpers/**,tests/fixtures/**"
       # Mirror the CI coverage baseline's feature set (serde_json toml
-      # json5 yaml) so feature-gated parsers are tested against mutants.
-      extra-args: "--features serde_json,toml,json5,yaml"
+      # json5 yaml) so feature-gated parsers are tested against mutants,
+      # and run the whole workspace's tests against each mutant: the
+      # derive-macro crate's behaviour is exercised by ortho_config's
+      # tests, so package-scoped runs would report false survivors.
+      extra-args: "--features serde_json,toml,json5,yaml --test-workspace=true"

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -22,10 +22,9 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The merge commit of leynos/shared-actions PR #319, matching the
-#: estate template (leynos/wireframe#572). Bump the workflow and this
-#: test together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+#: The leynos/shared-actions commit adding artefact preservation on
+#: timeout. Bump the workflow and this test together.
+PINNED_SHA = "2b09d10192627fd6e1034e7c12625dd266b45503"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
@@ -33,11 +32,13 @@ EXPECTED_USES = (
 
 #: The exact caller configuration: workspace member paths (virtual
 #: workspace, so the default src/ prefix covers nothing), test-support
-#: and fixture-crate excludes, and the CI coverage feature set.
+#: and fixture-crate excludes, and the CI coverage feature set plus
+#: workspace-wide test runs (the derive-macro crate's coverage lives in
+#: ortho_config's tests, so package-scoped runs report false survivors).
 EXPECTED_WITH = {
     "paths": "cargo-orthohelp/,examples/,ortho_config/,ortho_config_macros/",
     "exclude-globs": "test_helpers/**,tests/fixtures/**",
-    "extra-args": "--features serde_json,toml,json5,yaml",
+    "extra-args": "--features serde_json,toml,json5,yaml --test-workspace=true",
 }
 
 


### PR DESCRIPTION
## Summary

Follow-up to #366, applying an estate-wide review finding from rstest-bdd#569: `cargo-mutants` runs only the mutated package's tests by default, so workspace crates whose coverage lives in a dependent crate's tests report false survivors. The `ortho_config_macros` derive-macro crate is exactly this shape — its behaviour is exercised by `ortho_config`'s tests.

## Changes

- Appends ` --test-workspace=true` to `extra-args` (keeping the explicit feature list) so every mutant is tested against the whole workspace's suite. This is safe here because the CI baseline is already workspace-wide: `make test` runs `cargo test` at the virtual workspace root, and the coverage action invokes `cargo llvm-cov --workspace`.
- Bumps the shared-workflow pin from `47aea18960d24f33aedc4782ec6b73e365418313` to `2b09d10192627fd6e1034e7c12625dd266b45503`, which preserves mutation artefacts when a run overruns its budget (leynos/shared-actions#323).
- Updates the contract test's `PINNED_SHA` and expected `extra-args` to match.

## Validation

- `mutation-testing.yml` parses with PyYAML and passes `actionlint`.
- `make test-workflow-contracts`: 6 passed.

## References

- Caller guide: <https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md>
- Estate template: leynos/wireframe#572
