### PR TITLE
Add crates.io version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](
 https://deepwiki.com/leynos/ortho-config)
-![Crates.io Version](https://img.shields.io/crates/v/ortho-config)
+[![Crates.io Version](https://img.shields.io/crates/v/ortho-config)](
+https://crates.io/crates/ortho-config)
 
 **OrthoConfig** is a Rust configuration management library designed for
 simplicity and power, inspired by the flexible configuration mechanisms found

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](
 https://deepwiki.com/leynos/ortho-config)
+![Crates.io Version](https://img.shields.io/crates/v/ortho-config)
 
 **OrthoConfig** is a Rust configuration management library designed for
 simplicity and power, inspired by the flexible configuration mechanisms found

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # OrthoConfig
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](
-https://deepwiki.com/leynos/ortho-config)
-[![Crates.io Version](https://img.shields.io/crates/v/ortho-config)](
-https://crates.io/crates/ortho-config)
+[![Ask DeepWiki][dw]][dw-url] [![Crates.io Version][cr]][cr-url]
+
+[cr]: https://img.shields.io/crates/v/ortho_config "crates.io package"
+[cr-url]: https://crates.io/crates/ortho_config
+[dw]: https://deepwiki.com/badge.svg
+[dw-url]: https://deepwiki.com/leynos/ortho-config
 
 **OrthoConfig** is a Rust configuration management library designed for
 simplicity and power, inspired by the flexible configuration mechanisms found


### PR DESCRIPTION
## Summary

This branch adds the crates.io version badge beside the existing DeepWiki badge. The shield links directly to the [`ortho-config` crates.io page](https://crates.io/crates/ortho_config), so readers can both see the published version and open the package listing from the project overview.

This pull request is stacked on #407, which is itself stacked on the fallible test-helper remediation in #402.

## Review walkthrough

- Review [the README badge block](https://github.com/leynos/ortho-config/blob/bfcdb77c3fab9621cb47823160e1ddf66de6e20c/README.md) to confirm the crates.io shield appears beside the DeepWiki badge and links to the package page.

## Validation

- `CARGO_TARGET_DIR=/var/tmp/ortho-config-crates-io-shield-target make all`
- `git diff --check`

## Summary by Sourcery

Documentation:
- Display the published crates.io version for `ortho-config` in the README via a linked shields.io badge.

## References

- https://lody.ai/leynos/sessions/54e0fceb-9675-4ff9-9758-beddbcb12f97