### PR TITLE
Package-qualify mutation baseline features

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -40,4 +40,10 @@ jobs:
       # and run the whole workspace's tests against each mutant: the
       # derive-macro crate's behaviour is exercised by ortho_config's
       # tests, so package-scoped runs would report false survivors.
+      # The bare feature names only resolve because every mutated
+      # workspace member defines (or forwards) the full set:
+      # cargo-mutants scopes the baseline build to the packages
+      # containing a shard's mutants, and Cargo resolves bare names
+      # against the selected packages only (issue #380). The contract
+      # tests pin each member's feature list to prevent drift.
       extra-args: "--features serde_json,toml,json5,yaml --test-workspace=true"

--- a/cargo-orthohelp/Cargo.toml
+++ b/cargo-orthohelp/Cargo.toml
@@ -18,6 +18,17 @@ path = "src/main.rs"
 [lints]
 workspace = true
 
+# Forwarding features mirroring hello_world's: cargo-mutants scopes the
+# mutation-testing baseline build to the packages containing a shard's
+# mutants, and Cargo resolves the caller's bare feature list against
+# the selected packages only, so every mutated workspace member must
+# define the CI feature set for the baseline to build (issue #380).
+[features]
+serde_json = ["ortho_config/serde_json"]
+toml = ["ortho_config/toml"]
+json5 = ["ortho_config/json5"]
+yaml = ["ortho_config/yaml"]
+
 [dependencies]
 camino = "1"
 cap-std = { version = "4", features = ["fs_utf8"] }

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -18,8 +18,10 @@ Run via ``make test-workflow-contracts``.
 from __future__ import annotations
 
 import re
+import tomllib
 from pathlib import Path
 
+import pytest
 import yaml
 
 WORKFLOW_PATH = (
@@ -42,6 +44,21 @@ EXPECTED_WITH = {
     "paths": "cargo-orthohelp/,examples/,ortho_config/,ortho_config_macros/",
     "exclude-globs": "test_helpers/**,tests/fixtures/**",
     "extra-args": "--features serde_json,toml,json5,yaml --test-workspace=true",
+}
+
+#: The feature set named in extra-args, and the manifest of every
+#: workspace member that cargo-mutants may mutate (the paths above,
+#: minus the excluded scaffolding). A package-scoped baseline such as
+#: ``cargo test --package=cargo-orthohelp --features serde_json,...``
+#: fails feature resolution unless the selected package defines every
+#: bare name, so each mutated member must define (or forward) the set
+#: (issue #380).
+BASELINE_FEATURES = frozenset({"serde_json", "toml", "json5", "yaml"})
+MUTATED_MEMBER_MANIFESTS = {
+    "cargo-orthohelp": Path("cargo-orthohelp/Cargo.toml"),
+    "hello_world": Path("examples/hello_world/Cargo.toml"),
+    "ortho_config": Path("ortho_config/Cargo.toml"),
+    "ortho_config_macros": Path("ortho_config_macros/Cargo.toml"),
 }
 
 
@@ -135,4 +152,27 @@ def test_with_block_carries_the_caller_configuration() -> None:
         "jobs.mutation.with must be exactly the documented configuration "
         f"(workspace paths, scaffolding excludes, CI feature set); expected "
         f"{EXPECTED_WITH!r}, got {with_block!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "member", sorted(MUTATED_MEMBER_MANIFESTS), ids=sorted(MUTATED_MEMBER_MANIFESTS)
+)
+def test_mutated_members_define_the_baseline_feature_set(member: str) -> None:
+    """Every mutated workspace member defines the bare baseline features.
+
+    cargo-mutants scopes the unmutated baseline build to the packages
+    containing a shard's mutants, and Cargo resolves the caller's bare
+    feature names against the selected packages only. A member missing
+    any name deterministically fails its shard's baseline (issue #380),
+    so this pins the forwarding features alongside the extra-args value.
+    """
+    manifest_path = WORKFLOW_PATH.parents[2] / MUTATED_MEMBER_MANIFESTS[member]
+    manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    features = set(manifest.get("features", {}))
+    missing = BASELINE_FEATURES - features
+    assert not missing, (
+        f"{member} must define (or forward) the mutation baseline feature set "
+        f"{sorted(BASELINE_FEATURES)}; missing {sorted(missing)} — a shard whose "
+        "mutants all fall in this package cannot build its baseline without them"
     )


### PR DESCRIPTION
Closes #380.

The first full mutation-testing dispatch (run 29075169702) lost four of six shards. Two failed deterministically: cargo-mutants scopes each shard's unmutated baseline build to the packages containing that shard's mutants, and the caller's bare feature list (`--features serde_json,toml,json5,yaml`) did not resolve against `cargo-orthohelp`, which defined none of those features. Cargo aborted before building anything and the baseline exited 4.

This PR makes every mutated workspace member define the baseline feature set, so the bare list resolves whichever package a shard selects. Package-qualifying the features (`ortho_config/<feature>`) was tried first but regressed coverage: with `--test-workspace=true` it left `hello_world`'s forwarding features disabled, dropping its feature-gated tests from workspace runs, and extending the qualified list with `hello_world/<feature>` is rejected by Cargo when the selected package does not depend on `hello_world` (see the PR discussion for transcripts).

## Review walkthrough

- [cargo-orthohelp/Cargo.toml](https://github.com/leynos/ortho-config/blob/fix-mutation-baseline/cargo-orthohelp/Cargo.toml) — adds forwarding features (`serde_json`, `toml`, `json5`, `yaml`, each forwarding to the corresponding `ortho_config` parser feature), mirroring `hello_world`'s existing forwarding features. This was the only mutated member missing the set.
- [.github/workflows/mutation-testing.yml](https://github.com/leynos/ortho-config/blob/fix-mutation-baseline/.github/workflows/mutation-testing.yml) — `extra-args` keeps the bare feature list; the comment now records why bare names resolve (every mutated member defines or forwards the full set) and points at the contract-test guard.
- [tests/workflow_contracts/mutation_testing_test.py](https://github.com/leynos/ortho-config/blob/fix-mutation-baseline/tests/workflow_contracts/mutation_testing_test.py) — `EXPECTED_WITH` pins the configuration, and a new parameterized test (`test_mutated_members_define_the_baseline_feature_set`) asserts each mutated member (`cargo-orthohelp`, `hello_world`, `ortho_config`, `ortho_config_macros`) defines the baseline feature set, so dropping a forwarding feature fails on the pull request rather than in a scheduled run.

## Validation

- Failing shard shape now builds: `cargo test --no-run -p cargo-orthohelp --features serde_json,toml,json5,yaml` completes cleanly (before the fix it failed with `error: the package 'cargo-orthohelp' does not contain these features: json5, serde_json, toml, yaml`, matching the shard failure in the issue).
- `hello_world` shard shape builds with its feature-gated tests compiled in: `cargo test -p hello_world --features serde_json,toml,json5,yaml load_yaml_config_activates_excited_flag` runs and passes the yaml-gated test.
- `cargo test --workspace --features serde_json,toml,json5,yaml` passed three consecutive runs on the rebased branch (61 test binaries, no failures) — the repeated plain-`cargo test` verification cargo-mutants relies on.
- Workflow contract tests: 10/10 pass (`make test-workflow-contracts`), including the SHA-shape pin check and the new per-member feature guard.
- Commit gates run locally: `make check-fmt`, `make typecheck`, `make lint-clippy`, `make test` (61 Rust suites plus 106 Python tests), `make markdownlint`, and `make test-workflow-contracts` all pass.

## Note on the disk-exhaustion shards

The other two failed shards (2 and 3) died of runner disk exhaustion after roughly 2 h 35 m and 3 h of mutant testing — the runner filesystem filled completely (even the runner's own diagnostic log could not be written, and the job logs were lost). This is a separate, infrastructural failure mode. I have deliberately not raised `shard-count` here: the successful shards finished at 1 h 55 m and 2 h 34 m, so runtime alone does not cleanly separate the failures, and with the shard logs lost there is no per-shard disk data from which to size an increase. If exhaustion recurs on the next full dispatch (now that all six shards will run real workloads), the better fix likely belongs in the shared workflow (freeing runner disk space or pruning the target directory between mutants) rather than a guessed fan-out change.
