### PR TITLE
Wire CodeScene coverage gate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,23 +108,15 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: make publish-check
 
-      - name: Merge coverage results
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        shell: bash
-        run: >-
-          bun x lcov-result-merger
-          lcov-serde-saphyr.info lcov-no-serde-saphyr.info > lcov.info
-
-      # cs-coverage check diffs the pull request against its merge base and
-      # evaluates changed-line coverage. Run it from the ubuntu leg only so
-      # CodeScene receives one report per commit. The guard lets secret-less
-      # runs (forks) skip rather than fail.
-      - name: Check coverage against CodeScene gates
-        if: ${{ matrix.os == 'ubuntu-latest' && env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
-        with:
-          format: lcov
-          mode: check
-          project-url: https://api.codescene.io/v2/projects/69279
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+      # The `mode: check` CodeScene coverage gate is deliberately not wired
+      # in yet: CodeScene project 69279 has no coverage-gates configuration,
+      # so `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint and chutoro hit the byte-identical error). Add the
+      # gate in a fast-follow PR — merge the two feature-leg reports with
+      # `bun x lcov-result-merger lcov-serde-saphyr.info
+      # lcov-no-serde-saphyr.info > lcov.info`, then run the guarded
+      # `mode: check` step on the ubuntu leg only — once coverage-main.yml
+      # has uploaded to main at least once and the project's coverage gate
+      # is confirmed enabled CodeScene-side.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
       CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
       RUSTFLAGS: -D warnings
       RUSTDOCFLAGS: -D warnings
+      # generate-coverage kills cargo after RUN_RUST_CARGO_WAIT_TIMEOUT
+      # seconds (default 600). The windows coverage run legitimately takes
+      # ~12 min (the compile_fail trybuild test alone is ~200s), and the
+      # 927edd4 action now emits full per-line data, so raise the ceiling.
+      RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
       RUSTFLAGS: -D warnings
       RUSTDOCFLAGS: -D warnings
     strategy:
@@ -24,10 +23,15 @@ jobs:
           - os: windows-latest
     steps:
       - name: Checkout
+        # fetch-depth: 0 makes the pull request's merge base reachable so the
+        # CodeScene changed-line coverage gate (cs-coverage check) can diff
+        # against it.
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 
       - name: Install bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76  # v2
@@ -72,17 +76,21 @@ jobs:
         run: make test-workflow-contracts
 
       - name: Test and Measure Coverage (with serde_saphyr)
-        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        # Broadest feature set, so this leg carries the coverage ratchet
+        # (one baseline per job). Ratchet only on the ubuntu leg, which
+        # compares against the baseline written by coverage-main.yml.
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          output-path: lcov.info
+          output-path: lcov-serde-saphyr.info
           format: lcov
           features: serde_json toml json5 yaml
           artefact-name-suffix: serde-saphyr
+          with-ratchet: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Test and Measure Coverage (without serde_saphyr)
-        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          output-path: lcov.info
+          output-path: lcov-no-serde-saphyr.info
           format: lcov
           features: serde_json toml json5
           artefact-name-suffix: no-serde-saphyr
@@ -95,10 +103,23 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: make publish-check
 
-      - name: Upload coverage data to CodeScene
-        if: ${{ matrix.coverage && env.CS_ACCESS_TOKEN && vars.CODESCENE_CLI_SHA256 }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+      - name: Merge coverage results
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash
+        run: >-
+          bun x lcov-result-merger
+          lcov-serde-saphyr.info lcov-no-serde-saphyr.info > lcov.info
+
+      # cs-coverage check diffs the pull request against its merge base and
+      # evaluates changed-line coverage. Run it from the ubuntu leg only so
+      # CodeScene receives one report per commit. The guard lets secret-less
+      # runs (forks) skip rather than fail.
+      - name: Check coverage against CodeScene gates
+        if: ${{ matrix.os == 'ubuntu-latest' && env.CS_ACCESS_TOKEN }}
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/69279
           access-token: ${{ env.CS_ACCESS_TOKEN }}
           installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,69 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests run the
+# changed-line gate (`cs-coverage check`) in ci.yml instead. This
+# workflow also advances the coverage ratchet baseline: caches saved on
+# main are readable by every pull-request run, so the baseline written
+# here is the one PR ratchet checks compare against.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      RUSTFLAGS: -D warnings
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76  # v2
+        with:
+          bun-version: '1.2.21'
+
+      - name: Test and Measure Coverage (with serde_saphyr)
+        # Broadest feature set, so this leg carries the coverage ratchet
+        # (one baseline per job); it writes the authoritative baseline that
+        # pull-request runs compare against.
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: lcov-serde-saphyr.info
+          format: lcov
+          features: serde_json toml json5 yaml
+          artefact-name-suffix: serde-saphyr-main
+          with-ratchet: 'true'
+
+      - name: Test and Measure Coverage (without serde_saphyr)
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: lcov-no-serde-saphyr.info
+          format: lcov
+          features: serde_json toml json5
+          artefact-name-suffix: no-serde-saphyr-main
+
+      - name: Merge coverage results
+        shell: bash
+        run: >-
+          bun x lcov-result-merger
+          lcov-serde-saphyr.info lcov-no-serde-saphyr.info > lcov.info
+
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -20,6 +20,9 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: -D warnings
       RUSTDOCFLAGS: -D warnings
+      # generate-coverage kills cargo after RUN_RUST_CARGO_WAIT_TIMEOUT
+      # seconds (default 600); the full-suite coverage run needs longer.
+      RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

This onboards ortho-config to the CodeScene coverage rollout, following
the estate recipe (proven on netsuke and
[mxd#362](https://github.com/leynos/mxd/pull/362)) and its revised
policy from the ddlint/chutoro findings.

**The changed-line gate (`mode: check`) is deliberately deferred.**
CodeScene project [69279](https://codescene.io/projects/69279) has no
coverage-gates configuration, so `cs-coverage check` fails every run
with `received project-config isn't valid. Lacks the gates
configuration` — a CodeScene-side per-project setting that cannot be
enabled from CI (ddlint and chutoro hit the byte-identical error). This
PR therefore wires everything *except* the gate: the pin bump,
`fetch-depth: 0`, LCOV coverage generation, the ratchet, main-branch
upload, and secrets. A fast-follow PR adds the `mode: check` step once
`coverage-main.yml` has uploaded from main and the gate is confirmed
enabled CodeScene-side.

The required checks remain `build-test (ubuntu-latest)` and
`build-test (windows-latest)`; no CodeScene check is required in the
branch ruleset.

## Review walkthrough

Changes to
[`ci.yml`](https://github.com/leynos/ortho-config/blob/codescene-coverage-gate/.github/workflows/ci.yml):

- Bump the shared-actions pin for `setup-rust`, `generate-coverage` and
  (in the deferred gate) `upload-codescene-coverage` to
  `927edd45ae77be4251a8a18ca9eb5613a2e32cbd`, which carries the
  `mode: check` gate and the per-line report fix. The
  `mutation-testing.yml` and `dependabot-automerge.yml`
  reusable-workflow pins are left untouched: they are separately
  versioned and Dependabot-managed, and
  `tests/workflow_contracts/mutation_testing_test.py` pins the
  `mutation-cargo.yml` SHA.
- Check out with `fetch-depth: 0` so the PR's merge base is reachable
  for the deferred changed-line gate.
- Give the two feature-leg coverage runs distinct output paths and
  enable the coverage ratchet on the broadest (serde_saphyr) leg, on the
  ubuntu leg only.
- Raise `RUN_RUST_CARGO_WAIT_TIMEOUT` to 1800s: the 927edd4 action kills
  cargo after 600s by default and now emits full per-line data, so the
  windows coverage run (~12 min; the `compile_fail` trybuild test alone
  is ~200s) overran the ceiling. The previous pin had no such cap and
  completed in ~737s.
- Leave a comment where the `mode: check` step will go, describing the
  fast-follow (merge the two reports with `lcov-result-merger`, then the
  guarded gate).

New
[`coverage-main.yml`](https://github.com/leynos/ortho-config/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml):
on push to main it regenerates and merges the same coverage and uploads
it with the default `mode: upload` (CodeScene accepts uploads on
analysed branches regardless of gate config), and advances the ratchet
baseline that PR runs compare against.

`CS_ACCESS_TOKEN` has been set in both the Actions and Dependabot secret
stores.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` on both workflows.
- `make test-workflow-contracts` (6 passed) — unchanged, as this PR does
  not touch `mutation-testing.yml`.
- CI on this PR head confirms both `build-test` legs pass (an earlier
  run proved the wiring end to end: the coverage steps generate LCOV and
  the merge succeeds; the `mode: check` probe returned the expected
  gates-configuration error, which is why it is deferred).
