### PR TITLE
Propagate errors from test helpers

### DIFF
--- a/docs/execplans/6-2-3-define-downstream-context-json-command-naming.md
+++ b/docs/execplans/6-2-3-define-downstream-context-json-command-naming.md
@@ -398,8 +398,7 @@ The reader is assumed to know nothing about this repository. Key locations:
   function. No new error type is needed.
 - `ortho_config/Cargo.toml` — `serde_json` is an optional, default-on feature.
 - `cargo-orthohelp/src/cli/mod.rs` — the generator CLI. `OutputFormat` enum
-  (with
-  `AgentContext`) and `CargoSubcommand` (only `Orthohelp`). The positive
+  (with `AgentContext`) and `CargoSubcommand` (only `Orthohelp`). The positive
   control lives in `cli::tests`; the reserved-name guard lives in
   `cli/reserved_agent_context_tests.rs`.
 - `cargo-orthohelp/src/agent_context/mod.rs` and

--- a/docs/rfcs/0001-field-level-environment-aliases.md
+++ b/docs/rfcs/0001-field-level-environment-aliases.md
@@ -847,8 +847,8 @@ the target stay with the application.
 - The generated code calls `composer.push_environment` exactly once and appends
   resolution errors, individually, to the existing `errors` collection.
 - The runtime glue types (`EnvProjection`, `EnvAlias`, the resolver) are
-  internal
-  (`#[doc(hidden)]`), not committed public API, and are not `#[non_exhaustive]`.
+  internal (`#[doc(hidden)]`), not committed public API, and are not
+  `#[non_exhaustive]`.
 - The IR extension renames `var_name` to `canonical` (read-compatible via a
   serde alias) and bumps `ir_version` to `1.2`; the agent-context `env` block
   is additive and does not bump the agent-context schema version.

--- a/examples/hello_world/src/cli/tests/localisation.rs
+++ b/examples/hello_world/src/cli/tests/localisation.rs
@@ -3,16 +3,19 @@
 use super::super::{CommandLine, Commands, LocalizeCmd};
 use crate::localizer::DemoLocalizer;
 use clap::CommandFactory;
-use ortho_config::parse_localized_command;
+use ortho_config::{FluentLocalizerError, parse_localized_command};
 use rstest::{fixture, rstest};
 
 #[fixture]
-fn demo_localizer() -> DemoLocalizer {
-    DemoLocalizer::try_new().expect("demo localiser should build")
+fn demo_localizer() -> Result<DemoLocalizer, FluentLocalizerError> {
+    DemoLocalizer::try_new()
 }
 
 #[rstest]
-fn command_with_localizer_overrides_copy(demo_localizer: DemoLocalizer) {
+fn command_with_localizer_overrides_copy(
+    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
+) {
+    let demo_localizer = localizer_result.expect("demo localiser should build");
     let command = CommandLine::command()
         .with_base("hello_world.cli")
         .localize(&demo_localizer);
@@ -30,7 +33,10 @@ fn command_with_localizer_overrides_copy(demo_localizer: DemoLocalizer) {
 }
 
 #[rstest]
-fn localizes_subcommand_tree(demo_localizer: DemoLocalizer) {
+fn localizes_subcommand_tree(
+    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
+) {
+    let demo_localizer = localizer_result.expect("demo localiser should build");
     let command = CommandLine::command()
         .with_base("hello_world.cli")
         .localize(&demo_localizer);
@@ -46,7 +52,10 @@ fn localizes_subcommand_tree(demo_localizer: DemoLocalizer) {
 }
 
 #[rstest]
-fn try_parse_with_localizer_builds_cli(demo_localizer: DemoLocalizer) {
+fn try_parse_with_localizer_builds_cli(
+    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
+) {
+    let demo_localizer = localizer_result.expect("demo localiser should build");
     let args = ["hello-world", "greet"];
     let command = CommandLine::command()
         .with_base("hello_world.cli")
@@ -58,7 +67,10 @@ fn try_parse_with_localizer_builds_cli(demo_localizer: DemoLocalizer) {
 }
 
 #[rstest]
-fn try_parse_with_localizer_localises_errors(demo_localizer: DemoLocalizer) {
+fn try_parse_with_localizer_localises_errors(
+    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
+) {
+    let demo_localizer = localizer_result.expect("demo localiser should build");
     let command = CommandLine::command()
         .with_base("hello_world.cli")
         .localize(&demo_localizer);

--- a/examples/hello_world/src/cli/tests/localisation.rs
+++ b/examples/hello_world/src/cli/tests/localisation.rs
@@ -11,72 +11,70 @@ fn demo_localizer() -> Result<DemoLocalizer, FluentLocalizerError> {
     DemoLocalizer::try_new()
 }
 
-#[rstest]
-fn command_with_localizer_overrides_copy(
-    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
-) {
-    let demo_localizer = localizer_result.expect("demo localiser should build");
+#[track_caller]
+fn assert_expected_copy(demo_localizer: &DemoLocalizer) {
     let command = CommandLine::command()
         .with_base("hello_world.cli")
-        .localize(&demo_localizer);
-    let about = command
-        .get_about()
-        .expect("about text should be set")
-        .to_string();
-    assert!(about.contains("localised"), "expected demo copy in about");
+        .localize(demo_localizer);
+    let optional_about = command.get_about();
+    assert!(optional_about.is_some(), "about text should be set");
+    let about_text = optional_about.map(ToString::to_string).unwrap_or_default();
+    assert!(
+        about_text.contains("localised"),
+        "expected demo copy in about"
+    );
 
-    let long_about = command
-        .get_long_about()
-        .expect("long about text should be set")
-        .to_string();
-    assert!(long_about.contains(command.get_name()));
+    let optional_long_about = command.get_long_about();
+    assert!(
+        optional_long_about.is_some(),
+        "long about text should be set"
+    );
+    let long_about_text = optional_long_about
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    assert!(long_about_text.contains(command.get_name()));
 }
 
-#[rstest]
-fn localizes_subcommand_tree(
-    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
-) {
-    let demo_localizer = localizer_result.expect("demo localiser should build");
+#[track_caller]
+fn assert_localized_tree(demo_localizer: &DemoLocalizer) {
     let command = CommandLine::command()
         .with_base("hello_world.cli")
-        .localize(&demo_localizer);
+        .localize(demo_localizer);
     let greet = command
         .get_subcommands()
-        .find(|sub| sub.get_name() == "greet")
-        .expect("greet subcommand must exist");
-    let about = greet
-        .get_about()
-        .expect("greet about should be localized")
-        .to_string();
-    assert!(about.contains("friendly greeting"));
+        .find(|sub| sub.get_name() == "greet");
+    assert!(greet.is_some(), "greet subcommand must exist");
+    let optional_about = greet.and_then(clap::Command::get_about);
+    assert!(optional_about.is_some(), "greet about should be localized");
+    let about_text = optional_about.map(ToString::to_string).unwrap_or_default();
+    assert!(about_text.contains("friendly greeting"));
 }
 
-#[rstest]
-fn try_parse_with_localizer_builds_cli(
-    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
-) {
-    let demo_localizer = localizer_result.expect("demo localiser should build");
+#[track_caller]
+fn assert_cli_builds(demo_localizer: &DemoLocalizer) {
     let args = ["hello-world", "greet"];
     let command = CommandLine::command()
         .with_base("hello_world.cli")
-        .localize(&demo_localizer);
-    let (cli, _matches) =
-        parse_localized_command::<CommandLine, _, _>(command, args, &demo_localizer)
-            .expect("expected to parse args");
+        .localize(demo_localizer);
+    let parsed = parse_localized_command::<CommandLine, _, _>(command, args, demo_localizer);
+    assert!(parsed.is_ok(), "expected to parse args");
+    let Ok((cli, _matches)) = parsed else {
+        return;
+    };
     assert!(matches!(cli.command, Commands::Greet(_)));
 }
 
-#[rstest]
-fn try_parse_with_localizer_localises_errors(
-    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
-) {
-    let demo_localizer = localizer_result.expect("demo localiser should build");
+#[track_caller]
+fn assert_localized_error(demo_localizer: &DemoLocalizer) {
     let command = CommandLine::command()
         .with_base("hello_world.cli")
-        .localize(&demo_localizer);
-    let err =
-        parse_localized_command::<CommandLine, _, _>(command, ["hello-world"], &demo_localizer)
-            .expect_err("missing subcommand should be reported");
+        .localize(demo_localizer);
+    let parsed =
+        parse_localized_command::<CommandLine, _, _>(command, ["hello-world"], demo_localizer);
+    assert!(parsed.is_err(), "missing subcommand should be reported");
+    let Err(err) = parsed else {
+        return;
+    };
     let rendered = err.to_string();
     assert!(
         rendered.contains("Pick a workflow"),
@@ -86,6 +84,42 @@ fn try_parse_with_localizer_localises_errors(
         rendered.contains("greet") && rendered.contains("take-leave"),
         "expected available subcommands to flow into translation: {rendered}"
     );
+}
+
+#[rstest]
+fn command_with_localizer_overrides_copy(
+    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
+) -> Result<(), FluentLocalizerError> {
+    let demo_localizer = localizer_result?;
+    assert_expected_copy(&demo_localizer);
+    Ok(())
+}
+
+#[rstest]
+fn localizes_subcommand_tree(
+    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
+) -> Result<(), FluentLocalizerError> {
+    let demo_localizer = localizer_result?;
+    assert_localized_tree(&demo_localizer);
+    Ok(())
+}
+
+#[rstest]
+fn try_parse_with_localizer_builds_cli(
+    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
+) -> Result<(), FluentLocalizerError> {
+    let demo_localizer = localizer_result?;
+    assert_cli_builds(&demo_localizer);
+    Ok(())
+}
+
+#[rstest]
+fn try_parse_with_localizer_localises_errors(
+    #[from(demo_localizer)] localizer_result: Result<DemoLocalizer, FluentLocalizerError>,
+) -> Result<(), FluentLocalizerError> {
+    let demo_localizer = localizer_result?;
+    assert_localized_error(&demo_localizer);
+    Ok(())
 }
 
 #[test]

--- a/examples/hello_world/src/cli/tests/localisation.rs
+++ b/examples/hello_world/src/cli/tests/localisation.rs
@@ -3,12 +3,14 @@
 use super::super::{CommandLine, Commands, LocalizeCmd};
 use crate::localizer::DemoLocalizer;
 use clap::CommandFactory;
-use ortho_config::{FluentLocalizerError, parse_localized_command};
+use ortho_config::{FluentLocalizerError, LanguageIdentifier, langid, parse_localized_command};
 use rstest::{fixture, rstest};
 
 #[fixture]
-fn demo_localizer() -> Result<DemoLocalizer, FluentLocalizerError> {
-    DemoLocalizer::try_new()
+fn demo_localizer(
+    #[default(langid!("en-US"))] locale: LanguageIdentifier,
+) -> Result<DemoLocalizer, FluentLocalizerError> {
+    DemoLocalizer::try_for_locale(locale)
 }
 
 #[track_caller]
@@ -120,6 +122,16 @@ fn try_parse_with_localizer_localises_errors(
     let demo_localizer = localizer_result?;
     assert_localized_error(&demo_localizer);
     Ok(())
+}
+
+#[rstest]
+fn demo_localizer_propagates_unsupported_locale(
+    #[with(langid!("fr"))] demo_localizer: Result<DemoLocalizer, FluentLocalizerError>,
+) {
+    assert!(matches!(
+        demo_localizer,
+        Err(FluentLocalizerError::UnsupportedLocale { locale }) if locale == langid!("fr")
+    ));
 }
 
 #[test]

--- a/ortho_config/tests/rstest_bdd/behaviour/steps/localizer_steps.rs
+++ b/ortho_config/tests/rstest_bdd/behaviour/steps/localizer_steps.rs
@@ -216,8 +216,8 @@ fn assert_localised(context: &LocalizerContext, expected: String) -> Result<()> 
 fn assert_formatting_issue_logged(context: &LocalizerContext) -> Result<()> {
     let issues = context.take_issues();
     ensure!(
-        !issues.is_empty(),
-        "expected at least one formatting issue to be captured"
+        issues == ["cli.usage"],
+        "expected only the cli.usage formatting issue, captured {issues:?}"
     );
     Ok(())
 }

--- a/ortho_config/tests/rstest_bdd/behaviour/steps/localizer_steps.rs
+++ b/ortho_config/tests/rstest_bdd/behaviour/steps/localizer_steps.rs
@@ -55,21 +55,21 @@ fn clap_aware_localizer(context: &LocalizerContext) {
 }
 
 #[given("a fluent localizer with consumer overrides")]
-fn fluent_localizer(context: &LocalizerContext) {
+fn fluent_localizer(context: &LocalizerContext) -> Result<()> {
     install_fluent_localizer(
         context,
         &["cli.about = Localised about from consumer"],
         false,
-    );
+    )
 }
 
 #[given("a fluent localizer with a mismatched template")]
-fn fluent_localizer_with_error(context: &LocalizerContext) {
+fn fluent_localizer_with_error(context: &LocalizerContext) -> Result<()> {
     install_fluent_localizer(
         context,
         &["cli.usage = Usage: { $binary } and { $missing }"],
         true,
-    );
+    )
 }
 
 #[when("I request id {id} with fallback {fallback}")]
@@ -267,7 +267,7 @@ fn install_fluent_localizer(
     context: &LocalizerContext,
     resources: &[&'static str],
     capture_errors: bool,
-) {
+) -> Result<()> {
     let mut builder = FluentLocalizer::builder(langid!("en-US"))
         .with_consumer_resources(resources.iter().copied());
 
@@ -283,10 +283,9 @@ fn install_fluent_localizer(
         }));
     }
 
-    let localizer = builder
-        .try_build()
-        .expect("fluent localizer should be constructed in tests");
+    let localizer = builder.try_build()?;
     context.localizer.set(Box::new(localizer));
+    Ok(())
 }
 
 fn extract_argument(error: &clap::Error) -> String {

--- a/ortho_config/tests/rstest_bdd/canary_steps.rs
+++ b/ortho_config/tests/rstest_bdd/canary_steps.rs
@@ -1,6 +1,7 @@
 //! Step definitions backing the canary `rstest-bdd` scenario.
 
 use super::scenario_state::{CanaryConfig, CanaryState};
+use anyhow::{Result, anyhow, ensure};
 use ortho_config::OrthoConfig;
 use rstest_bdd::ScenarioState as _;
 use rstest_bdd_macros::{given, then, when};
@@ -15,22 +16,27 @@ fn reset_state(canary_state: &CanaryState) {
 }
 
 #[when("I load the canary config with level {level:u8}")]
-fn load_canary(canary_state: &CanaryState, binary_name: &str, level: u8) {
+fn load_canary(canary_state: &CanaryState, binary_name: &str, level: u8) -> Result<()> {
     let args = vec![
         binary_name.to_string(),
         "--level".to_string(),
         level.to_string(),
     ];
-    let config =
-        CanaryConfig::load_from_iter(args).expect("canary configuration should load successfully");
+    let config = CanaryConfig::load_from_iter(args)
+        .map_err(|error| anyhow!("canary configuration should load successfully: {error}"))?;
     canary_state.loaded_config.set(config);
+    Ok(())
 }
 
 #[then("the canary level equals {expected:u8}")]
-fn assert_level(canary_state: &CanaryState, expected: u8) {
+fn assert_level(canary_state: &CanaryState, expected: u8) -> Result<()> {
     let actual = canary_state
         .loaded_config
         .with_ref(|cfg| cfg.level)
-        .expect("a canary config must have been stored");
-    assert_eq!(actual, expected);
+        .ok_or_else(|| anyhow!("a canary config must have been stored"))?;
+    ensure!(
+        actual == expected,
+        "actual level {actual}; expected {expected}"
+    );
+    Ok(())
 }

--- a/ortho_config/tests/rstest_bdd/canary_steps.rs
+++ b/ortho_config/tests/rstest_bdd/canary_steps.rs
@@ -1,8 +1,12 @@
 //! Step definitions backing the canary `rstest-bdd` scenario.
 
+#[cfg(test)]
+use super::scenario_state::canary_state;
 use super::scenario_state::{CanaryConfig, CanaryState};
 use anyhow::{Context, Result, anyhow, ensure};
 use ortho_config::OrthoConfig;
+#[cfg(test)]
+use rstest::rstest;
 use rstest_bdd::ScenarioState as _;
 use rstest_bdd_macros::{given, then, when};
 
@@ -22,10 +26,43 @@ fn load_canary(canary_state: &CanaryState, binary_name: &str, level: u8) -> Resu
         "--level".to_string(),
         level.to_string(),
     ];
+    load_canary_from_args(canary_state, args)
+}
+
+fn load_canary_from_args(canary_state: &CanaryState, args: Vec<String>) -> Result<()> {
     let config = CanaryConfig::load_from_iter(args)
         .context("canary configuration should load successfully")?;
     canary_state.loaded_config.set(config);
     Ok(())
+}
+
+#[rstest]
+fn invalid_canary_level_preserves_error_chain(canary_state: CanaryState) {
+    let result = load_canary_from_args(
+        &canary_state,
+        vec![
+            "ortho-config-bdd".to_owned(),
+            "--level".to_owned(),
+            "not-a-number".to_owned(),
+        ],
+    );
+    assert!(result.is_err(), "invalid canary level should be rejected");
+    let Err(error) = result else {
+        return;
+    };
+    let error_chain = error.chain().map(ToString::to_string).collect::<Vec<_>>();
+    assert_eq!(
+        error_chain.first().map(String::as_str),
+        Some("canary configuration should load successfully")
+    );
+    assert!(
+        error_chain
+            .iter()
+            .skip(1)
+            .any(|message| message.contains("not-a-number")),
+        "original parser error should remain in the chain: {error_chain:?}"
+    );
+    assert!(canary_state.loaded_config.is_empty());
 }
 
 #[then("the canary level equals {expected:u8}")]

--- a/ortho_config/tests/rstest_bdd/canary_steps.rs
+++ b/ortho_config/tests/rstest_bdd/canary_steps.rs
@@ -1,7 +1,7 @@
 //! Step definitions backing the canary `rstest-bdd` scenario.
 
 use super::scenario_state::{CanaryConfig, CanaryState};
-use anyhow::{Result, anyhow, ensure};
+use anyhow::{Context, Result, anyhow, ensure};
 use ortho_config::OrthoConfig;
 use rstest_bdd::ScenarioState as _;
 use rstest_bdd_macros::{given, then, when};
@@ -23,7 +23,7 @@ fn load_canary(canary_state: &CanaryState, binary_name: &str, level: u8) -> Resu
         level.to_string(),
     ];
     let config = CanaryConfig::load_from_iter(args)
-        .map_err(|error| anyhow!("canary configuration should load successfully: {error}"))?;
+        .context("canary configuration should load successfully")?;
     canary_state.loaded_config.set(config);
     Ok(())
 }

--- a/ortho_config/tests/rstest_bdd/scenario_state.rs
+++ b/ortho_config/tests/rstest_bdd/scenario_state.rs
@@ -11,6 +11,10 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, PoisonError};
 
+#[cfg(test)]
+#[path = "scenario_state_tests.rs"]
+mod scenario_state_tests;
+
 /// Re-exported so BDD merge-error steps can reference the sample config
 /// struct without reaching into the shared fixtures module directly.
 pub use super::fixtures::merge_fixtures::MergeErrorSample;

--- a/ortho_config/tests/rstest_bdd/scenario_state.rs
+++ b/ortho_config/tests/rstest_bdd/scenario_state.rs
@@ -9,7 +9,7 @@ use rstest_bdd_macros::ScenarioState;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, PoisonError};
 
 /// Re-exported so BDD merge-error steps can reference the sample config
 /// struct without reaching into the shared fixtures module directly.
@@ -117,9 +117,7 @@ impl LocalizerContext {
     #[must_use]
     pub fn take_issues(&self) -> Vec<String> {
         if let Some(issues) = self.issues.take() {
-            let mut guard = issues
-                .lock()
-                .expect("formatting issue mutex poisoned during take");
+            let mut guard = issues.lock().unwrap_or_else(PoisonError::into_inner);
             let collected = guard.clone();
             guard.clear();
             collected

--- a/ortho_config/tests/rstest_bdd/scenario_state_tests.rs
+++ b/ortho_config/tests/rstest_bdd/scenario_state_tests.rs
@@ -1,0 +1,27 @@
+//! Regression tests for scenario-state recovery behaviour.
+
+use super::LocalizerContext;
+use rstest::rstest;
+use std::sync::{Arc, PoisonError};
+
+#[rstest]
+fn take_issues_recovers_from_poisoned_mutex() {
+    let context = LocalizerContext {
+        issues: LocalizerContext::init_issues(),
+        ..LocalizerContext::default()
+    };
+    let issues = context
+        .issues
+        .with_ref(Arc::clone)
+        .expect("issues state should be initialized");
+
+    let poisoning_thread = std::thread::spawn(move || {
+        let mut guard = issues.lock().unwrap_or_else(PoisonError::into_inner);
+        guard.push("captured issue".to_owned());
+        panic!("poison issues mutex deliberately");
+    });
+    assert!(poisoning_thread.join().is_err());
+
+    assert_eq!(context.take_issues(), vec!["captured issue"]);
+    assert!(context.take_issues().is_empty());
+}


### PR DESCRIPTION
## Summary

This branch makes fallible rstest fixtures and BDD helpers propagate setup
errors so the full Whitaker gate succeeds without treating helper failures as
panic boundaries. It covers both successful setup and deterministic localizer
and canary failure paths, and recovers poisoned formatting-issue state without
introducing another panic.

## Review walkthrough

- Start with [the demo localizer tests](https://github.com/leynos/ortho-config/blob/1549bbc/examples/hello_world/src/cli/tests/localisation.rs) to see successful fixture consumption and unsupported-locale error propagation at recognized test boundaries.
- Then review [the localizer BDD steps](https://github.com/leynos/ortho-config/blob/1549bbc/ortho_config/tests/rstest_bdd/behaviour/steps/localizer_steps.rs) and [the canary steps](https://github.com/leynos/ortho-config/blob/1549bbc/ortho_config/tests/rstest_bdd/canary_steps.rs) for exact issue recording and preserved parser-error chains.
- Finish with [the scenario state](https://github.com/leynos/ortho-config/blob/1549bbc/ortho_config/tests/rstest_bdd/scenario_state.rs) and [its regression test](https://github.com/leynos/ortho-config/blob/1549bbc/ortho_config/tests/rstest_bdd/scenario_state_tests.rs) for poisoned-mutex recovery during issue collection.

## Validation

- `make check-fmt`: passed.
- `make lint`: passed.
- `make typecheck`: passed.
- `make test`: passed (Python: 106 passed, 1 skipped).
- `git diff --check`: passed.

## References

- [Lody session](https://lody.ai/leynos/sessions/9801ac9d-781e-4610-94bb-5972c6c9fdb3)
