### PR TITLE
Drop exact-SHA pinning from the mutation-testing contract test

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -377,6 +377,41 @@ integration (CI) environments.
   from the design document and from this guide where future contributors should
   be aware of the decision.
 
+### Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Spelling gate
 
 `make markdownlint` enforces en-GB-oxendict (Oxford) spelling over the

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -3,17 +3,21 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests;
 ortho-config's caller is declarative configuration. These tests parse
-the caller with PyYAML and pin the contract it must uphold, so drift
-(repointing the pin at a branch, widening permissions, or losing the
-workspace paths, scaffolding excludes, or feature configuration) fails
-CI on the pull request rather than surfacing in a scheduled or manual
-run.
+the caller with PyYAML and assert that it references the correct
+reusable workflow at a commit SHA, and that it upholds the rest of the
+contract (permissions, triggers, workspace paths, scaffolding excludes,
+and feature configuration), so drift (repointing the pin at a branch,
+widening permissions, or losing the caller configuration) fails CI on
+the pull request rather than surfacing in a scheduled or manual run.
+Dependabot owns the pinned SHA value; see the developers' guide's
+"Dependency management" section.
 
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -22,12 +26,11 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The leynos/shared-actions commit adding artefact preservation on
-#: timeout. Bump the workflow and this test together.
-PINNED_SHA = "2b09d10192627fd6e1034e7c12625dd266b45503"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+#: Matches the caller referencing the correct reusable workflow path,
+#: pinned to a full 40-hex commit SHA (never a branch or tag). The
+#: specific SHA is intentionally not asserted: Dependabot owns it.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: workspace member paths (virtual
@@ -65,25 +68,14 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-cargo.yml pinned to a 40-hex commit SHA."""
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; the execution plan documents {PINNED_SHA!r} — "
-        "bump the plan and this test together with the workflow"
+    assert USES_RE.match(uses), (
+        "jobs.mutation.uses must reference "
+        "leynos/shared-actions/.github/workflows/mutation-cargo.yml pinned to a "
+        f"full 40-character lowercase-hex commit SHA (not a branch or tag), got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- The mutation-testing workflow contract test pinned the caller's exact `leynos/shared-actions` commit SHA, so every Dependabot bump of `mutation-cargo.yml` failed CI until a human hand-edited the pinned constant.
- Replace the exact-SHA equality assertion with a shape assertion: the `uses:` reference must still point at `leynos/shared-actions/.github/workflows/mutation-cargo.yml` and be pinned to a full 40-hex commit SHA (never a branch or tag such as `main`/`rolling`), but the specific SHA value is no longer asserted.
- This hands ownership of the pinned SHA to Dependabot while keeping the structural contract (path, pin format, permissions, triggers, and `with:` configuration) intact.
- Document the policy in the developers' guide's "Dependency management" section so future contract tests follow the same shape-not-value pattern.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: dropped `PINNED_SHA` and `EXPECTED_USES`; added a `USES_RE` regex; renamed `test_uses_reference_is_pinned_to_the_documented_sha` to `test_uses_reference_is_pinned_to_a_commit_sha` and rewrote it to match the regex instead of an exact string; updated the module docstring to describe the shape contract and note Dependabot ownership. All other tests (permissions, workflow-level permissions, concurrency, triggers, `with:` block) are unchanged.
- `docs/developers-guide.md`: added a "Workflow pins and Dependabot" subsection under "Dependency management" explaining why contract tests must not pin an exact SHA, with a worked example.
- The workflow file itself (`.github/workflows/mutation-testing.yml`) and its current pinned SHA are untouched — Dependabot continues to own bumping that value.

## Validation

- `make test-workflow-contracts` passes locally (6 passed), confirming the regex matches the current pinned SHA.
- Reasoned/tested the regex directly: it matches the current SHA, matches a hypothetical different 40-hex SHA, and rejects a branch ref such as `@main`.
- `make spellcheck` passes over the updated docs.
- `.github/dependabot.yml` already has a `github-actions` ecosystem entry with `directory: "/"` and weekly schedule — no change needed there.
