### PR TITLE
Fix the coverage merge command to produce a populated report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,9 @@ jobs:
       # configuration." — a CodeScene-side per-project setting, not a CI
       # defect (ddlint and chutoro hit the byte-identical error). Add the
       # gate in a fast-follow PR — merge the two feature-leg reports with
-      # `bun x lcov-result-merger lcov-serde-saphyr.info
-      # lcov-no-serde-saphyr.info > lcov.info`, then run the guarded
-      # `mode: check` step on the ubuntu leg only — once coverage-main.yml
-      # has uploaded to main at least once and the project's coverage gate
-      # is confirmed enabled CodeScene-side.
+      # `bun x lcov-result-merger 'lcov-*.info' > lcov.info` (a single glob
+      # pattern; two file paths would make the second the output file and
+      # leave stdout empty), then run the guarded `mode: check` step on the
+      # ubuntu leg only — once coverage-main.yml has uploaded to main at
+      # least once and the project's coverage gate is confirmed enabled
+      # CodeScene-side.

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -57,9 +57,12 @@ jobs:
 
       - name: Merge coverage results
         shell: bash
-        run: >-
-          bun x lcov-result-merger
-          lcov-serde-saphyr.info lcov-no-serde-saphyr.info > lcov.info
+        # lcov-result-merger takes a single glob pattern and an optional
+        # output file; passing two file paths treats the second as the
+        # output and leaves stdout empty. Match both feature-leg reports
+        # with one glob ('lcov-*.info' excludes the lcov.info output) and
+        # write the merged result via stdout.
+        run: bun x lcov-result-merger 'lcov-*.info' > lcov.info
 
       - name: Upload coverage data to CodeScene
         env:


### PR DESCRIPTION
## Summary

Follow-up to #376. The main-branch coverage upload in `coverage-main.yml`
failed at the `cs-coverage upload` step with `The coverage data does not
contains any records related to the current repo`, because the merge step
produced an empty `lcov.info`.

`lcov-result-merger` takes a single glob **pattern** and an optional
**output file**. Passing two file paths (`lcov-result-merger a.info
b.info`) makes the second path the output file and leaves stdout empty,
so `... a.info b.info > lcov.info` writes an empty `lcov.info` (and
silently overwrites `b.info`). This is the exact command shape the
rollout recipe documents and that mxd's `coverage-main.yml` uses, so it
is worth flagging estate-wide.

## Review walkthrough

- [`coverage-main.yml`](https://github.com/leynos/ortho-config/blob/fix-coverage-merge-command/.github/workflows/coverage-main.yml):
  merge both feature-leg reports with a single glob —
  `bun x lcov-result-merger 'lcov-*.info' > lcov.info`. The pattern
  `lcov-*.info` matches `lcov-serde-saphyr.info` and
  `lcov-no-serde-saphyr.info` but not the `lcov.info` output (no hyphen),
  so the merge does not read its own result.
- [`ci.yml`](https://github.com/leynos/ortho-config/blob/fix-coverage-merge-command/.github/workflows/ci.yml):
  update the deferred `mode: check` comment to document the same merge
  form for the fast-follow.

## Validation

- Reproduced locally with two minimal LCOV files: the two-path form
  yields a 0-byte output and overwrites the second file; the glob form
  yields a populated merge carrying both `SF` records.
- `python3 -c "import yaml; yaml.safe_load(...)"` on both workflows.
- `coverage-main.yml` runs only on push to main, so this PR's CI does not
  exercise it; the next push to main after merge will.
