### PR TITLE
Enable CodeScene mode: check gate on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,30 @@ jobs:
           features: serde_json toml json5
           artefact-name-suffix: no-serde-saphyr
 
+      - name: Merge coverage results
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        shell: bash
+        # lcov-result-merger takes a single glob pattern and an optional
+        # output file; passing two file paths treats the second as the
+        # output and leaves stdout empty. Match both feature-leg reports
+        # with one glob ('lcov-*.info' excludes the lcov.info output) and
+        # write the merged result via stdout.
+        run: bun x lcov-result-merger 'lcov-*.info' > lcov.info
+
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: >-
+          env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request' &&
+          matrix.os == 'ubuntu-latest'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/69279
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+
       - name: Validate PowerShell wrapper
         if: ${{ matrix.os == 'windows-latest' }}
         run: make powershell-wrapper-validate
@@ -145,17 +169,3 @@ jobs:
       - name: Publish dry run
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: make publish-check
-
-      # The `mode: check` CodeScene coverage gate is deliberately not wired
-      # in yet: CodeScene project 69279 has no coverage-gates configuration,
-      # so `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (ddlint and chutoro hit the byte-identical error). Add the
-      # gate in a fast-follow PR — merge the two feature-leg reports with
-      # `bun x lcov-result-merger 'lcov-*.info' > lcov.info` (a single glob
-      # pattern; two file paths would make the second the output file and
-      # leave stdout empty), then run the guarded `mode: check` step on the
-      # ubuntu leg only — once coverage-main.yml has uploaded to main at
-      # least once and the project's coverage gate is confirmed enabled
-      # CodeScene-side.


### PR DESCRIPTION
## Summary

- CodeScene's coverage gate is now enabled for project 69279, so this
  replaces the deferred-gate comment in `ci.yml` with the real guarded
  `mode: check` step.
- The step runs `cs-coverage check` against
  `https://api.codescene.io/v2/projects/69279`, guarded on
  `CS_ACCESS_TOKEN` being set, the event being a `pull_request`, and
  `matrix.os == 'ubuntu-latest'` — an expression over the existing
  matrix value, not a new matrix key.
- Since the coverage job merges two feature-leg lcov reports
  (`lcov-serde-saphyr.info`, `lcov-no-serde-saphyr.info`), a "Merge
  coverage results" step (same `lcov-result-merger` invocation used by
  `coverage-main.yml`) now runs on the ubuntu leg first, so the gate
  reads the merged `lcov.info`.
- `fetch-depth: 0` was already in place from the earlier PR, so the
  merge base is reachable for the changed-line diff.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/ortho-config/blob/codescene-mode-check/.github/workflows/ci.yml):
  the deferred-gate comment block is replaced by a "Merge coverage
  results" step and the "Check coverage against CodeScene gates" step,
  both gated to the ubuntu leg; the shared-actions pin
  (`927edd45ae77be4251a8a18ca9eb5613a2e32cbd`) matches the repo's
  existing `generate-coverage`/`setup-rust` pin, and `format: lcov`
  matches the repo's existing coverage format.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- `make test-workflow-contracts`
- CI on this PR: confirm the "Check coverage against CodeScene gates"
  step executes (not skipped) on the ubuntu leg and the `CodeScene
  Code Coverage` check completes successfully.
