### PR TITLE
Apply Markdown formatter output

### DIFF
--- a/docs/execplans/6-2-3-define-downstream-context-json-command-naming.md
+++ b/docs/execplans/6-2-3-define-downstream-context-json-command-naming.md
@@ -398,8 +398,7 @@ The reader is assumed to know nothing about this repository. Key locations:
   function. No new error type is needed.
 - `ortho_config/Cargo.toml` — `serde_json` is an optional, default-on feature.
 - `cargo-orthohelp/src/cli/mod.rs` — the generator CLI. `OutputFormat` enum
-  (with
-  `AgentContext`) and `CargoSubcommand` (only `Orthohelp`). The positive
+  (with `AgentContext`) and `CargoSubcommand` (only `Orthohelp`). The positive
   control lives in `cli::tests`; the reserved-name guard lives in
   `cli/reserved_agent_context_tests.rs`.
 - `cargo-orthohelp/src/agent_context/mod.rs` and

--- a/docs/rfcs/0001-field-level-environment-aliases.md
+++ b/docs/rfcs/0001-field-level-environment-aliases.md
@@ -847,8 +847,8 @@ the target stay with the application.
 - The generated code calls `composer.push_environment` exactly once and appends
   resolution errors, individually, to the existing `errors` collection.
 - The runtime glue types (`EnvProjection`, `EnvAlias`, the resolver) are
-  internal
-  (`#[doc(hidden)]`), not committed public API, and are not `#[non_exhaustive]`.
+  internal (`#[doc(hidden)]`), not committed public API, and are not
+  `#[non_exhaustive]`.
 - The IR extension renames `var_name` to `canonical` (read-compatible via a
   serde alias) and bumps `ir_version` to `1.2`; the agent-context `env` block
   is additive and does not bump the agent-context schema version.


### PR DESCRIPTION
## Summary

- apply the repository Markdown formatter's current wrapping to the execution plan and RFC
- keep the formatter-only correction separate from both the Rust lint fixes and the crates.io shield

This PR is stacked on #402 and provides the middle layer for the documentation-only shield PR.

## Review walkthrough

The single commit normalizes stale line wrapping in:

- [`docs/execplans/6-2-3-define-downstream-context-json-command-naming.md`](https://github.com/leynos/ortho-config/blob/b7a990ac48c228810d8cde127db36af933109c14/docs/execplans/6-2-3-define-downstream-context-json-command-naming.md)
- [`docs/rfcs/0001-field-level-environment-aliases.md`](https://github.com/leynos/ortho-config/blob/b7a990ac48c228810d8cde127db36af933109c14/docs/rfcs/0001-field-level-environment-aliases.md)

## Validation

- `make markdownlint`
- `CARGO_TARGET_DIR=/var/tmp/ortho-config-crates-io-shield-target make all` on the complete stack
- `git diff --check`
