### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -421,6 +421,77 @@ If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
 
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow,
+[`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy
+lifting — running `cargo-mutants`, sharding, and summarizing survivors — lives
+in `shared-actions`; this repository carries only declarative configuration.
+The run is **informational only**: it never gates a pull request. Survivors
+are reported through the job summary and downloadable artefacts so they can
+be triaged into tests, not enforced as a blocking check.
+
+The workflow runs in two modes. A **daily schedule** fires a change-scoped run
+that mutates only the source files touched within the detection window, so
+quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run
+workflow" control) mutates the whole workspace, fanned out across shards;
+select a branch in that control to exercise a feature branch.
+
+The caller passes a small set of configuration inputs, each carrying intent:
+
+- `paths` — the change-detection globs that decide whether a scheduled run
+  has anything to mutate. This is a virtual workspace, so the crate default
+  of `src/` covers nothing; the caller instead lists every member directory
+  (`cargo-orthohelp/`, `examples/`, `ortho_config/`, `ortho_config_macros/`).
+- `exclude-globs` — `test_helpers/**` and `tests/fixtures/**`, the
+  test-support crate and the orthohelp test fixture crate that exist only to
+  exercise other crates' tests, whose surviving mutants are noise rather than
+  genuine test gaps.
+- `extra-args` — `--features serde_json,toml,json5,yaml --test-workspace=true`,
+  forwarded to `cargo-mutants` so the mutation run matches the CI coverage
+  baseline's feature set, and so every workspace member's tests run against
+  the full workspace test run rather than a package-scoped one: the
+  derive-macro crate's behaviour is exercised through `ortho_config`'s tests,
+  so a package-scoped baseline would report false survivors there. Because
+  `cargo-mutants` scopes the unmutated baseline build to the packages
+  containing a shard's mutants, and Cargo resolves the caller's bare feature
+  names only against the selected packages, every mutated workspace member
+  must itself define (or forward) the full baseline feature set; a contract
+  test pins each member's manifest to guard against that drift (see below).
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit (see
+["Workflow pins and Dependabot"](#workflow-pins-and-dependabot) above).
+
+Because the caller is configuration rather than code, a contract test pins
+the shape it must uphold, failing the pull request when the caller drifts —
+repointing the pin at a branch, widening the token scope, or dropping a
+configuration input — rather than letting the breakage surface only in a
+scheduled run. Run it locally with `make test-workflow-contracts` (this
+wraps `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest
+tests/workflow_contracts -q`). The test, in
+`tests/workflow_contracts/mutation_testing_test.py`, validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to a full commit
+  SHA;
+- the `with:` block carries exactly the expected configuration (the
+  workspace paths, scaffolding excludes, and feature arguments above);
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with
+  no legacy branch input; and
+- every mutated workspace member's `Cargo.toml` defines the baseline feature
+  set named in `extra-args` (`serde_json`, `toml`, `json5`, `yaml`), so a
+  shard whose mutants fall entirely within one package can still build its
+  baseline.
+
 ## Spelling gate
 
 `make markdownlint` enforces en-GB-oxendict (Oxford) spelling over the


### PR DESCRIPTION
## Summary

- Add a `## Mutation-testing workflow contract tests` section to
  `docs/developers-guide.md`, documenting the caller workflow
  (`.github/workflows/mutation-testing.yml`) and the contract test that
  pins its shape (`tests/workflow_contracts/mutation_testing_test.py`).
- This is a workspace repository (Permutation B): the section describes
  the virtual-workspace `paths`, the `test_helpers/**` and
  `tests/fixtures/**` excludes, and the real `extra-args` value
  (`--features serde_json,toml,json5,yaml --test-workspace=true`),
  including the additional per-workspace-member baseline-feature check
  (`test_mutated_members_define_the_baseline_feature_set`) that the
  generic template does not otherwise cover.
- Documents the local run command, `make test-workflow-contracts`.

## Contract-test style

Shape-only (`USES_RE`): the test matches the `uses:` pin against
`^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$`
rather than a hard-coded SHA, so Dependabot bumps the pin without any
accompanying test edit.

## Placement

No mutation-testing section previously existed in the developers' guide,
so this adds a new top-level `##` section, placed directly after
"Workflow pins and Dependabot" (end of the "Dependency management"
section) since it applies that section's shape-only pinning policy to
this specific workflow.

## TOC / cross-links

`docs/developers-guide.md` has no internal table of contents to update.
`docs/contents.md` already links to the developers' guide as a whole, so
no further cross-link was needed there.

## Roadmap / execplan tracking

No roadmap or execplan item tracks this documentation work; `docs/roadmap.md`
and `docs/execplans/` were checked and contain no relevant open item
(their "mutation" hits are all about `MutationEffect`/CLI mutation
metadata, unrelated to mutation *testing*). No roadmap/execplan tracking
applies.

## Docs lint

`make markdownlint` passes clean on this branch (markdownlint-cli2: 0
errors across 65 files; spellcheck/typos: 65 passed, no findings after
correcting two `-ise` spellings introduced by the new prose to `-ize`
per the Oxford dictionary gate).

## Changed file

- [`docs/developers-guide.md`](../../blob/docs/mutation-contract-tests/docs/developers-guide.md)
