### PR TITLE
Bump workspace version to 0.8.1 to resolve publish drift (#414)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-orthohelp"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "camino",
  "cap-std 4.0.2",
@@ -914,7 +914,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello_world"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1242,7 +1242,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ortho_config"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "camino",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "ortho_config_macros"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "figment",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "ortho_config_test_helpers"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "camino",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "orthohelp_fixture"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "clap",
  "ortho_config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Payton McIntosh <pmcintosh@df12.net>"]
 edition = "2024"
 rust-version = "1.89.0"

--- a/cargo-orthohelp/Cargo.toml
+++ b/cargo-orthohelp/Cargo.toml
@@ -34,7 +34,7 @@ camino = "1"
 cap-std = { version = "4", features = ["fs_utf8"] }
 clap = { version = "4", features = ["derive"] }
 cargo_metadata = "0.18"
-ortho_config = { path = "../ortho_config", version = "0.8.0", features = ["serde_json"] }
+ortho_config = { path = "../ortho_config", version = "0.8.1", features = ["serde_json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
@@ -48,6 +48,6 @@ proptest = "1"
 rstest = "0.26.1"
 rstest-bdd.workspace = true
 rstest-bdd-macros.workspace = true
-test_helpers = { package = "ortho_config_test_helpers", path = "../test_helpers", version = "0.8.0" }
+test_helpers = { package = "ortho_config_test_helpers", path = "../test_helpers", version = "0.8.1" }
 tempfile = "3"
 trybuild = "1"

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello_world"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version.workspace = true
 publish = false
@@ -17,8 +17,8 @@ workspace = true
 
 [dependencies]
 # `figment`, `uncased`, and `xdg` are available via `ortho_config` re-exports.
-ortho_config = { path = "../../ortho_config", version = "0.8.0" }
-ortho_config_macros = { path = "../../ortho_config_macros", version = "0.8.0" }
+ortho_config = { path = "../../ortho_config", version = "0.8.1" }
+ortho_config_macros = { path = "../../ortho_config_macros", version = "0.8.1" }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 clap = { version = "4", features = ["derive"] }
@@ -37,7 +37,7 @@ shlex = "1.3.0"
 tempfile = "3"
 cap-std = "4"
 toml = "0.9"
-test_helpers = { package = "ortho_config_test_helpers", path = "../../test_helpers", version = "0.8.0" }
+test_helpers = { package = "ortho_config_test_helpers", path = "../../test_helpers", version = "0.8.1" }
 
 [features]
 default = ["serde_json"]

--- a/ortho_config/Cargo.toml
+++ b/ortho_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ortho_config"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version.workspace = true
 readme = "README.md"
@@ -13,7 +13,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-ortho_config_macros = { path = "../ortho_config_macros", version = "0.8.0" }
+ortho_config_macros = { path = "../ortho_config_macros", version = "0.8.1" }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 clap = { version = "4", features = ["derive", "string"] }
@@ -59,9 +59,9 @@ rstest-bdd-macros.workspace = true
 insta = "1"
 serial_test = "3"
 tempfile = "3"
-test_helpers = { package = "ortho_config_test_helpers", path = "../test_helpers", version = "0.8.0" }
+test_helpers = { package = "ortho_config_test_helpers", path = "../test_helpers", version = "0.8.1" }
 anyhow = "1"
-ortho_config_macros = { path = "../ortho_config_macros", version = "0.8.0" }
+ortho_config_macros = { path = "../ortho_config_macros", version = "0.8.1" }
 proptest = "1.11.0"
 tracing-subscriber = "0.3"
 

--- a/ortho_config_macros/Cargo.toml
+++ b/ortho_config_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ortho_config_macros"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version.workspace = true
 readme = "README.md"

--- a/tests/fixtures/orthohelp_fixture/Cargo.toml
+++ b/tests/fixtures/orthohelp_fixture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orthohelp_fixture"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version.workspace = true
 publish = false
@@ -9,7 +9,7 @@ publish = false
 workspace = true
 
 [dependencies]
-ortho_config = { path = "../../../ortho_config", version = "0.8.0" }
+ortho_config = { path = "../../../ortho_config", version = "0.8.1" }
 serde = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 


### PR DESCRIPTION
## Summary

This branch bumps every workspace crate from 0.8.0 to 0.8.1 so the publish
dry run stops verifying unreleased workspace content against the published
crates.io 0.8.0 releases.

Closes #414.

The workspace `ortho_config_macros` gained the `OrthoConfigSubcommandDocs`
derive in #331 while keeping version 0.8.0. Because crates.io already holds
an `ortho_config_macros` 0.8.0 without that export, `make publish-check`
resolved the dependency to the registry release and failed tarball
verification with E0432 on the re-export in
[ortho_config/src/lib.rs](https://github.com/leynos/ortho-config/blob/b50911c81069c1746736688067572398a08a9153/ortho_config/src/lib.rs#L12).
Versioning the drifted content ahead of the registry restores lading's
unpublished-workspace-dependency allowance. No code changes are included.

## Review walkthrough

- Start with [Cargo.toml](https://github.com/leynos/ortho-config/blob/b50911c81069c1746736688067572398a08a9153/Cargo.toml#L13)
  for the workspace-level bump.
- Then review [ortho_config/Cargo.toml](https://github.com/leynos/ortho-config/blob/b50911c81069c1746736688067572398a08a9153/ortho_config/Cargo.toml)
  and the remaining member manifests: the crate versions and every
  inter-crate `version = "0.8.1"` requirement move together.
- Finish with [Cargo.lock](https://github.com/leynos/ortho-config/blob/b50911c81069c1746736688067572398a08a9153/Cargo.lock),
  which only re-records the six workspace crates at 0.8.1.

## Validation

- `make check-fmt`: pass (`/tmp/check-fmt-ortho-config-issue-414.out`)
- `make publish-check`: pass — the dry run now plans all four publishable
  crates at 0.8.1 and dry-run-publishes `ortho_config_macros` cleanly
  (`/tmp/publish-check-ortho-config-issue-414.out`)
- `make test`: pass (`/tmp/test-ortho-config-issue-414.out`)

## Notes

- The dry run cannot compile `ortho_config`'s packaged tarball against a
  real `ortho_config_macros` 0.8.1 until the macros crate is actually
  published; lading records this as an expected index-lookup downgrade for
  an unpublished workspace dependency. Release sequencing should publish
  `ortho_config_macros` first, as usual.
- Whether the next release ought to be 0.8.1 or 0.9.0 is a release-time
  decision; 0.8.1 is the minimal bump that removes the collision, and the
  unreleased changelog section is unaffected.

## Summary by Sourcery

Bump the workspace and all member crates from 0.8.0 to 0.8.1 to realign crate versions and dependency constraints with the published artifacts.

Build:
- Update workspace.package version and all crate manifests to 0.8.1, including internal dependency version requirements and examples/fixtures.
- Regenerate Cargo.lock to record the six workspace crates at version 0.8.1.