### PR TITLE
Serialise nested_subcommand_end_to_end to fix bridge cache race

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,9 +10,15 @@ slow-timeout = { period = "120s", terminate-after = 5 }
 # Serialise powershell_windows cases: both cases write to the same bridge
 # directory under target/orthohelp/<hash>/ and Windows file-sharing semantics
 # prevent concurrent truncate+write while cargo holds a read lock on the manifest.
+# Serialise nested_subcommand_end_to_end: its rstest cases spawn concurrent
+# bridge builds that share the target/orthohelp/<hash>/ cache, and an
+# inter-process race on that shared Cargo.toml intermittently yields
+# BridgeBuildFailure ("manifest is missing either a [package] or a
+# [workspace]") under coverage runs.
 [test-groups]
 rstest_bdd = { max-threads = 1 }
 powershell_windows = { max-threads = 1 }
+nested_subcommand_end_to_end = { max-threads = 1 }
 
 [[profile.default.overrides]]
 filter = 'binary(rstest_bdd)'
@@ -21,3 +27,7 @@ test-group = 'rstest_bdd'
 [[profile.default.overrides]]
 filter = 'binary(powershell_windows)'
 test-group = 'powershell_windows'
+
+[[profile.default.overrides]]
+filter = 'binary(nested_subcommand_end_to_end)'
+test-group = 'nested_subcommand_end_to_end'


### PR DESCRIPTION
## Summary

- Serialises `nested_subcommand_end_to_end` into its own `max-threads = 1` nextest test-group, mirroring the existing `rstest_bdd` and `powershell_windows` serialisation for the same shared-cache constraint.
- Fixes an intermittent coverage-run failure: the test's rstest cases spawn concurrent bridge builds that race on the shared `target/orthohelp/<hash>/Cargo.toml`, which cargo occasionally observes mid-write and rejects with `BridgeBuildFailure { ... manifest is missing either a [package] or a [workspace] }`.

## Motivation

Recent `Coverage (main)` runs have hit this race:

- Run [29049672090](https://github.com/leynos/ortho-config/actions/runs/29049672090) (`Coverage (main)`, 2026-07-09): `nested_subcommand_tree_survives_bridge_outputs::case_1_ir` fails with `BridgeBuildFailure { status: 101, message: "... failed to parse manifest at .../target/orthohelp/156dbdd2.../Cargo.toml ... manifest is missing either a [package] or a [workspace]" }`.

`.config/nextest.toml` already documents and serialises two other binaries for exactly this class of problem (`rstest_bdd`, `powershell_windows`), both because concurrent nextest processes touch the same `target/orthohelp/<hash>/` cache. `nested_subcommand_end_to_end` runs three rstest cases (`ir`, `man`, `powershell`) against that same shared bridge cache and was missing the same protection.

## Review walkthrough

- `.config/nextest.toml`: add a `nested_subcommand_end_to_end` test-group with `max-threads = 1`, an override binding `binary(nested_subcommand_end_to_end)` to that group, and a comment stating the shared-cache race this prevents (matching the style of the existing `rstest_bdd`/`powershell_windows` comments).

## Validation

- [x] `.config/nextest.toml` parses as valid TOML (checked with Python's `tomllib`).
- [x] `cargo nextest list -p cargo-orthohelp --test nested_subcommand_end_to_end` discovers the three `nested_subcommand_tree_survives_bridge_outputs` cases.
- [x] `cargo nextest show-config test-groups -p cargo-orthohelp --test nested_subcommand_end_to_end` confirms all three cases are now bound to the `nested_subcommand_end_to_end` group with `max threads = 1`.
- [ ] CI (`build-test` on `ubuntu-latest` and `windows-latest`) — awaiting results on this PR.
- [ ] Next `Coverage (main)` run after merge — confirm the bridge-cache race no longer reproduces and the CodeScene upload proceeds.
